### PR TITLE
139 - add command to dump current plan information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,3 +122,7 @@ any extra access details
 ## [3.4.1] - 2017-05-22
 
 - fixes uninitialized security group
+
+## [4.0.0] - 2017-07-XX
+
+- added command `get_plan_info` to dump plan information to the console. Advised to run before updating.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ See the [examples](https://github.com/GoogleCloudPlatform/gcp-service-broker/blo
 The [cmd](https://github.com/GoogleCloudPlatform/gcp-service-broker/blob/master/cmd/) folder contains commands that can be run independent of the broker.
 
 * `migrate`: migrates the database to the latest schema
+* `get_plan_info`: dumps plan information stored in the database for versions < 4.0.0 to the command line. Advised to 
+run this command and copy plan guids into manifest.yml before upgrading between < 4 to >= 4.
 
 ## Testing
 

--- a/cmd/get_plan_info/get_plan_info.go
+++ b/cmd/get_plan_info/get_plan_info.go
@@ -1,0 +1,42 @@
+// Copyright the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+
+package main
+
+import (
+	"code.cloudfoundry.org/lager"
+	"encoding/json"
+	"gcp-service-broker/brokerapi/brokers/models"
+	"gcp-service-broker/db_service"
+)
+
+func main() {
+	logger := lager.NewLogger("get_plan_info_cmd")
+	db := db_service.SetupDb(logger)
+
+	var pds []*models.PlanDetails
+	if err := db.Find(&pds).Error; err != nil {
+		panic("Could not retrieve plan details rows from db")
+	}
+
+	prettybytes, err := json.MarshalIndent(&pds, "", "    ")
+	if err != nil {
+		panic("Could not marshal plan details to json string")
+	}
+	println(string(prettybytes))
+
+}

--- a/db_service/setup_db.go
+++ b/db_service/setup_db.go
@@ -35,6 +35,11 @@ func SetupDb(logger lager.Logger) *gorm.DB {
 	dbHost := os.Getenv("DB_HOST")
 	dbUsername := os.Getenv("DB_USERNAME")
 	dbPassword := os.Getenv("DB_PASSWORD")
+
+	if dbPassword == "" || dbHost == "" || dbUsername == "" {
+		panic("DB_HOST, DB_USERNAME and DB_PASSWORD are required environment variables.")
+	}
+
 	dbPort := os.Getenv("DB_PORT")
 	dbName := os.Getenv("DB_NAME")
 


### PR DESCRIPTION
#139 - plan information so that ids can be copied to manifest.yml 