### PR TITLE
Use New Registry

### DIFF
--- a/brokerapi/brokers/account_managers/sql_account_manager.go
+++ b/brokerapi/brokers/account_managers/sql_account_manager.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"golang.org/x/oauth2/jwt"
 	googlecloudsql "google.golang.org/api/sqladmin/v1beta4"
@@ -178,10 +179,7 @@ func (b *SqlAccountManager) BuildInstanceCredentials(bindRecord models.ServiceBi
 	instanceDetails := instanceRecord.GetOtherDetails()
 	bindDetails := bindRecord.GetOtherDetails()
 
-	service_to_name, err := utils.MapServiceIdToName()
-	if err != nil {
-		return map[string]string{}, err
-	}
+	service_to_name := broker.MapServiceIdToName()
 
 	sid := instanceRecord.ServiceId
 

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -28,11 +28,11 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/name_generator"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 
 	"context"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"golang.org/x/oauth2/jwt"
 	googlecloudsql "google.golang.org/api/sqladmin/v1beta4"
 )
@@ -86,10 +86,7 @@ func (b *CloudSQLBroker) Provision(instanceId string, details models.ProvisionDe
 	var params map[string]string
 	var err error
 
-	idToNameMap, err := utils.MapServiceIdToName()
-	if err != nil {
-		return models.ServiceInstanceDetails{}, err
-	}
+	idToNameMap := broker.MapServiceIdToName()
 
 	// validate parameters
 

--- a/brokerapi/brokers/config/broker_config.go
+++ b/brokerapi/brokers/config/broker_config.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
-	"github.com/spf13/viper"
 	"golang.org/x/oauth2/jwt"
-	"gopkg.in/validator.v2"
 )
 
 type BrokerConfig struct {
@@ -48,11 +47,7 @@ func NewBrokerConfigFromEnv() (*BrokerConfig, error) {
 		return &BrokerConfig{}, err
 	}
 	bc.HttpConfig = conf
-	cat, err := bc.InitCatalogFromEnv()
-	if err != nil {
-		return &BrokerConfig{}, err
-	}
-	bc.Catalog = cat
+	bc.Catalog = bc.InitCatalogFromEnv()
 	return &bc, nil
 }
 
@@ -72,24 +67,12 @@ func (bc *BrokerConfig) GetCredentialsFromEnv() (models.GCPCredentials, error) {
 }
 
 // pulls SERVICES, PLANS, and environment variables to construct catalog
