### PR TITLE
Create service account for binds to cloud sql instances

### DIFF
--- a/brokerapi/brokers/account_managers/sql_account_manager.go
+++ b/brokerapi/brokers/account_managers/sql_account_manager.go
@@ -40,14 +40,14 @@ func (sam *SqlAccountManager) CreateAccountInGoogle(instanceID string, bindingID
 	var err error
 	username, usernameOk := details.Parameters["username"].(string)
 	password, passwordOk := details.Parameters["password"].(string)
-	credType, sslCertsOk := details.Parameters["credential_type"].(string)
+	generateCerts, sslCertsOk := details.Parameters["generate_ssl_certs"].(string)
 
 	if !passwordOk || !usernameOk {
 		return models.ServiceBindingCredentials{}, errors.New("Error binding, missing parameters. Required parameters are username and password")
 	}
 
 	if !sslCertsOk {
-		credType = "service_account"
+		generateCerts = "false"
 	}
 
 	// create username, pw with grants
@@ -76,7 +76,7 @@ func (sam *SqlAccountManager) CreateAccountInGoogle(instanceID string, bindingID
 		Password:        password,
 	}
 
-	if credType == "ssl_certifcate" {
+	if generateCerts == "true" {
 		// create ssl certs
 		certname := bindingID[:10] + "cert"
 		newCert, err := sqlService.SslCerts.Insert(sam.ProjectId, instance.Name, &googlecloudsql.SslCertsInsertRequest{

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -166,12 +166,14 @@ func New(Logger lager.Logger) (*GCPAsyncServiceBroker, error) {
 			ProjectId:      self.RootGCPCredentials.ProjectId,
 			Logger:         self.Logger,
 			AccountManager: sqlManager,
+			SaAccountManager: saManager,
 		},
 		models.CloudsqlPostgresName: &cloudsql.CloudSQLBroker{
 			Client:         self.GCPClient,
 			ProjectId:      self.RootGCPCredentials.ProjectId,
 			Logger:         self.Logger,
 			AccountManager: sqlManager,
+			SaAccountManager: saManager,
 		},
 		models.BigtableName: &bigtable.BigTableBroker{
 			Client:    self.GCPClient,

--- a/docs/use.md
+++ b/docs/use.md
@@ -89,8 +89,10 @@ Notes:
         * `replication_type` (defaults to `synchronous`)
         * `auto_resize` (2nd gen only, defaults to `false`, set to "true" to use)
     * Bind
+        * `role` without "roles/" prefix (see https://cloud.google.com/iam/docs/understanding-roles for available roles)
         * `username` (defaults to a generated value)
         * `password` (defaults to a generated value)
+        * `generate_ssl_certs` (defaults to false)
 
         **Example Binding credentials**
 

--- a/integration_tests/async_integration_test.go
+++ b/integration_tests/async_integration_test.go
@@ -153,8 +153,11 @@ var _ = Describe("AsyncIntegrationTests", func() {
 			bindDetails := models.BindDetails{
 				ServiceID: serviceNameToId[models.CloudsqlMySQLName],
 				PlanID:    serviceNameToPlanId[models.CloudsqlMySQLName],
+				Parameters: map[string]interface{}{
+					"role": "editor",
+				},
 			}
-			creds, err := gcpBroker.Bind("integration_test_instance", "binding_id", bindDetails)
+			creds, err := gcpBroker.Bind("integration_test_instance", "bind-id", bindDetails)
 			Expect(err).NotTo(HaveOccurred())
 			credsMap := creds.Credentials.(map[string]string)
 			Expect(credsMap["uri"]).To(ContainSubstring("mysql"))
@@ -169,7 +172,7 @@ var _ = Describe("AsyncIntegrationTests", func() {
 				ServiceID: serviceNameToId[models.CloudsqlMySQLName],
 				PlanID:    serviceNameToPlanId[models.CloudsqlMySQLName],
 			}
-			err = gcpBroker.Unbind("integration_test_instance", "binding_id", unBindDetails)
+			err = gcpBroker.Unbind("integration_test_instance", "bind-id", unBindDetails)
 			Expect(err).NotTo(HaveOccurred())
 
 			// make sure google no longer has certs
@@ -234,8 +237,11 @@ var _ = Describe("AsyncIntegrationTests", func() {
 			bindDetails := models.BindDetails{
 				ServiceID: serviceNameToId[models.CloudsqlPostgresName],
 				PlanID:    serviceNameToPlanId[models.CloudsqlPostgresName],
+				Parameters: map[string]interface{}{
+					"role": "editor",
+				},
 			}
-			creds, err := gcpBroker.Bind("integration_test_instance", "binding_id", bindDetails)
+			creds, err := gcpBroker.Bind("integration_test_instance", "bind-id", bindDetails)
 			Expect(err).NotTo(HaveOccurred())
 			credsMap := creds.Credentials.(map[string]string)
 
@@ -251,7 +257,7 @@ var _ = Describe("AsyncIntegrationTests", func() {
 				PlanID:    serviceNameToPlanId[models.CloudsqlPostgresName],
 			}
 
-			err = gcpBroker.Unbind("integration_test_instance", "binding_id", unBindDetails)
+			err = gcpBroker.Unbind("integration_test_instance", "bind-id", unBindDetails)
 			Expect(err).NotTo(HaveOccurred())
 
 			// make sure google no longer has certs


### PR DESCRIPTION
For #135

Service accounts will be created when binding to a cloud sql instance. The fields necessary to use the proxying libraries will be returned. These fields are project id, region and private key data.

ssl certs will be generated optionally, based on the generate_ssl_certs parameter to bind.