### PR TITLE
Add authorized networks field to plan details for cloud sql

### DIFF
--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -145,17 +145,10 @@ func (b *CloudSQLBroker) Provision(instanceId string, details models.ProvisionDe
 		}
 	}
 
-	var authorizedNetworks []string
 	openAcls := []*googlecloudsql.AclEntry{}
 	aclsPlanDetails, aclsPlanDetailsOk := planDetails["authorized_networks"]
-	if !aclsPlanDetailsOk || aclsPlanDetails == "" {
-		openAcl := googlecloudsql.AclEntry{
-			Value: "0.0.0.0/0",
-		}
-		openAcls = append(openAcls, &openAcl)
-	} else if err = json.Unmarshal([]byte(aclsPlanDetails), &authorizedNetworks); err != nil {
-		return models.ServiceInstanceDetails{}, fmt.Errorf("%s is not a valid value for authorized_networks", aclsPlanDetails)
-	} else {
+	if aclsPlanDetailsOk && aclsPlanDetails != "" {
+		authorizedNetworks := strings.Split(aclsPlanDetails, ",")
 		for _, v := range authorizedNetworks {
 			openAcl := googlecloudsql.AclEntry{
 				Value: v,

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -97,8 +97,6 @@ func (b *CloudSQLBroker) Provision(instanceId string, details models.ProvisionDe
 		params["instance_name"] = name_generator.Sql.InstanceName()
 	}
 
-
-
 	instanceName := params["instance_name"]
 
 	// get plan parameters
@@ -106,7 +104,6 @@ func (b *CloudSQLBroker) Provision(instanceId string, details models.ProvisionDe
 	if err = json.Unmarshal([]byte(plan.Features), &planDetails); err != nil {
 		return models.ServiceInstanceDetails{}, fmt.Errorf("Error unmarshalling plan features: %s", err)
 	}
-
 
 	var binlogEnabled = false
 	isFirstGen := false
@@ -147,7 +144,10 @@ func (b *CloudSQLBroker) Provision(instanceId string, details models.ProvisionDe
 
 	openAcls := []*googlecloudsql.AclEntry{}
 	aclsPlanDetails, aclsPlanDetailsOk := planDetails["authorized_networks"]
-	if aclsPlanDetailsOk && aclsPlanDetails != "" {
+	if aclsPlanDetailsOk && aclsPlanDetails == "" {
+		return models.ServiceInstanceDetails{}, fmt.Errorf("authorized_networks is a required field")
+	}
+	if aclsPlanDetailsOk && aclsPlanDetails != "none" && aclsPlanDetails != "\"none\"" && aclsPlanDetails != "None" {
 		authorizedNetworks := strings.Split(aclsPlanDetails, ",")
 		for _, v := range authorizedNetworks {
 			openAcl := googlecloudsql.AclEntry{
@@ -692,10 +692,10 @@ type CloudSQLDynamicPlan struct {
 func MapPlan(details map[string]string) map[string]string {
 
 	features := map[string]string{
-		"tier":          details["tier"],
-		"authorized_networks":          details["authorized_networks"],
-		"max_disk_size": details["max_disk_size"],
-		"pricing_plan":  details["pricing_plan"],
+		"tier":                details["tier"],
+		"authorized_networks": details["authorized_networks"],
+		"max_disk_size":       details["max_disk_size"],
+		"pricing_plan":        details["pricing_plan"],
 	}
 	return features
 }

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -97,6 +97,8 @@ func (b *CloudSQLBroker) Provision(instanceId string, details models.ProvisionDe
 		params["instance_name"] = name_generator.Sql.InstanceName()
 	}
 
+
+
 	instanceName := params["instance_name"]
 
 	// get plan parameters
@@ -104,6 +106,7 @@ func (b *CloudSQLBroker) Provision(instanceId string, details models.ProvisionDe
 	if err = json.Unmarshal([]byte(plan.Features), &planDetails); err != nil {
 		return models.ServiceInstanceDetails{}, fmt.Errorf("Error unmarshalling plan features: %s", err)
 	}
+
 
 	var binlogEnabled = false
 	isFirstGen := false
@@ -142,8 +145,23 @@ func (b *CloudSQLBroker) Provision(instanceId string, details models.ProvisionDe
 		}
 	}
 
-	openAcl := googlecloudsql.AclEntry{
-		Value: "0.0.0.0/0",
+	var authorizedNetworks []string
+	openAcls := []*googlecloudsql.AclEntry{}
+	aclsPlanDetails, aclsPlanDetailsOk := planDetails["authorized_networks"]
+	if !aclsPlanDetailsOk || aclsPlanDetails == "" {
+		openAcl := googlecloudsql.AclEntry{
+			Value: "0.0.0.0/0",
+		}
+		openAcls = append(openAcls, &openAcl)
+	} else if err = json.Unmarshal([]byte(aclsPlanDetails), &authorizedNetworks); err != nil {
+		return models.ServiceInstanceDetails{}, fmt.Errorf("%s is not a valid value for authorized_networks", aclsPlanDetails)
+	} else {
+		for _, v := range authorizedNetworks {
+			openAcl := googlecloudsql.AclEntry{
+				Value: v,
+			}
+			openAcls = append(openAcls, &openAcl)
+		}
 	}
 
 	backupsEnabled := true
@@ -172,7 +190,7 @@ func (b *CloudSQLBroker) Provision(instanceId string, details models.ProvisionDe
 		StartTime:        backupStartTime,
 		BinaryLogEnabled: binlogEnabled,
 	}
-	di.Settings.IpConfiguration.AuthorizedNetworks = []*googlecloudsql.AclEntry{&openAcl}
+	di.Settings.IpConfiguration.AuthorizedNetworks = openAcls
 
 	// init sqladmin service
 	sqlService, err := googlecloudsql.New(b.Client)
@@ -682,6 +700,7 @@ func MapPlan(details map[string]string) map[string]string {
 
 	features := map[string]string{
 		"tier":          details["tier"],
+		"authorized_networks":          details["authorized_networks"],
 		"max_disk_size": details["max_disk_size"],
 		"pricing_plan":  details["pricing_plan"],
 	}

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -12,38 +12,38 @@ Optionally add these to the env section of `manifest.yml`
 
 ## [Optional plan vars](#optional-plan)
 
-* `CLOUDSQL_MYSQL_CUSTOM_PLANS` (A map of plan names to string maps with fields `guid`, `name`, `description`, `authorized_networks`, 
-`tier`, `pricing_plan`, `max_disk_size`, `display_name`, and `service` (CloudSQL MySQL's service id)) - if unset, the service
-will be disabled. e.g.,
+* `CLOUDSQL_MYSQL_CUSTOM_PLANS` (A map of plan names to string maps with fields `guid`, `name`, `description`
+`tier`, `pricing_plan`, `max_disk_size`, `authorized_networks`, `display_name`, and `service` 
+(CloudSQL MySQL's service id)) - if unset, the service will be disabled. e.g.,
 
 ```json
 {
     "test_plan": {
         "name": "test_plan",
         "description": "testplan",
-	"authorized_networks": "[\"0.0.0.0/0\"]",
         "tier": "D8",
         "pricing_plan": "PER_USE",
         "max_disk_size": "15",
+	"authorized_networks": "0.0.0.0/0",
         "display_name": "FOOBAR",
         "service": "4bc59b9a-8520-409f-85da-1c7552315863"
     }
 }
 ```
 
-* `CLOUDSQL_POSTGRES_CUSTOM_PLANS` (A map of plan names to string maps with fields `guid`, `name`, `description`, `authorized_networks`, 
-`tier`, `pricing_plan`, `max_disk_size`, `display_name`, and `service` (CloudSQL PostgreSQL's service id)) - if unset, the service
-will be disabled. e.g.,
+* `CLOUDSQL_POSTGRES_CUSTOM_PLANS` (A map of plan names to string maps with fields `guid`, `name`, `description`,
+`tier`, `pricing_plan`, `max_disk_size`, `authorized_networks`, `display_name`, and `service` 
+(CloudSQL PostgreSQL's service id)) - if unset, the service will be disabled. e.g.,
 
 ```json
 {
     "test_plan": {
         "name": "test_plan",
         "description": "testplan",
-	"authorized_networks": "[\"0.0.0.0/0\"]",
         "tier": "custom-db-4-4096",
         "pricing_plan": "PER_USE",
         "max_disk_size": "15",
+	"authorized_networks": "0.0.0.0/0",
         "display_name": "FOOBAR",
         "service": "cbad6d78-a73c-432d-b8ff-b219a17a803a"
     }

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -12,8 +12,8 @@ Optionally add these to the env section of `manifest.yml`
 
 ## [Optional plan vars](#optional-plan)
 
-* `CLOUDSQL_MYSQL_CUSTOM_PLANS` (A map of plan names to string maps with fields `guid`, `name`, `description`, `tier`,
-`pricing_plan`, `max_disk_size`, `display_name`, and `service` (CloudSQL MySQL's service id)) - if unset, the service
+* `CLOUDSQL_MYSQL_CUSTOM_PLANS` (A map of plan names to string maps with fields `guid`, `name`, `description`, `authorized_networks`, 
+`tier`, `pricing_plan`, `max_disk_size`, `display_name`, and `service` (CloudSQL MySQL's service id)) - if unset, the service
 will be disabled. e.g.,
 
 ```json
@@ -21,6 +21,7 @@ will be disabled. e.g.,
     "test_plan": {
         "name": "test_plan",
         "description": "testplan",
+	"authorized_networks": "[\"0.0.0.0/0\"]",
         "tier": "D8",
         "pricing_plan": "PER_USE",
         "max_disk_size": "15",
@@ -30,8 +31,8 @@ will be disabled. e.g.,
 }
 ```
 
-* `CLOUDSQL_POSTGRES_CUSTOM_PLANS` (A map of plan names to string maps with fields `guid`, `name`, `description`, `tier`,
-`pricing_plan`, `max_disk_size`, `display_name`, and `service` (CloudSQL PostgreSQL's service id)) - if unset, the service
+* `CLOUDSQL_POSTGRES_CUSTOM_PLANS` (A map of plan names to string maps with fields `guid`, `name`, `description`, `authorized_networks`, 
+`tier`, `pricing_plan`, `max_disk_size`, `display_name`, and `service` (CloudSQL PostgreSQL's service id)) - if unset, the service
 will be disabled. e.g.,
 
 ```json
@@ -39,6 +40,7 @@ will be disabled. e.g.,
     "test_plan": {
         "name": "test_plan",
         "description": "testplan",
+	"authorized_networks": "[\"0.0.0.0/0\"]",
         "tier": "custom-db-4-4096",
         "pricing_plan": "PER_USE",
         "max_disk_size": "15",

--- a/fakes/fake_env_vars.go
+++ b/fakes/fake_env_vars.go
@@ -241,6 +241,7 @@ const TestCloudSQLMySQLPlan = `{
 				"tier": "D4",
 				"pricing_plan": "PER_USE",
 				"max_disk_size": "20",
+				"authorized_networks": "0.0.0.0/0",
 				"display_name": "test_cloudsql_mysql_plan",
 				"service": "4bc59b9a-8520-409f-85da-1c7552315863"
 			}
@@ -253,6 +254,7 @@ const TestCloudSQLPostgresPlan = `{
 				"tier": "db-custom-2-4096",
 				"pricing_plan": "PER_USE",
 				"max_disk_size": "20",
+				"authorized_networks": "0.0.0.0/0",
 				"display_name": "test_cloudsql_postgres_plan",
 				"service": "cbad6d78-a73c-432d-b8ff-b219a17a803a"
 			}

--- a/tile.yml
+++ b/tile.yml
@@ -351,9 +351,8 @@ service_plan_forms:
     - name: authorized_networks
       label: Authorized Networks
       type: string
-      description: "Comma separated list without spaces of authorized networks, defaults to none"
+      description: "Comma separated list without spaces of authorized networks, or \"none\""
       configurable: true
-      optional: true
 - name: cloudsql_postgres_custom_plans
   description: Generate custom plans for CloudSQL PostgreSQL (required to enable the service for developers)
   label: CloudSQL PostgreSQL Custom Plans
@@ -399,9 +398,8 @@ service_plan_forms:
     - name: authorized_networks
       label: Authorized Networks
       type: string
-      description: "Comma separated list without spaces of authorized networks, defaults to none"
+      description: "Comma separated list without spaces of authorized networks, or \"none\""
       configurable: true
-      optional: true
 - name: bigtable_custom_plans
   description: Generate custom plans for Bigtable (required to enable the service for developers)
   label: Bigtable Custom Plans

--- a/tile.yml
+++ b/tile.yml
@@ -348,6 +348,12 @@ service_plan_forms:
       default: '10'
       description: "Maximum disk size in GB (applicable only to Second Generation instances, 10 minimum/default)"
       configurable: true
+    - name: authorized_networks
+      label: Authorized Networks
+      type: string
+      description: "Comma separated list without spaces of authorized networks, defaults to none"
+      configurable: true
+      optional: true
 - name: cloudsql_postgres_custom_plans
   description: Generate custom plans for CloudSQL PostgreSQL (required to enable the service for developers)
   label: CloudSQL PostgreSQL Custom Plans
@@ -390,6 +396,12 @@ service_plan_forms:
       default: '10'
       description: "Maximum disk size in GB (10 minimum/default)"
       configurable: true
+    - name: authorized_networks
+      label: Authorized Networks
+      type: string
+      description: "Comma separated list without spaces of authorized networks, defaults to none"
+      configurable: true
+      optional: true
 - name: bigtable_custom_plans
   description: Generate custom plans for Bigtable (required to enable the service for developers)
   label: Bigtable Custom Plans


### PR DESCRIPTION
For #172

`authorized_networks` is a comma separated list of authorized networks. If no networks are desired, the field should be set to "none".

The field is required in the tile, so if people are updating the service broker, they will be required to fill in a value for this in their plans. I don't believe previously created instances will be updated to respect this new field.