### PR TITLE
If role is not provided, use default role.

### DIFF
--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -42,7 +42,7 @@ type ServiceAccountManager struct {
 func (sam *ServiceAccountManager) CreateAccountInGoogle(instanceID string, bindingID string, details models.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
 	role, ok := details.Parameters["role"].(string)
 	if !ok {
-		role = "owner"
+		role = "storage.objectAdmin"
 	}
 
 	someName := ServiceAccountName(bindingID)

--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -19,7 +19,6 @@ package account_managers
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"gcp-service-broker/brokerapi/brokers/models"
 	"gcp-service-broker/utils"
@@ -43,7 +42,7 @@ type ServiceAccountManager struct {
 func (sam *ServiceAccountManager) CreateAccountInGoogle(instanceID string, bindingID string, details models.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
 	role, ok := details.Parameters["role"].(string)
 	if !ok {
-		return models.ServiceBindingCredentials{}, errors.New("Error getting role as string from request")
+		role = "owner"
 	}
 
 	someName := ServiceAccountName(bindingID)


### PR DESCRIPTION
Because of https://github.com/cloudfoundry/cli/issues/1173 this pull request sets 'owner' as the default role if no role is specified in the bind-service command.

I guess reading the default role from the config would be great, but I would need some advice how to implement that.

If you don't want to merge it as is, please provide advice on how to improve the code.

Thanks!