-func (bc *BrokerConfig) InitCatalogFromEnv() (map[string]models.Service, error) {
-
-	// set up services
+func (bc *BrokerConfig) InitCatalogFromEnv() map[string]models.Service {
 	serviceMap := make(map[string]models.Service)
 
-	for _, varname := range models.ServiceNameList {
-		var svc models.Service
-		if err := json.Unmarshal([]byte(viper.GetString("service."+varname+".definition")), &svc); err != nil {
-			return map[string]models.Service{}, fmt.Errorf("Error getting catalog info for %q: %v (var is %q)", varname, err, viper.GetString(varname))
-		} else {
-			if errs := validator.Validate(svc); errs != nil {
-				return map[string]models.Service{}, errs
-			} else {
-				serviceMap[svc.ID] = svc
-			}
-		}
-
+	for _, service := range broker.GetEnabledServices() {
+		serviceMap[service.CatalogEntry().ID] = service.CatalogEntry()
 	}
 
-	return serviceMap, nil
+	return serviceMap
 }

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -20,7 +20,6 @@ package models
 import (
 	"encoding/json"
 	"errors"
-	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -178,30 +177,8 @@ const StackdriverDebuggerName = "google-stackdriver-debugger"
 const DatastoreName = "google-datastore"
 const rootSaEnvVar = "ROOT_SERVICE_ACCOUNT_JSON"
 
-var ServiceNameList = []string{
-	StorageName,
-	BigqueryName,
-	BigtableName,
-	CloudsqlMySQLName,
-	CloudsqlPostgresName,
-	PubsubName,
-	MlName,
-	SpannerName,
-	StackdriverTraceName,
-	StackdriverDebuggerName,
-	DatastoreName,
-}
-
 func init() {
 	viper.BindEnv("google.account", rootSaEnvVar)
-
-	// Bind a name of a service like google-datastore to an environment variable
-	// GOOGLE_DATASTORE and a property service.google-datastore
-	replacer := strings.NewReplacer("-", "_")
-	for _, service := range ServiceNameList {
-		env := replacer.Replace(strings.ToUpper(service))
-		viper.BindEnv("service."+service+".definition", env)
-	}
 }
 
 func GetServiceAccountJson() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Configuration file to be read")
 	viper.SetEnvPrefix("gsb")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv()
 }
 

--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/jinzhu/gorm"
 	googlecloudsql "google.golang.org/api/sqladmin/v1beta4"
@@ -136,10 +137,7 @@ func RunMigrations(db *gorm.DB) error {
 			return fmt.Errorf("Error getting authorized http client: %s", err)
 		}
 
-		idToNameMap, err := utils.MapServiceIdToName()
-		if err != nil {
-			return err
-		}
+		idToNameMap := broker.MapServiceIdToName()
 
 		var prs []models.ProvisionRequestDetails
 		if err := DbConnection.Find(&prs).Error; err != nil {

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -15,8 +15,8 @@ Optionally add these to the env section of `manifest.yml`
 update the following variables in `manifest.yml` if you wish to enable these services
 
 * `GOOGLE_CLOUDSQL_MYSQL.plans` (A list of json objects with fields `id`, `name`, `description`, `
-service_properties` (containing `tier`, `pricing_plan`, `max_disk_size`), `display_name`, and `service_id` 
-(Cloud SQL's service id)) - if unset, the service will be disabled. 
+service_properties` (containing `tier`, `pricing_plan`, `max_disk_size`), `display_name`, and `service_id`
+(Cloud SQL's service id)) - if unset, the service will be disabled.
 
 e.g.,
 
@@ -58,8 +58,8 @@ will be disabled. e.g.,
 
 
 * `GOOGLE_BIGTABLE.plans` (A list of json objects with fields `id`, `name`, `description`,
-`service_properties` (containing `storage_type`, `num_nodes`), `display_name`, and `service_id` (Bigtable's service id)) 
-- if unset, the service will be disabled. 
+`service_properties` (containing `storage_type`, `num_nodes`), `display_name`, and `service_id` (Bigtable's service id))
+- if unset, the service will be disabled.
 
 e.g.,
 
@@ -78,8 +78,8 @@ e.g.,
     }
 ]
 ```
-* `GOOGLE_SPANNER.plans` (A list of json objects with fields `id`, `name`, `description`, `service_properties` (containing 
-`num_nodes`), `display_name`, and `service_id` (Spanner's service id)) - if unset, the service will be disabled. 
+* `GOOGLE_SPANNER.plans` (A list of json objects with fields `id`, `name`, `description`, `service_properties` (containing
+`num_nodes`), `display_name`, and `service_id` (Spanner's service id)) - if unset, the service will be disabled.
 
 e.g.,
 
@@ -97,3 +97,19 @@ e.g.,
     }
 ]
 ```
+
+## [Disabling Services Vars](#disable-service)
+
+You can disable services by setting their associated enabled flag to be `false`:
+
+* `GSB_SERVICE_GOOGLE_BIGQUERY_ENABLED`
+* `GSB_SERVICE_GOOGLE_BIGTABLE_ENABLED`
+* `GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_ENABLED`
+* `GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_ENABLED`
+* `GSB_SERVICE_GOOGLE_DATASTORE_ENABLED`
+* `GSB_SERVICE_GOOGLE_ML_APIS_ENABLED`
+* `GSB_SERVICE_GOOGLE_PUBSUB_ENABLED`
+* `GSB_SERVICE_GOOGLE_SPANNER_ENABLED`
+* `GSB_SERVICE_GOOGLE_STACKDRIVER_DEBUGGER_ENABLED`
+* `GSB_SERVICE_GOOGLE_STACKDRIVER_TRACE_ENABLED`
+* `GSB_SERVICE_GOOGLE_STORAGE_ENABLED`

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -66,6 +66,16 @@ func GetAllServices() []*BrokerService {
 	return out
 }
 
+func MapServiceIdToName() map[string]string {
+	out := map[string]string{}
+
+	for _, svc := range brokerRegistry {
+		out[svc.CatalogEntry().ID] = svc.Name
+	}
+
+	return out
+}
+
 type BrokerService struct {
 	Name                     string
 	DefaultServiceDefinition string

--- a/tile.yml
+++ b/tile.yml
@@ -71,7 +71,120 @@ forms:
     type: text
     label: Client key
     optional: true
-
+- name: enable_disable
+  label: Enable Services
+  description: Enable or Disable Services
+  properties:
+    - name: gsb_service_google_bigquery_enabled
+      label: Let end-users create plans for google_bigquery
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_bigtable_enabled
+      label: Let end-users create plans for google_bigtable
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_cloudsql_mysql_enabled
+      label: Let end-users create plans for google_cloudsql_mysql
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_cloudsql_postgres_enabled
+      label: Let end-users create plans for google_cloudsql_postgres
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_datastore_enabled
+      label: Let end-users create plans for google_datastore
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_ml_apis_enabled
+      label: Let end-users create plans for google_ml_apis
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_pubsub_enabled
+      label: Let end-users create plans for google_pubsub
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_spanner_enabled
+      label: Let end-users create plans for google_spanner
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_stackdriver_debugger_enabled
+      label: Let end-users create plans for google_stackdriver_debugger
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_stackdriver_trace_enabled
+      label: Let end-users create plans for google_stackdriver_trace
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
+    - name: gsb_service_google_storage_enabled
+      label: Let end-users create plans for google_storage
+      type: dropdown_select
+      configurable: true
+      default: 'true'
+      options:
+        - name: 'true'
+          label: 'Enable'
+        - name: 'false'
+          label: 'Disable'
 
 service_plan_forms:
 - name: cloudsql_mysql_custom_plans

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,30 +17,12 @@
 package utils
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
-	"github.com/spf13/viper"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 )
-
-func MapServiceIdToName() (map[string]string, error) {
-	idToNameMap := make(map[string]string)
-
-	for _, varname := range models.ServiceNameList {
-
-		var svc models.Service
-		if err := json.Unmarshal([]byte(viper.GetString("service."+varname+".definition")), &svc); err != nil {
-			return map[string]string{}, fmt.Errorf("Error getting catalog info for %q: %v (var is %q)", varname, err, viper.GetString(varname))
-		} else {
-			idToNameMap[svc.ID] = svc.Name
-		}
-	}
-
-	return idToNameMap, nil
-}
 
 func GetAuthedConfig() (*jwt.Config, error) {
 	rootCreds := models.GetServiceAccountJson()


### PR DESCRIPTION
Make the broker reference services from the new registry.

Now custom configuration is pulled in exactly ONE place. This allows #51 to be fixed as a side-effect because now a user can set the following properties to disable services:

```
service:
  google-cloudsql-mysql:
    enabled: false
  google-cloudsql-postgres:
    enabled: false
```

and/or the following environment variables:

```
GSB_SERVICE_GOOGLE_PUBSUB_ENABLED=false
```

...or through the new tile form.