### PR TITLE
Update postgres uri to enable using spring cloud connectors

### DIFF
--- a/brokerapi/brokers/account_managers/sql_account_manager.go
+++ b/brokerapi/brokers/account_managers/sql_account_manager.go
@@ -198,8 +198,8 @@ func (b *SqlAccountManager) BuildInstanceCredentials(bindRecord models.ServiceBi
 		combinedCreds["uri"] = fmt.Sprintf("mysql://%s:%s@%s/%s?ssl_mode=required",
 			url.QueryEscape(combinedCreds["Username"]), url.QueryEscape(combinedCreds["Password"]), combinedCreds["host"], combinedCreds["database_name"])
 	} else if service_to_name[sid] == models.CloudsqlPostgresName {
-		combinedCreds["uri"] = fmt.Sprintf("postgres://%s/%s?user=%s&password=%s&ssl=true",
-			combinedCreds["host"], combinedCreds["database_name"], url.QueryEscape(combinedCreds["Username"]), url.QueryEscape(combinedCreds["Password"]))
+		combinedCreds["uri"] = fmt.Sprintf("jdbc:postgres://%s:%s@%s/%s?sslmode=require&sslcert=%s&sslkey=%s&sslrootcert=%s",
+			url.QueryEscape(combinedCreds["Username"]), url.QueryEscape(combinedCreds["Password"]), combinedCreds["host"], combinedCreds["database_name"], url.QueryEscape(combinedCreds["ClientCert"]), url.QueryEscape(combinedCreds["ClientKey"]), url.QueryEscape(combinedCreds["CaCert"]))
 	} else {
 		return map[string]string{}, errors.New("Unknown service")
 	}

--- a/brokerapi/brokers/account_managers/sql_account_manager.go
+++ b/brokerapi/brokers/account_managers/sql_account_manager.go
@@ -195,11 +195,11 @@ func (b *SqlAccountManager) BuildInstanceCredentials(bindRecord models.ServiceBi
 	combinedCreds := utils.MergeStringMaps(bindDetails, instanceDetails)
 
 	if service_to_name[sid] == models.CloudsqlMySQLName {
-		combinedCreds["uri"] = fmt.Sprintf("mysql://%s:%s@%s/%s?ssl_mode=required",
-			url.QueryEscape(combinedCreds["Username"]), url.QueryEscape(combinedCreds["Password"]), combinedCreds["host"], combinedCreds["database_name"])
+		combinedCreds["uri"] = fmt.Sprintf("%smysql://%s:%s@%s/%s?ssl_mode=required",
+			combinedCreds["UriPrefix"], url.QueryEscape(combinedCreds["Username"]), url.QueryEscape(combinedCreds["Password"]), combinedCreds["host"], combinedCreds["database_name"])
 	} else if service_to_name[sid] == models.CloudsqlPostgresName {
-		combinedCreds["uri"] = fmt.Sprintf("jdbc:postgres://%s:%s@%s/%s?sslmode=require&sslcert=%s&sslkey=%s&sslrootcert=%s",
-			url.QueryEscape(combinedCreds["Username"]), url.QueryEscape(combinedCreds["Password"]), combinedCreds["host"], combinedCreds["database_name"], url.QueryEscape(combinedCreds["ClientCert"]), url.QueryEscape(combinedCreds["ClientKey"]), url.QueryEscape(combinedCreds["CaCert"]))
+		combinedCreds["uri"] = fmt.Sprintf("%spostgres://%s:%s@%s/%s?sslmode=require&sslcert=%s&sslkey=%s&sslrootcert=%s",
+			combinedCreds["UriPrefix"], url.QueryEscape(combinedCreds["Username"]), url.QueryEscape(combinedCreds["Password"]), combinedCreds["host"], combinedCreds["database_name"], url.QueryEscape(combinedCreds["ClientCert"]), url.QueryEscape(combinedCreds["ClientKey"]), url.QueryEscape(combinedCreds["CaCert"]))
 	} else {
 		return map[string]string{}, errors.New("Unknown service")
 	}

--- a/docs/use.md
+++ b/docs/use.md
@@ -93,6 +93,7 @@ Notes:
         * `role` without "roles/" prefix (see https://cloud.google.com/iam/docs/understanding-roles for available roles)
         * `username` (defaults to a generated value)
         * `password` (defaults to a generated value)
+	* `jdbc_uri_format` (if `true`, `uri` field will contain a jdbc formatted uri, defaults to false)
 
         **Example Binding credentials**
 

--- a/examples/go/sb-test/README.md
+++ b/examples/go/sb-test/README.md
@@ -37,7 +37,8 @@ This is not an official Google product.
 
 * `/test-storage` - lists all buckets in the given project
 * `/test-pubsub` - returns the name of the first topic in the project
-* `/test-cloudsql` - tests the connection to the first bound database
+* `/test-cloudsql-mysql` - tests the connection to the first bound mysql database
+* `/test-cloudsql-postgres` - tests the connection to the first bound postgres database
 * `/test-bigquery` - lists all the bigquery datasets in the project
 * `/test-bigtable` - lists all the bigtable instances in the project
 * `/test-spanner` - lists all the spanner instances in the project


### PR DESCRIPTION
Adding certs to the connection uri that is returned in VCAP_SERVICES to applications on bind, and updated go test app to use the uri for connections instead of building it's own uri.

Spring cloud connectors would only connect if I added the `jdbc` in front of the url. 