### PR TITLE
157 - refactor service and plan env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,3 +130,5 @@ any extra access details
 - changed custom plan id field name from `guid` to `id`
 - modified `"features"` plan config field name to `"service_properties"`
 - modified the formatting of custom plans to be consistent with that of preconfigured plans
+- modified structure of all catalog-related environment variables - `plans` is now a sub-field of the Service object, 
+and Service objects are defined individually by setting env variables like `GOOGLE_<SERVICE_NAME>`

--- a/brokerapi/brokers/models/catalog.go
+++ b/brokerapi/brokers/models/catalog.go
@@ -18,8 +18,8 @@
 package models
 
 type Service struct {
-	ID              string                  `json:"id"`
-	Name            string                  `json:"name"`
+	ID              string                  `json:"id" validate:"nonzero"`
+	Name            string                  `json:"name" validate:"nonzero"`
 	Description     string                  `json:"description"`
 	Bindable        bool                    `json:"bindable"`
 	Tags            []string                `json:"tags,omitempty"`
@@ -37,12 +37,12 @@ type ServiceDashboardClient struct {
 }
 
 type ServicePlan struct {
-	ID                string               `json:"id"`
-	Name              string               `json:"name"`
+	ID                string               `json:"id" validate:"nonzero"`
+	Name              string               `json:"name" validate:"nonzero"`
 	Description       string               `json:"description"`
 	Free              *bool                `json:"free,omitempty"`
 	Metadata          *ServicePlanMetadata `json:"metadata,omitempty"`
-	ServiceProperties map[string]string
+	ServiceProperties map[string]string    `json:"service_properties"`
 }
 
 type ServicePlanMetadata struct {
@@ -63,10 +63,6 @@ type ServiceMetadata struct {
 	ProviderDisplayName string `json:"providerDisplayName,omitempty"`
 	DocumentationUrl    string `json:"documentationUrl,omitempty"`
 	SupportUrl          string `json:"supportUrl,omitempty"`
-}
-
-func FreeValue(v bool) *bool {
-	return &v
 }
 
 type RequiredPermission string

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -172,3 +172,15 @@ const SpannerName = "google-spanner"
 const StackdriverTraceName = "google-stackdriver-trace"
 const StackdriverDebuggerName = "google-stackdriver-debugger"
 const RootSaEnvVar = "ROOT_SERVICE_ACCOUNT_JSON"
+
+var ServiceEnvVarNames = []string{
+	"GOOGLE_SPANNER",
+	"GOOGLE_BIGQUERY",
+	"GOOGLE_BIGTABLE",
+	"GOOGLE_STORAGE",
+	"GOOGLE_PUBSUB",
+	"GOOGLE_STACKDRIVER_DEBUGGER",
+	"GOOGLE_STACKDRIVER_TRACE",
+	"GOOGLE_ML_APIS",
+	"GOOGLE_CLOUDSQL",
+}

--- a/brokerapi/brokers/spanner/broker.go
+++ b/brokerapi/brokers/spanner/broker.go
@@ -173,11 +173,11 @@ func (s *SpannerBroker) PollInstance(instanceId string) (bool, error) {
 		op.Status = "FAILED"
 		op.ErrorMessage = err.Error()
 
-		if err = db_service.DbConnection.Save(&op).Error; err != nil {
-			return false, fmt.Errorf(`Error saving operation details to database: %s.`, err)
+		if dberr := db_service.DbConnection.Save(&op).Error; dberr != nil {
+			return false, fmt.Errorf(`Error saving operation details to database: %s.`, dberr)
 		}
 
-		return true, fmt.Errorf("Error provisioning instance: %s", err)
+		return true, fmt.Errorf("Error provisioning instance: %v", err)
 	} else if spannerInstance == nil && err == nil && !done {
 		op.Status = spannerInstance.State.String()
 

--- a/db_service/db_service_test.go
+++ b/db_service/db_service_test.go
@@ -71,7 +71,7 @@ var _ = Describe("DbService", func() {
 		logger = lager.NewLogger("brokers_test")
 		logger.RegisterSink(lager.NewWriterSink(GinkgoWriter, lager.DEBUG))
 
-		os.Setenv("SERVICES", fakes.Services)
+		fakes.SetUpTestServices()
 
 		createTestDatabase()
 		testDb, _ := gorm.Open("mysql", getLocalTestConnectionStr("servicebroker"))

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -10,9 +10,11 @@ Optionally add these to the env section of `manifest.yml`
 * `CLIENT_CERT`
 * `CLIENT_KEY`
 
-## [Optional plan vars](#optional-plan)
+## [Optional service vars](#optional-plan)
 
-* `CLOUDSQL_CUSTOM_PLANS` (A list of json objects with fields `id`, `name`, `description`, `
+update the following variables in `manifest.yml` if you wish to enable these services
+
+* `GOOGLE_CLOUDSQL.plans` (A list of json objects with fields `id`, `name`, `description`, `
 service_properties` (containing `tier`, `pricing_plan`, `max_disk_size`), `display_name`, and `service_id` 
 (Cloud SQL's service id)) - if unset, the service will be disabled. 
 
@@ -34,7 +36,7 @@ e.g.,
     }
 ]
 ```
-* `BIGTABLE_CUSTOM_PLANS` (A list of json objects with fields `id`, `name`, `description`,
+* `GOOGLE_BIGTABLE.plans` (A list of json objects with fields `id`, `name`, `description`,
 `service_properties` (containing `storage_type`, `num_nodes`), `display_name`, and `service_id` (Bigtable's service id)) 
 - if unset, the service will be disabled. 
 
@@ -55,7 +57,7 @@ e.g.,
     }
 ]
 ```
-* `SPANNER_CUSTOM_PLANS` (A list of json objects with fields `id`, `name`, `description`, `service_properties` (containing 
+* `GOOGLE_SPANNER.plans` (A list of json objects with fields `id`, `name`, `description`, `service_properties` (containing 
 `num_nodes`), `display_name`, and `service_id` (Spanner's service id)) - if unset, the service will be disabled. 
 
 e.g.,

--- a/fakes/fake_env_vars.go
+++ b/fakes/fake_env_vars.go
@@ -1,97 +1,210 @@
 package fakes
 
-const Services string = `[
-        {
-          "id": "b9e4332e-b42b-4680-bda5-ea1506797474",
-          "description": "A Powerful, Simple and Cost Effective Object Storage Service",
-          "name": "google-storage",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google Cloud Storage",
-            "longDescription": "A Powerful, Simple and Cost Effective Object Storage Service",
-            "documentationUrl": "https://cloud.google.com/storage/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/storage.svg"
-          },
-          "tags": ["gcp", "storage"]
+import "os"
+
+const StorageEnvSettings = `{
+"id": "b9e4332e-b42b-4680-bda5-ea1506797474",
+"description": "A Powerful, Simple and Cost Effective Object Storage Service",
+"name": "google-storage",
+"bindable": true,
+"plan_updateable": false,
+"metadata": {
+"displayName": "Google Cloud Storage",
+"longDescription": "A Powerful, Simple and Cost Effective Object Storage Service",
+"documentationUrl": "https://cloud.google.com/storage/docs/overview",
+"supportUrl": "https://cloud.google.com/support/",
+"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/storage.svg"
+},
+"tags": ["gcp", "storage"],
+"plans": [
+{
+"id": "e1d11f65-da66-46ad-977c-6d56513baf43",
+"service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
+"name": "standard",
+"display_name": "Standard",
+"description": "Standard storage class",
+"service_properties": {"storage_class": "STANDARD"}
+},
+{
+"id": "a42c1182-d1a0-4d40-82c1-28220518b360",
+"service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
+"name": "nearline",
+"display_name": "Nearline",
+"description": "Nearline storage class",
+"service_properties": {"storage_class": "NEARLINE"}
+},
+{
+"id": "1a1f4fe6-1904-44d0-838c-4c87a9490a6b",
+"service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
+"name": "reduced_availability",
+"display_name": "Durable Reduced Availability",
+"description": "Durable Reduced Availability storage class",
+"service_properties": {"storage_class": "DURABLE_REDUCED_AVAILABILITY"}
+}
+]
+}`
+
+const PubsubEnvSettings = `{
+"id": "628629e3-79f5-4255-b981-d14c6c7856be",
+"description": "A global service for real-time and reliable messaging and streaming data",
+"name": "google-pubsub",
+"bindable": true,
+"plan_updateable": false,
+"metadata": {
+"displayName": "Google PubSub",
+"longDescription": "A global service for real-time and reliable messaging and streaming data",
+"documentationUrl": "https://cloud.google.com/pubsub/docs/",
+"supportUrl": "https://cloud.google.com/support/",
+"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/pubsub.svg"
+},
+"tags": ["gcp", "pubsub"],
+"plans": [
+{
+"id": "622f4da3-8731-492a-af29-66a9146f8333",
+"service_id": "628629e3-79f5-4255-b981-d14c6c7856be",
+"name": "default",
+"display_name": "Default",
+"description": "PubSub Default plan",
+"service_properties": {}
+}
+]
+}`
+
+const BigqueryEnvSettings = `{
+"id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",
+"description": "A fast, economical and fully managed data warehouse for large-scale data analytics",
+"name": "google-bigquery",
+"bindable": true,
+"plan_updateable": false,
+"metadata": {
+"displayName": "Google BigQuery",
+"longDescription": "A fast, economical and fully managed data warehouse for large-scale data analytics",
+"documentationUrl": "https://cloud.google.com/bigquery/docs/",
+"supportUrl": "https://cloud.google.com/support/",
+"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigquery.svg"
+},
+"tags": ["gcp", "bigquery"],
+"plans": [
+{
+"id": "10ff4e72-6e84-44eb-851f-bdb38a791914",
+"service_id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",
+"name": "default",
+"display_name": "Default",
+"description": "BigQuery default plan",
+"service_properties": {}
+}
+]
+}`
+
+const CloudSqlEnvSettings = `{
+"id": "4bc59b9a-8520-409f-85da-1c7552315863",
+"description": "Google Cloud SQL is a fully-managed MySQL database service",
+"name": "google-cloudsql",
+"bindable": true,
+"plan_updateable": false,
+"metadata": {
+"displayName": "Google CloudSQL",
+"longDescription": "Google Cloud SQL is a fully-managed MySQL database service",
+"documentationUrl": "https://cloud.google.com/sql/docs/",
+"supportUrl": "https://cloud.google.com/support/",
+"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/sql.svg"
+},
+"tags": ["gcp", "cloudsql"],
+"plans": [
+    {
+        "id": "test-cloudsql-plan",
+        "name": "test_plan",
+        "description": "testplan",
+        "service_properties": {
+            "tier": "D8",
+            "pricing_plan": "PER_USE",
+            "max_disk_size": "15"
         },
-        {
-          "id": "628629e3-79f5-4255-b981-d14c6c7856be",
-          "description": "A global service for real-time and reliable messaging and streaming data",
-          "name": "google-pubsub",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google PubSub",
-            "longDescription": "A global service for real-time and reliable messaging and streaming data",
-            "documentationUrl": "https://cloud.google.com/pubsub/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/pubsub.svg"
-          },
-          "tags": ["gcp", "pubsub"]
-        },
-        {
-          "id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",
-          "description": "A fast, economical and fully managed data warehouse for large-scale data analytics",
-          "name": "google-bigquery",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google BigQuery",
-            "longDescription": "A fast, economical and fully managed data warehouse for large-scale data analytics",
-            "documentationUrl": "https://cloud.google.com/bigquery/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigquery.svg"
-          },
-          "tags": ["gcp", "bigquery"]
-        },
-        {
-          "id": "4bc59b9a-8520-409f-85da-1c7552315863",
-          "description": "Google Cloud SQL is a fully-managed MySQL database service",
-          "name": "google-cloudsql",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google CloudSQL",
-            "longDescription": "Google Cloud SQL is a fully-managed MySQL database service",
-            "documentationUrl": "https://cloud.google.com/sql/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/sql.svg"
-          },
-          "tags": ["gcp", "cloudsql"]
-        },
-        {
-          "id": "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4",
-          "description": "Machine Learning Apis including Vision, Translate, Speech, and Natural Language",
-          "name": "google-ml-apis",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google Machine Learning APIs",
-            "longDescription": "Machine Learning Apis including Vision, Translate, Speech, and Natural Language",
-            "documentationUrl": "https://cloud.google.com/ml/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/machine-learning.svg"
-          },
-          "tags": ["gcp", "ml"]
-        },
-        {
-         "id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe",
-         "description": "A high performance NoSQL database service for large analytical and operational workloads",
-         "name": "google-bigtable",
-         "bindable": true,
-         "plan_updateable": false,
-         "metadata": {
-           "displayName": "Google Bigtable",
-           "longDescription": "A high performance NoSQL database service for large analytical and operational workloads",
-           "documentationUrl": "https://cloud.google.com/bigtable/",
-           "supportUrl": "https://cloud.google.com/support/",
-           "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigtable.svg"
-         },
-         "tags": ["gcp", "bigtable"]
-        },
-        {
+        "display_name": "FOOBAR",
+        "service_id": "4bc59b9a-8520-409f-85da-1c7552315863"
+    }
+]
+}`
+
+const MlApiEnvSettings = `{
+"id": "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4",
+"description": "Machine Learning Apis including Vision, Translate, Speech, and Natural Language",
+"name": "google-ml-apis",
+"bindable": true,
+"plan_updateable": false,
+"metadata": {
+"displayName": "Google Machine Learning APIs",
+"longDescription": "Machine Learning Apis including Vision, Translate, Speech, and Natural Language",
+"documentationUrl": "https://cloud.google.com/ml/",
+"supportUrl": "https://cloud.google.com/support/",
+"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/machine-learning.svg"
+},
+"tags": ["gcp", "ml"],
+"plans":  [
+{
+"id": "be7954e1-ecfb-4936-a0b6-db35e6424c7a",
+"service_id": "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4",
+"name": "default",
+"display_name": "Default",
+"description": "Machine Learning api default plan",
+"service_properties": {}
+}
+]
+}`
+
+const StackdriverDebuggerEnvSettings = `{
+"id": "83837945-1547-41e0-b661-ea31d76eed11",
+"description": "Stackdriver Debugger",
+"name": "google-stackdriver-debugger",
+"bindable": true,
+"plan_updateable": false,
+"metadata": {
+"displayName": "Stackdriver Debugger",
+"longDescription": "Stackdriver Debugger is a feature of the Google Cloud Platform that lets you inspect the state of an application at any code location without using logging statements and without stopping or slowing down your applications. Your users are not impacted during debugging. Using the production debugger you can capture the local variables and call stack and link it back to a specific line location in your source code.",
+"documentationUrl": "https://cloud.google.com/debugger/docs/",
+"supportUrl": "https://cloud.google.com/support/",
+"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/debugger.svg"
+},
+"tags": ["gcp", "stackdriver", "debugger"],
+"plans": [
+{
+"id": "10866183-a775-49e8-96e3-4e7a901e4a79",
+"service_id": "83837945-1547-41e0-b661-ea31d76eed11",
+"name": "default",
+"display_name": "Default",
+"description": "Stackdriver Debugger default plan",
+"service_properties": {}
+}
+]
+}`
+
+const StackdriverTraceEnvSettings = `{
+"id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
+"description": "Stackdriver Trace",
+"name": "google-stackdriver-trace",
+"bindable": true,
+"plan_updateable": false,
+"metadata": {
+"displayName": "Stackdriver Trace",
+"longDescription": "Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console. You can track how requests propagate through your application and receive detailed near real-time performance insights.",
+"documentationUrl": "https://cloud.google.com/trace/docs/",
+"supportUrl": "https://cloud.google.com/support/",
+"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/trace.svg"
+},
+"tags": ["gcp", "stackdriver", "trace"],
+"plans": [
+{
+"id": "ab6c2287-b4bc-4ff4-a36a-0575e7910164",
+"service_id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
+"name": "default",
+"display_name": "Default",
+"description": "Stackdriver Trace default plan",
+"service_properties": {}
+}
+]
+}`
+
+const SpannerEnvSettings = `{
           "id": "51b3e27e-d323-49ce-8c5f-1211e6409e82",
           "description": "The first horizontally scalable, globally consistent, relational database service",
           "name": "google-spanner",
@@ -104,150 +217,119 @@ const Services string = `[
             "supportUrl": "https://cloud.google.com/support/",
             "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/spanner.svg"
           },
-          "tags": ["gcp", "spanner"]
-	    },
-        {
-		  "id": "83837945-1547-41e0-b661-ea31d76eed11",
-          "description": "Stackdriver Debugger",
-          "name": "google-stackdriver-debugger",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google Stackdriver Debugger",
-            "longDescription": "Google Stackdriver Debugger provides powerful production diagnostics tools",
-            "documentationUrl": "https://cloud.google.com/debugger/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/debugger.svg"
-          },
-          "tags": ["gcp", "stackdriver", "debugger"]
+          "tags": ["gcp", "spanner"],
+          "plans": [
+    {
+        "id": "test-spanner-plan",
+        "name": "spannerplan",
+        "description": "Basic Spanner plan",
+        "service_properties": {
+            "num_nodes": "3"
         },
-        {
-          "id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
-          "description": "Stackdriver Trace",
-          "name": "google-stackdriver-trace",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Stackdriver Trace",
-            "longDescription": "Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console. You can track how requests propagate through your application and receive detailed near real-time performance insights.",
-            "documentationUrl": "https://cloud.google.com/trace/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/trace.svg"
-          },
-          "tags": ["gcp", "stackdriver", "trace"]
-        }
-      ]`
+        "display_name": "Spanner Plan",
+        "service_id": "51b3e27e-d323-49ce-8c5f-1211e6409e82"
+    }
+]
+        }`
 
-const PreconfiguredPlans = `[
-	{
-          "id": "e1d11f65-da66-46ad-977c-6d56513baf43",
-          "service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
-          "name": "standard",
-          "display_name": "Standard",
-          "description": "Standard storage class",
-          "service_properties": {"storage_class": "STANDARD"}
-        },
-        {
-          "id": "a42c1182-d1a0-4d40-82c1-28220518b360",
-          "service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
-          "name": "nearline",
-          "display_name": "Nearline",
-          "description": "Nearline storage class",
-          "service_properties": {"storage_class": "NEARLINE"}
-        },
-        {
-          "id": "1a1f4fe6-1904-44d0-838c-4c87a9490a6b",
-          "service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
-          "name": "reduced_availability",
-          "display_name": "Durable Reduced Availability",
-          "description": "Durable Reduced Availability storage class",
-          "service_properties": {"storage_class": "DURABLE_REDUCED_AVAILABILITY"}
-        },
-        {
-          "id": "622f4da3-8731-492a-af29-66a9146f8333",
-          "service_id": "628629e3-79f5-4255-b981-d14c6c7856be",
-          "name": "default",
-          "display_name": "Default",
-          "description": "PubSub Default plan",
-          "service_properties": {}
-        },
-        {
-          "id": "10ff4e72-6e84-44eb-851f-bdb38a791914",
-          "service_id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",
-          "name": "default",
-          "display_name": "Default",
-          "description": "BigQuery default plan",
-          "service_properties": {}
-        },
-        {
-          "id": "be7954e1-ecfb-4936-a0b6-db35e6424c7a",
-          "service_id": "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4",
-          "name": "default",
-          "display_name": "Default",
-          "description": "Machine Learning api default plan",
-          "service_properties": {}
-        },
-        {
-          "id": "10866183-a775-49e8-96e3-4e7a901e4a79",
-          "service_id": "83837945-1547-41e0-b661-ea31d76eed11",
-          "name": "default",
-          "display_name": "Default",
-          "description": "Stackdriver Debugger default plan",
-          "service_properties": {}
+const BigtableEnvSettings = `{
+         "id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe",
+         "description": "A high performance NoSQL database service for large analytical and operational workloads",
+         "name": "google-bigtable",
+         "bindable": true,
+         "plan_updateable": false,
+         "metadata": {
+           "displayName": "Google Bigtable",
+           "longDescription": "A high performance NoSQL database service for large analytical and operational workloads",
+           "documentationUrl": "https://cloud.google.com/bigtable/",
+           "supportUrl": "https://cloud.google.com/support/",
+           "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigtable.svg"
          },
-         {
-          "id": "ab6c2287-b4bc-4ff4-a36a-0575e7910164",
-          "service_id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
-          "name": "default",
-          "display_name": "Default",
-          "description": "Stackdriver Trace default plan",
-          "service_properties": {}
-         }
-]`
+         "tags": ["gcp", "bigtable"],
+         "plans": [
+    {
+        "id": "test-bigtable-plan",
+        "name": "bt_plan",
+        "description": "Bigtable basic plan",
+        "service_properties": {
+            "storage_type": "HDD",
+            "num_nodes": "5"
+        },
+        "display_name": "Bigtable Plan",
+        "service_id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe"
+    }
+]
+        }`
 
-const PlanNoId = `[
-	{
-		"service_id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
-		"name": "default",
-		"display_name": "Default",
-		"description": "Stackdriver Trace default plan",
-		"service_properties": {}
+const PlanNoId = `{
+"id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
+"description": "Stackdriver Trace",
+"name": "google-stackdriver-trace",
+"bindable": true,
+"plan_updateable": false,
+"metadata": {
+"displayName": "Stackdriver Trace",
+"longDescription": "Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console. You can track how requests propagate through your application and receive detailed near real-time performance insights.",
+"documentationUrl": "https://cloud.google.com/trace/docs/",
+"supportUrl": "https://cloud.google.com/support/",
+"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/trace.svg"
+},
+"tags": ["gcp", "stackdriver", "trace"],
+"plans": [
+{
+"service_id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
+"name": "default",
+"display_name": "Default",
+"description": "Stackdriver Trace default plan",
+"service_properties": {}
+}
+]
+}`
+
+const CloudSqlNewPlan = `{
+"id": "4bc59b9a-8520-409f-85da-1c7552315863",
+"description": "Google Cloud SQL is a fully-managed MySQL database service",
+"name": "google-cloudsql",
+"bindable": true,
+"plan_updateable": false,
+"metadata": {
+"displayName": "Google CloudSQL",
+"longDescription": "Google Cloud SQL is a fully-managed MySQL database service",
+"documentationUrl": "https://cloud.google.com/sql/docs/",
+"supportUrl": "https://cloud.google.com/support/",
+"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/sql.svg"
+},
+"tags": ["gcp", "cloudsql"],
+"plans": [
+				{
+					"id": "some-other-cloudsql-plan",
+					"name": "newPlan",
+					"description": "testplan",
+					"service_properties": {
+						"tier": "D8",
+						"pricing_plan": "athing",
+						"max_disk_size": "15"
+					},
+					"display_name": "FOOBAR",
+					"service_id": "4bc59b9a-8520-409f-85da-1c7552315863"
+				}
+			]
+}`
+
+var TestServiceEnvSettingsVars = map[string]string{
+	"GOOGLE_SPANNER":              SpannerEnvSettings,
+	"GOOGLE_BIGQUERY":             BigqueryEnvSettings,
+	"GOOGLE_BIGTABLE":             BigtableEnvSettings,
+	"GOOGLE_STORAGE":              StorageEnvSettings,
+	"GOOGLE_PUBSUB":               PubsubEnvSettings,
+	"GOOGLE_STACKDRIVER_DEBUGGER": StackdriverDebuggerEnvSettings,
+	"GOOGLE_STACKDRIVER_TRACE":    StackdriverTraceEnvSettings,
+	"GOOGLE_ML_APIS":              MlApiEnvSettings,
+	"GOOGLE_CLOUDSQL":             CloudSqlEnvSettings,
+}
+
+func SetUpTestServices() {
+	for envVarName, goVarName := range TestServiceEnvSettingsVars {
+		os.Setenv(envVarName, goVarName)
 	}
-]`
-
-const TestCloudSQLPlan = `[{
-				"id": "test_cloudsql_plan",
-				"name": "test_cloudsql_plan",
-				"description": "test-cloudsql-plan",
-				"service_properties": {
-					"tier": "D4",
-					"pricing_plan": "PER_USE",
-					"max_disk_size": "20"
-				},
-				"display_name": "test_cloudsql_plan",
-				"service_id": "4bc59b9a-8520-409f-85da-1c7552315863"
-			}
-		]`
-const TestBigtablePlan = `[{
-				"id": "test_bigtable_plan",
-				"name": "test_bigtable_plan",
-				"description": "test-bigtable-plan",
-				"service_properties": {
-					"storage_type": "SSD",
-					"num_nodes": "3"
-				},
-				"display_name": "test_bigtable_plan",
-				"service_id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe"
-			}
-		]`
-const TestSpannerPlan = `[{
-				"id": "test_spanner_plan",
-				"name": "test_spanner_plan",
-				"description": "test-spanner-plan",
-				"service_properties": {
-					"num_nodes": "3"
-				},
-				"display_name": "test_spanner_plan",
-				"service_id": "51b3e27e-d323-49ce-8c5f-1211e6409e82"
-			}
-		]`
+}

--- a/integration_tests/async_integration_test.go
+++ b/integration_tests/async_integration_test.go
@@ -85,12 +85,8 @@ var _ = Describe("AsyncIntegrationTests", func() {
 
 		os.Setenv("SECURITY_USER_NAME", "username")
 		os.Setenv("SECURITY_USER_PASSWORD", "password")
-		os.Setenv("SERVICES", fakes.Services)
-		os.Setenv("PRECONFIGURED_PLANS", fakes.PreconfiguredPlans)
 
-		os.Setenv("CLOUDSQL_CUSTOM_PLANS", fakes.TestCloudSQLPlan)
-		os.Setenv("BIGTABLE_CUSTOM_PLANS", fakes.TestBigtablePlan)
-		os.Setenv("SPANNER_CUSTOM_PLANS", fakes.TestSpannerPlan)
+		fakes.SetUpTestServices()
 
 		var creds models.GCPCredentials
 		creds, err = brokers.GetCredentialsFromEnv()

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -201,12 +201,8 @@ var _ = Describe("LiveIntegrationTests", func() {
 
 		os.Setenv("SECURITY_USER_NAME", "username")
 		os.Setenv("SECURITY_USER_PASSWORD", "password")
-		os.Setenv("SERVICES", fakes.Services)
-		os.Setenv("PRECONFIGURED_PLANS", fakes.PreconfiguredPlans)
 
-		os.Setenv("CLOUDSQL_CUSTOM_PLANS", fakes.TestCloudSQLPlan)
-		os.Setenv("BIGTABLE_CUSTOM_PLANS", fakes.TestBigtablePlan)
-		os.Setenv("SPANNER_CUSTOM_PLANS", fakes.TestSpannerPlan)
+		fakes.SetUpTestServices()
 
 		var creds models.GCPCredentials
 		creds, err = brokers.GetCredentialsFromEnv()

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,53 +23,98 @@ applications:
     buildpack: go_buildpack
     env:
       GO15VENDOREXPERIMENT: 1
-      SERVICES: '[
-        {
-          "id": "b9e4332e-b42b-4680-bda5-ea1506797474",
-          "description": "A Powerful, Simple and Cost Effective Object Storage Service",
-          "name": "google-storage",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google Cloud Storage",
-            "longDescription": "A Powerful, Simple and Cost Effective Object Storage Service",
-            "documentationUrl": "https://cloud.google.com/storage/docs/overview",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/storage.svg"
-          },
-          "tags": ["gcp", "storage"]
+      GOOGLE_STORAGE: '{
+        "id": "b9e4332e-b42b-4680-bda5-ea1506797474",
+        "description": "A Powerful, Simple and Cost Effective Object Storage Service",
+        "name": "google-storage",
+        "bindable": true,
+        "plan_updateable": false,
+        "metadata": {
+          "displayName": "Google Cloud Storage",
+          "longDescription": "A Powerful, Simple and Cost Effective Object Storage Service",
+          "documentationUrl": "https://cloud.google.com/storage/docs/overview",
+          "supportUrl": "https://cloud.google.com/support/",
+          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/storage.svg"
         },
-        {
-          "id": "628629e3-79f5-4255-b981-d14c6c7856be",
-          "description": "A global service for real-time and reliable messaging and streaming data",
-          "name": "google-pubsub",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google PubSub",
-            "longDescription": "A global service for real-time and reliable messaging and streaming data",
-            "documentationUrl": "https://cloud.google.com/pubsub/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/pubsub.svg"
+        "tags": ["gcp", "storage"],
+        "plans": [
+          {
+            "id": "e1d11f65-da66-46ad-977c-6d56513baf43",
+            "service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
+            "name": "standard",
+            "display_name": "Standard",
+            "description": "Standard storage class",
+            "service_properties": {"storage_class": "STANDARD"}
           },
-          "tags": ["gcp", "pubsub"]
-        },
-        {
-          "id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",
-          "description": "A fast, economical and fully managed data warehouse for large-scale data analytics",
-          "name": "google-bigquery",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google BigQuery",
-            "longDescription": "A fast, economical and fully managed data warehouse for large-scale data analytics",
-            "documentationUrl": "https://cloud.google.com/bigquery/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigquery.svg"
+          {
+            "id": "a42c1182-d1a0-4d40-82c1-28220518b360",
+            "service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
+            "name": "nearline",
+            "display_name": "Nearline",
+            "description": "Nearline storage class",
+            "service_properties": {"storage_class": "NEARLINE"}
           },
-          "tags": ["gcp", "bigquery"]
+          {
+            "id": "1a1f4fe6-1904-44d0-838c-4c87a9490a6b",
+            "service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
+            "name": "reduced_availability",
+            "display_name": "Durable Reduced Availability",
+            "description": "Durable Reduced Availability storage class",
+            "service_properties": {"storage_class": "DURABLE_REDUCED_AVAILABILITY"}
+          }
+        ]
+      }'
+      GOOGLE_PUBSUB: '{
+        "id": "628629e3-79f5-4255-b981-d14c6c7856be",
+        "description": "A global service for real-time and reliable messaging and streaming data",
+        "name": "google-pubsub",
+        "bindable": true,
+        "plan_updateable": false,
+        "metadata": {
+          "displayName": "Google PubSub",
+          "longDescription": "A global service for real-time and reliable messaging and streaming data",
+          "documentationUrl": "https://cloud.google.com/pubsub/docs/",
+          "supportUrl": "https://cloud.google.com/support/",
+          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/pubsub.svg"
         },
-        {
+        "tags": ["gcp", "pubsub"],
+        "plans": [
+          {
+            "id": "622f4da3-8731-492a-af29-66a9146f8333",
+            "service_id": "628629e3-79f5-4255-b981-d14c6c7856be",
+            "name": "default",
+            "display_name": "Default",
+            "description": "PubSub Default plan",
+            "service_properties": {}
+          }
+        ]
+      }'
+      GOOGLE_BIGQUERY: '{
+        "id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",
+        "description": "A fast, economical and fully managed data warehouse for large-scale data analytics",
+        "name": "google-bigquery",
+        "bindable": true,
+        "plan_updateable": false,
+        "metadata": {
+          "displayName": "Google BigQuery",
+          "longDescription": "A fast, economical and fully managed data warehouse for large-scale data analytics",
+          "documentationUrl": "https://cloud.google.com/bigquery/docs/",
+          "supportUrl": "https://cloud.google.com/support/",
+          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigquery.svg"
+        },
+        "tags": ["gcp", "bigquery"],
+        "plans": [
+          {
+            "id": "10ff4e72-6e84-44eb-851f-bdb38a791914",
+            "service_id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",
+            "name": "default",
+            "display_name": "Default",
+            "description": "BigQuery default plan",
+            "service_properties": {}
+          }
+        ]
+      }'
+      GOOGLE_CLOUDSQL: '{
           "id": "4bc59b9a-8520-409f-85da-1c7552315863",
           "description": "Google Cloud SQL is a fully-managed MySQL database service",
           "name": "google-cloudsql",
@@ -82,117 +127,84 @@ applications:
             "supportUrl": "https://cloud.google.com/support/",
             "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/sql.svg"
           },
-          "tags": ["gcp", "cloudsql"]
+          "tags": ["gcp", "cloudsql"],
+          "plans": []
+      }'
+      GOOGLE_ML_APIS: '{
+        "id": "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4",
+        "description": "Machine Learning Apis including Vision, Translate, Speech, and Natural Language",
+        "name": "google-ml-apis",
+        "bindable": true,
+        "plan_updateable": false,
+        "metadata": {
+          "displayName": "Google Machine Learning APIs",
+          "longDescription": "Machine Learning Apis including Vision, Translate, Speech, and Natural Language",
+          "documentationUrl": "https://cloud.google.com/ml/",
+          "supportUrl": "https://cloud.google.com/support/",
+          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/machine-learning.svg"
         },
-        {
-          "id": "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4",
-          "description": "Machine Learning Apis including Vision, Translate, Speech, and Natural Language",
-          "name": "google-ml-apis",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Google Machine Learning APIs",
-            "longDescription": "Machine Learning Apis including Vision, Translate, Speech, and Natural Language",
-            "documentationUrl": "https://cloud.google.com/ml/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/machine-learning.svg"
-          },
-          "tags": ["gcp", "ml"]
+        "tags": ["gcp", "ml"],
+        "plans":  [
+          {
+           "id": "be7954e1-ecfb-4936-a0b6-db35e6424c7a",
+           "service_id": "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4",
+           "name": "default",
+           "display_name": "Default",
+           "description": "Machine Learning api default plan",
+           "service_properties": {}
+          }
+        ]
+      }'
+      GOOGLE_STACKDRIVER_DEBUGGER: '{
+        "id": "83837945-1547-41e0-b661-ea31d76eed11",
+        "description": "Stackdriver Debugger",
+        "name": "google-stackdriver-debugger",
+        "bindable": true,
+        "plan_updateable": false,
+        "metadata": {
+          "displayName": "Stackdriver Debugger",
+          "longDescription": "Stackdriver Debugger is a feature of the Google Cloud Platform that lets you inspect the state of an application at any code location without using logging statements and without stopping or slowing down your applications. Your users are not impacted during debugging. Using the production debugger you can capture the local variables and call stack and link it back to a specific line location in your source code.",
+          "documentationUrl": "https://cloud.google.com/debugger/docs/",
+          "supportUrl": "https://cloud.google.com/support/",
+          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/debugger.svg"
         },
-        {
-          "id": "83837945-1547-41e0-b661-ea31d76eed11",
-          "description": "Stackdriver Debugger",
-          "name": "google-stackdriver-debugger",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Stackdriver Debugger",
-            "longDescription": "Stackdriver Debugger is a feature of the Google Cloud Platform that lets you inspect the state of an application at any code location without using logging statements and without stopping or slowing down your applications. Your users are not impacted during debugging. Using the production debugger you can capture the local variables and call stack and link it back to a specific line location in your source code.",
-            "documentationUrl": "https://cloud.google.com/debugger/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/debugger.svg"
-          },
-          "tags": ["gcp", "stackdriver", "debugger"]
+        "tags": ["gcp", "stackdriver", "debugger"],
+        "plans": [
+          {
+            "id": "10866183-a775-49e8-96e3-4e7a901e4a79",
+            "service_id": "83837945-1547-41e0-b661-ea31d76eed11",
+            "name": "default",
+            "display_name": "Default",
+            "description": "Stackdriver Debugger default plan",
+            "service_properties": {}
+          }
+        ]
+      }'
+      GOOGLE_STACKDRIVER_TRACE: '{
+        "id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
+        "description": "Stackdriver Trace",
+        "name": "google-stackdriver-trace",
+        "bindable": true,
+        "plan_updateable": false,
+        "metadata": {
+          "displayName": "Stackdriver Trace",
+          "longDescription": "Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console. You can track how requests propagate through your application and receive detailed near real-time performance insights.",
+          "documentationUrl": "https://cloud.google.com/trace/docs/",
+          "supportUrl": "https://cloud.google.com/support/",
+          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/trace.svg"
         },
-        {
-          "id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
-          "description": "Stackdriver Trace",
-          "name": "google-stackdriver-trace",
-          "bindable": true,
-          "plan_updateable": false,
-          "metadata": {
-            "displayName": "Stackdriver Trace",
-            "longDescription": "Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console. You can track how requests propagate through your application and receive detailed near real-time performance insights.",
-            "documentationUrl": "https://cloud.google.com/trace/docs/",
-            "supportUrl": "https://cloud.google.com/support/",
-            "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/trace.svg"
-          },
-          "tags": ["gcp", "stackdriver", "trace"]
-        }
-      ]'
-      PRECONFIGURED_PLANS: '[
-        {
-          "id": "e1d11f65-da66-46ad-977c-6d56513baf43",
-          "service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
-          "name": "standard",
-          "display_name": "Standard",
-          "description": "Standard storage class",
-          "service_properties": {"storage_class": "STANDARD"}
-        },
-        {
-          "id": "a42c1182-d1a0-4d40-82c1-28220518b360",
-          "service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
-          "name": "nearline",
-          "display_name": "Nearline",
-          "description": "Nearline storage class",
-          "service_properties": {"storage_class": "NEARLINE"}
-        },
-        {
-          "id": "1a1f4fe6-1904-44d0-838c-4c87a9490a6b",
-          "service_id": "b9e4332e-b42b-4680-bda5-ea1506797474",
-          "name": "reduced_availability",
-          "display_name": "Durable Reduced Availability",
-          "description": "Durable Reduced Availability storage class",
-          "service_properties": {"storage_class": "DURABLE_REDUCED_AVAILABILITY"}
-        },
-        {
-          "id": "622f4da3-8731-492a-af29-66a9146f8333",
-          "service_id": "628629e3-79f5-4255-b981-d14c6c7856be",
-          "name": "default",
-          "display_name": "Default",
-          "description": "PubSub Default plan",
-          "service_properties": {}
-        },
-        {
-          "id": "10ff4e72-6e84-44eb-851f-bdb38a791914",
-          "service_id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",
-          "name": "default",
-          "display_name": "Default",
-          "description": "BigQuery default plan",
-          "service_properties": {}
-        },
-        {
-          "id": "be7954e1-ecfb-4936-a0b6-db35e6424c7a",
-          "service_id": "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4",
-          "name": "default",
-          "display_name": "Default",
-          "description": "Machine Learning api default plan",
-          "service_properties": {}
-        },
-        {
-          "id": "10866183-a775-49e8-96e3-4e7a901e4a79",
-          "service_id": "83837945-1547-41e0-b661-ea31d76eed11",
-          "name": "default",
-          "display_name": "Default",
-          "description": "Stackdriver Debugger default plan",
-          "service_properties": {}
-         },
-         {
-          "id": "ab6c2287-b4bc-4ff4-a36a-0575e7910164",
-          "service_id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
-          "name": "default",
-          "display_name": "Default",
-          "description": "Stackdriver Trace default plan",
-          "service_properties": {}
-         }
-      ]'
+        "tags": ["gcp", "stackdriver", "trace"],
+        "plans": [
+          {
+            "id": "ab6c2287-b4bc-4ff4-a36a-0575e7910164",
+            "service_id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
+            "name": "default",
+            "display_name": "Default",
+            "description": "Stackdriver Trace default plan",
+            "service_properties": {}
+          }
+        ]
+      }'
+      GOOGLE_SPANNER: '{}'
+      GOOGLE_BIGTABLE: '{}'
+

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,7 +27,6 @@ import (
 
 func MapServiceIdToName() (map[string]string, error) {
 	idToNameMap := make(map[string]string)
-	var serviceList []models.Service
 
 	for _, varname := range models.ServiceEnvVarNames {
 
@@ -35,13 +34,10 @@ func MapServiceIdToName() (map[string]string, error) {
 		if err := json.Unmarshal([]byte(os.Getenv(varname)), &svc); err != nil {
 			return map[string]string{}, err
 		} else {
-			serviceList = append(serviceList, svc)
+			idToNameMap[svc.ID] = svc.Name
 		}
 	}
 
-	for _, service := range serviceList {
-		idToNameMap[service.ID] = service.Name
-	}
 	return idToNameMap, nil
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,9 +28,15 @@ import (
 func MapServiceIdToName() (map[string]string, error) {
 	idToNameMap := make(map[string]string)
 	var serviceList []models.Service
-	serviceStr := os.Getenv("SERVICES")
-	if err := json.Unmarshal([]byte(serviceStr), &serviceList); err != nil {
-		return idToNameMap, fmt.Errorf("Error unmarshalling service list %s", err)
+
+	for _, varname := range models.ServiceEnvVarNames {
+
+		var svc models.Service
+		if err := json.Unmarshal([]byte(os.Getenv(varname)), &svc); err != nil {
+			return map[string]string{}, err
+		} else {
+			serviceList = append(serviceList, svc)
+		}
 	}
 
 	for _, service := range serviceList {

--- a/vendor/code.cloudfoundry.org/lager/json_redacter.go
+++ b/vendor/code.cloudfoundry.org/lager/json_redacter.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 )
 
-
 const awsAccessKeyIDPattern = `AKIA[A-Z0-9]{16}`
 const awsSecretAccessKeyPattern = `KEY["']?\s*(?::|=>|=)\s*["']?[A-Z0-9/\+=]{40}["']?`
 const cryptMD5Pattern = `\$1\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{22}`
@@ -14,26 +13,26 @@ const cryptSHA512Pattern = `\$6\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{86}`
 const privateKeyHeaderPattern = `-----BEGIN(.*)PRIVATE KEY-----`
 
 type JSONRedacter struct {
-	keyMatchers []*regexp.Regexp
+	keyMatchers   []*regexp.Regexp
 	valueMatchers []*regexp.Regexp
 }
 
 func NewJSONRedacter(keyPatterns []string, valuePatterns []string) (*JSONRedacter, error) {
 	if keyPatterns == nil {
-		keyPatterns = []string{"[Pp]wd","[Pp]ass"}
+		keyPatterns = []string{"[Pp]wd", "[Pp]ass"}
 	}
 	if valuePatterns == nil {
 		valuePatterns = []string{awsAccessKeyIDPattern, awsSecretAccessKeyPattern, cryptMD5Pattern, cryptSHA256Pattern, cryptSHA512Pattern, privateKeyHeaderPattern}
 	}
 	ret := &JSONRedacter{}
-	for _ ,v := range keyPatterns {
+	for _, v := range keyPatterns {
 		r, err := regexp.Compile(v)
 		if err != nil {
 			return nil, err
 		}
 		ret.keyMatchers = append(ret.keyMatchers, r)
 	}
-	for _ ,v := range valuePatterns {
+	for _, v := range valuePatterns {
 		r, err := regexp.Compile(v)
 		if err != nil {
 			return nil, err
@@ -99,7 +98,7 @@ func (r JSONRedacter) redactObject(data *map[string]interface{}) {
 	}
 }
 
-func handleError (err error) []byte {
+func handleError(err error) []byte {
 	var content []byte
 	if _, ok := err.(*json.UnsupportedTypeError); ok {
 		data := map[string]interface{}{"lager serialisation error": err.Error()}

--- a/vendor/code.cloudfoundry.org/lager/json_redacter_test.go
+++ b/vendor/code.cloudfoundry.org/lager/json_redacter_test.go
@@ -1,6 +1,5 @@
 package lager_test
 
-
 import (
 	"code.cloudfoundry.org/lager"
 
@@ -10,9 +9,9 @@ import (
 
 var _ = Describe("JSON Redacter", func() {
 	var (
-	  resp []byte
-	  err error
-	  jsonRedacter *lager.JSONRedacter
+		resp         []byte
+		err          error
+		jsonRedacter *lager.JSONRedacter
 	)
 
 	BeforeEach(func() {
@@ -21,10 +20,10 @@ var _ = Describe("JSON Redacter", func() {
 	})
 
 	Context("when called with normal (non-secret) json", func() {
-		BeforeEach(func(){
+		BeforeEach(func() {
 			resp = jsonRedacter.Redact([]byte(`{"foo":"bar"}`))
 		})
-		It("should return the same text", func(){
+		It("should return the same text", func() {
 			Expect(resp).To(Equal([]byte(`{"foo":"bar"}`)))
 		})
 	})

--- a/vendor/code.cloudfoundry.org/lager/redacting_writer_sink.go
+++ b/vendor/code.cloudfoundry.org/lager/redacting_writer_sink.go
@@ -6,9 +6,9 @@ import (
 )
 
 type redactingWriterSink struct {
-	writer      io.Writer
-	minLogLevel LogLevel
-	writeL      *sync.Mutex
+	writer       io.Writer
+	minLogLevel  LogLevel
+	writeL       *sync.Mutex
 	jsonRedacter *JSONRedacter
 }
 
@@ -18,9 +18,9 @@ func NewRedactingWriterSink(writer io.Writer, minLogLevel LogLevel, keyPatterns 
 		return nil, err
 	}
 	return &redactingWriterSink{
-		writer:      writer,
-		minLogLevel: minLogLevel,
-		writeL:      new(sync.Mutex),
+		writer:       writer,
+		minLogLevel:  minLogLevel,
+		writeL:       new(sync.Mutex),
 		jsonRedacter: jsonRedacter,
 	}, nil
 }
@@ -38,6 +38,3 @@ func (sink *redactingWriterSink) Log(log LogFormat) {
 	sink.writer.Write([]byte("\n"))
 	sink.writeL.Unlock()
 }
-
-
-

--- a/vendor/github.com/onsi/ginkgo/ginkgo/testrunner/test_runner.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/testrunner/test_runner.go
@@ -101,7 +101,7 @@ func (t *TestRunner) CompileTo(path string) error {
 	}
 
 	if fileExists(path) == false {
-		compiledFile := filepath.Join(t.Suite.Path, t.Suite. PackageName+".test")
+		compiledFile := filepath.Join(t.Suite.Path, t.Suite.PackageName+".test")
 		if fileExists(compiledFile) {
 			// seems like we are on an old go version that does not support the -o flag on go test
 			// move the compiled test file to the desired location by hand

--- a/vendor/github.com/onsi/ginkgo/integration/_fixtures/hanging_suite/hanging_suite_test.go
+++ b/vendor/github.com/onsi/ginkgo/integration/_fixtures/hanging_suite/hanging_suite_test.go
@@ -2,8 +2,8 @@ package hanging_suite_test
 
 import (
 	"fmt"
-	"time"
 	. "github.com/onsi/ginkgo"
+	"time"
 )
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Also added service/plan validation via a new lib.

Separating this info out per service will allow easier enable/disable/config of services especially for tile users, and reduces code complexity.