### PR TITLE
CloudSQL username and password are generated if not provided on bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,6 @@ used by default.
 - updated credentials type returned by bind call to be a map[string]string instead
 of a string.
 
+## Unreleased
+
+- CloudSQL will generate a username/password on bind if one is not provided.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Service calls take the following custom parameters, all as strings, (required wh
         * replication_type (defaults to synchronous)
         * auto_resize (2nd gen only, defaults to false, set to "true" to use)
     * Bind
-        * username
-        * password
+        * username (defaults to a generated value)
+        * password (defaults to a generated value)
 * [ML APIs](https://cloud.google.com/ml/)
     * Bind
         * role without "roles/" prefix (see https://cloud.google.com/iam/docs/understanding-roles for available roles)

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -522,11 +522,7 @@ var _ = Describe("AccountManagers", func() {
 			It("should return a generated username and password", func() {
 				db_service.DbConnection.Create(&models.ServiceInstanceDetails{ID: "foo"})
 
-				_, err := cloudsqlBroker.Bind("foo", "bar", models.BindDetails{
-					Parameters: map[string]interface{}{
-						"foo": "bar",
-					},
-				})
+				_, err := cloudsqlBroker.Bind("foo", "bar", models.BindDetails{})
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(accountManager.CreateAccountInGoogleCallCount()).To(Equal(1))

--- a/brokerapi/brokers/cloudsql/cloudsql_suite_test.go
+++ b/brokerapi/brokers/cloudsql/cloudsql_suite_test.go
@@ -1,0 +1,13 @@
+package cloudsql_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestCloudsql(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CloudSQL Suite")
+}

--- a/brokerapi/brokers/cloudsql/credentials_generator.go
+++ b/brokerapi/brokers/cloudsql/credentials_generator.go
@@ -1,0 +1,38 @@
+package cloudsql
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+const (
+	maxUsernameLength       = 16 // Limit from http://dev.mysql.com/doc/refman/5.7/en/user-names.html
+	generatedPasswordLength = 32
+)
+
+func GenerateUsername(instanceID, bindingID string) (string, error) {
+	if len(instanceID)+len(bindingID) == 0 {
+		return "", fmt.Errorf("empty instanceID and bindingID")
+	}
+
+	username := instanceID + bindingID
+	if len(username) > maxUsernameLength {
+		username = username[:maxUsernameLength]
+	}
+
+	return username, nil
+}
+
+func GeneratePassword() (string, error) {
+	rb := make([]byte, generatedPasswordLength)
+	_, err := rand.Read(rb)
+
+	if err != nil {
+		return "", err
+	}
+
+	rs := base64.URLEncoding.EncodeToString(rb)
+
+	return rs, nil
+}

--- a/brokerapi/brokers/cloudsql/credentials_generator.go
+++ b/brokerapi/brokers/cloudsql/credentials_generator.go
@@ -16,7 +16,7 @@ func GenerateUsername(instanceID, bindingID string) (string, error) {
 		return "", fmt.Errorf("empty instanceID and bindingID")
 	}
 
-	username := instanceID + bindingID
+	username := bindingID + instanceID
 	if len(username) > maxUsernameLength {
 		username = username[:maxUsernameLength]
 	}

--- a/brokerapi/brokers/cloudsql/credentials_generator_test.go
+++ b/brokerapi/brokers/cloudsql/credentials_generator_test.go
@@ -1,0 +1,40 @@
+package cloudsql_test
+
+import (
+	. "gcp-service-broker/brokerapi/brokers/cloudsql"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("credentials generation", func() {
+	It("does not generate a username for empty instanceID/bindingID", func() {
+		_, err := GenerateUsername("", "")
+		Expect(err).To(HaveOccurred())
+	})
+	It("generates a username", func() {
+		u, err := GenerateUsername("foo", "bar")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(u)).To(BeNumerically(">", 1))
+	})
+	It("truncates very long instanceID/bindingIDs", func() {
+		longStr := "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo"
+		u, err := GenerateUsername(longStr, longStr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(u)).To(BeNumerically("<", len(longStr)))
+	})
+	It("generates a password", func() {
+		p, err := GeneratePassword()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(p)).To(BeNumerically(">", 1))
+	})
+	It("generates unique passwords", func() {
+		generated := map[string]bool{}
+		for i := 0; i < 10; i++ {
+			p, err := GeneratePassword()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(generated[p]).To(BeFalse())
+			generated[p] = true
+		}
+	})
+})

--- a/product/metadata/gcp-service-broker.yml
+++ b/product/metadata/gcp-service-broker.yml
@@ -124,12 +124,12 @@ property_blueprints:
 - configurable: true
   label: Database username
   name: db_username
-  optional: false
+  optional: true
   type: string
 - configurable: true
   label: Database password
   name: db_password
-  optional: false
+  optional: true
   type: secret
 - configurable: true
   default: '3306'

--- a/product/metadata/gcp-service-broker.yml
+++ b/product/metadata/gcp-service-broker.yml
@@ -124,12 +124,10 @@ property_blueprints:
 - configurable: true
   label: Database username
   name: db_username
-  optional: true
   type: string
 - configurable: true
   label: Database password
   name: db_password
-  optional: true
   type: secret
 - configurable: true
   default: '3306'

--- a/tile.yml
+++ b/tile.yml
@@ -162,9 +162,11 @@ forms:
   - name: db_username
     type: string
     label: Database username
+    optional: true
   - name: db_password
     type: secret
     label: Database password
+    optional: true
   - name: db_port
     type: string
     default: '3306'


### PR DESCRIPTION
# Changes
- Generate username/password inside of the CloudSQLBroker
- Mark username/password as optional fields in tile
- Don't require a value for `details.Parameters` on bind


# Validation
- Unit tested CloudSQLBroker.Bind for credentials generation
- Deployed broker, created a new cloudsql instance, bound to an app. Username/Password populated in `VCAP_SERVICES` env variable

# Open Issues
 - [x] Update README.md now that username/password are optional on Bind

Fixes #13
