### PR TITLE
Remove wait for ssl certificate request to finish

### DIFF
--- a/brokerapi/brokers/account_managers/sql_account_manager.go
+++ b/brokerapi/brokers/account_managers/sql_account_manager.go
@@ -74,11 +74,6 @@ func (sam *SqlAccountManager) CreateAccountInGoogle(instanceID string, bindingID
 	if err != nil {
 		return models.ServiceBindingCredentials{}, fmt.Errorf("Error creating ssl certs: %s", err)
 	}
-	certInsertOperation := newCert.Operation
-	err = sam.pollOperationUntilDone(certInsertOperation, sam.ProjectId)
-	if err != nil {
-		return models.ServiceBindingCredentials{}, fmt.Errorf("Error encountered while polling until operation id %s completes: %s", op.Name, err)
-	}
 
 	creds := SqlAccountInfo{
 		Username:        username,

--- a/integration_tests/async_integration_test.go
+++ b/integration_tests/async_integration_test.go
@@ -201,10 +201,11 @@ var _ = Describe("AsyncIntegrationTests", func() {
 
 	Describe("Cloud SQL - PostgreSQL", func() {
 
+		var sqlService *googlecloudsql.Service
 		var dbService *googlecloudsql.InstancesService
 		var sslService *googlecloudsql.SslCertsService
 		BeforeEach(func() {
-			sqlService, err := googlecloudsql.New(gcpBroker.GCPClient)
+			sqlService, err = googlecloudsql.New(gcpBroker.GCPClient)
 			Expect(err).NotTo(HaveOccurred())
 			dbService = googlecloudsql.NewInstancesService(sqlService)
 			sslService = googlecloudsql.NewSslCertsService(sqlService)
@@ -246,7 +247,19 @@ var _ = Describe("AsyncIntegrationTests", func() {
 			Expect(credsMap["uri"]).To(ContainSubstring("postgres"))
 
 			// The bind oepration finishes before the instance has finished updating
-			time.Sleep(60 * time.Second)
+			keepWaiting := true
+			for keepWaiting == true {
+				resp, err := sqlService.Operations.List(gcpBroker.RootGCPCredentials.ProjectId, cloudsqlInstanceName).Do()
+				Expect(err).NotTo(HaveOccurred())
+				keepWaiting = false
+				for _, op := range resp.Items {
+					if op.EndTime == "" {
+						keepWaiting = true
+					}
+				}
+				// sleep for 1 second between polling so we don't hit our rate limit
+				time.Sleep(time.Second)
+			}
 
 			// unbind the instance
 			unBindDetails := models.UnbindDetails{

--- a/integration_tests/async_integration_test.go
+++ b/integration_tests/async_integration_test.go
@@ -245,6 +245,9 @@ var _ = Describe("AsyncIntegrationTests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(credsMap["uri"]).To(ContainSubstring("postgres"))
 
+			// The bind oepration finishes before the instance has finished updating
+			time.Sleep(60 * time.Second)
+
 			// unbind the instance
 			unBindDetails := models.UnbindDetails{
 				ServiceID: serviceNameToId[models.CloudsqlPostgresName],


### PR DESCRIPTION
Waiting for the ssl certificate request to complete makes the bind operation for mysql 2nd generation instances consistently take longer than 60 seconds, which is the default timeout. I'm removing the wait for now and adding a longer sleep to the integration tests so they will still pass.

The ssl certificates are returned before the bind operation finishes, but the instance needs to be updated to use them, which takes 40-60 seconds. The request will continue to run in the background.