### PR TITLE
add custom plan parsing

### DIFF
--- a/brokerapi/brokers/account_managers/sql_account_manager.go
+++ b/brokerapi/brokers/account_managers/sql_account_manager.go
@@ -186,16 +186,17 @@ func (b *SqlAccountManager) BuildInstanceCredentials(bindRecord models.ServiceBi
 	instanceDetails := instanceRecord.GetOtherDetails()
 	bindDetails := bindRecord.GetOtherDetails()
 
-	service_to_name := broker.MapServiceIdToName()
-
-	sid := instanceRecord.ServiceId
+	service, err := broker.GetServiceById(instanceRecord.ServiceId)
+	if err != nil {
+		return nil, err
+	}
 
 	combinedCreds := utils.MergeStringMaps(bindDetails, instanceDetails)
 
-	if service_to_name[sid] == models.CloudsqlMySQLName {
+	if service.Name == models.CloudsqlMySQLName {
 		combinedCreds["uri"] = fmt.Sprintf("%smysql://%s:%s@%s/%s?ssl_mode=required",
 			combinedCreds["UriPrefix"], url.QueryEscape(combinedCreds["Username"]), url.QueryEscape(combinedCreds["Password"]), combinedCreds["host"], combinedCreds["database_name"])
-	} else if service_to_name[sid] == models.CloudsqlPostgresName {
+	} else if service.Name == models.CloudsqlPostgresName {
 		combinedCreds["uri"] = fmt.Sprintf("%spostgres://%s:%s@%s/%s?sslmode=require&sslcert=%s&sslkey=%s&sslrootcert=%s",
 			combinedCreds["UriPrefix"], url.QueryEscape(combinedCreds["Username"]), url.QueryEscape(combinedCreds["Password"]), combinedCreds["host"], combinedCreds["database_name"], url.QueryEscape(combinedCreds["ClientCert"]), url.QueryEscape(combinedCreds["ClientKey"]), url.QueryEscape(combinedCreds["CaCert"]))
 	} else {

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -87,8 +87,6 @@ func (b *CloudSQLBroker) Provision(instanceId string, details brokerapi.Provisio
 	var params map[string]string
 	var err error
 
-	idToNameMap := broker.MapServiceIdToName()
-
 	// validate parameters
 
 	if len(details.RawParameters) == 0 {
@@ -114,9 +112,14 @@ func (b *CloudSQLBroker) Provision(instanceId string, details brokerapi.Provisio
 
 	var binlogEnabled = false
 
+	svc, err := broker.GetServiceById(details.ServiceID)
+	if err != nil {
+		return models.ServiceInstanceDetails{}, err
+	}
+
 	_, versionOk := params["version"]
 	// set default parameters or cast strings to proper values
-	if idToNameMap[details.ServiceID] == models.CloudsqlPostgresName {
+	if svc.Name == models.CloudsqlPostgresName {
 		if !versionOk {
 			params["version"] = PostgresDefaultVersion
 		}

--- a/brokerapi/brokers/config/broker_config.go
+++ b/brokerapi/brokers/config/broker_config.go
@@ -47,7 +47,11 @@ func NewBrokerConfigFromEnv() (*BrokerConfig, error) {
 		return &BrokerConfig{}, err
 	}
 	bc.HttpConfig = conf
-	bc.Catalog = bc.InitCatalogFromEnv()
+	bc.Catalog, err = bc.InitCatalogFromEnv()
+	if err != nil {
+		return &BrokerConfig{}, err
+	}
+
 	return &bc, nil
 }
 
@@ -67,12 +71,16 @@ func (bc *BrokerConfig) GetCredentialsFromEnv() (models.GCPCredentials, error) {
 }
 
 // pulls SERVICES, PLANS, and environment variables to construct catalog
-func (bc *BrokerConfig) InitCatalogFromEnv() map[string]models.Service {
+func (bc *BrokerConfig) InitCatalogFromEnv() (map[string]models.Service, error) {
 	serviceMap := make(map[string]models.Service)
 
 	for _, service := range broker.GetEnabledServices() {
-		serviceMap[service.CatalogEntry().ID] = service.CatalogEntry()
+		entry, err := service.CatalogEntry()
+		if err != nil {
+			return serviceMap, err
+		}
+		serviceMap[entry.ID] = *entry
 	}
 
-	return serviceMap
+	return serviceMap, nil
 }

--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -137,8 +137,6 @@ func RunMigrations(db *gorm.DB) error {
 			return fmt.Errorf("Error getting authorized http client: %s", err)
 		}
 
-		idToNameMap := broker.MapServiceIdToName()
-
 		var prs []models.ProvisionRequestDetails
 		if err := DbConnection.Find(&prs).Error; err != nil {
 			return err
@@ -156,7 +154,12 @@ func RunMigrations(db *gorm.DB) error {
 			newOd := make(map[string]string)
 
 			// cloudsql
-			switch serviceName := idToNameMap[si.ServiceId]; serviceName {
+			svc, err := broker.GetServiceById(si.ServiceId)
+			if err != nil {
+				return err
+			}
+
+			switch svc.Name {
 			case models.CloudsqlMySQLName:
 				newOd["instance_name"] = od["instance_name"]
 				newOd["database_name"] = od["database_name"]
@@ -187,7 +190,6 @@ func RunMigrations(db *gorm.DB) error {
 				newOd["topic_name"] = od["topic_name"]
 				newOd["subscription_name"] = od["subscription_name"]
 			default:
-				println(fmt.Sprintf("%v", idToNameMap))
 				return fmt.Errorf("unrecognized service: %s", si.ServiceId)
 			}
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -16,6 +16,7 @@ package broker
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/spf13/viper"
 )
@@ -63,4 +64,177 @@ func ExampleBrokerService_IsEnabled() {
 
 	// Output: true
 	// false
+}
+
+func ExampleBrokerService_ServiceDefinition() {
+	service := BrokerService{
+		Name: "left-handed-smoke-sifter",
+		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl"}`,
+	}
+
+	// Default definition
+	defn, err := service.ServiceDefinition()
+	fmt.Printf("%q %v\n", defn.ID, err)
+
+	// Override
+	viper.Set(service.DefinitionProperty(), `{"id":"override-id"}`)
+	defn, err = service.ServiceDefinition()
+	fmt.Printf("%q %v\n", defn.ID, err)
+
+	// Bad Value
+	viper.Set(service.DefinitionProperty(), "nil")
+	_, err = service.ServiceDefinition()
+	fmt.Printf("%v\n", err == nil)
+
+	// Cleanup
+	viper.Set(service.DefinitionProperty(), nil)
+
+	// Output: "abcd-efgh-ijkl" <nil>
+	// "override-id" <nil>
+	// false
+}
+
+func ExampleBrokerService_GetPlanById() {
+	service := BrokerService{
+		Name: "left-handed-smoke-sifter",
+		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl", "plans": [{"id": "builtin-plan", "name": "Builtin!"}]}`,
+	}
+
+	viper.Set(service.UserDefinedPlansProperty(), `[{"id":"custom-plan", "name": "Custom!"}]`)
+	defer viper.Set(service.UserDefinedPlansProperty(), nil)
+
+	plan, err := service.GetPlanById("builtin-plan")
+	fmt.Printf("%q %v\n", plan.Name, err)
+
+	plan, err = service.GetPlanById("custom-plan")
+	fmt.Printf("%q %v\n", plan.Name, err)
+
+	_, err = service.GetPlanById("missing-plan")
+	fmt.Printf("%s\n", err)
+
+	// Output: "Builtin!" <nil>
+	// "Custom!" <nil>
+	// Plan ID "missing-plan" could not be found
+}
+
+func TestBrokerService_UserDefinedPlans(t *testing.T) {
+	cases := map[string]struct {
+		Value       interface{}
+		PlanCount   int
+		ExpectError bool
+	}{
+		"default-no-plans": {
+			Value:       nil,
+			PlanCount:   0,
+			ExpectError: false,
+		},
+		"single-plan": {
+			Value:       `[{"id":"aaa"}]`,
+			PlanCount:   1,
+			ExpectError: false,
+		},
+		"bad-json": {
+			Value:       `42`,
+			PlanCount:   0,
+			ExpectError: true,
+		},
+		"multiple-plans": {
+			Value:       `[{"id":"aaa"},{"id":"bbb"}]`,
+			PlanCount:   2,
+			ExpectError: false,
+		},
+	}
+
+	service := BrokerService{
+		Name: "left-handed-smoke-sifter",
+		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl"}`,
+	}
+
+	for tn, tc := range cases {
+		viper.Set(service.UserDefinedPlansProperty(), tc.Value)
+		plans, err := service.UserDefinedPlans()
+
+		// Check errors
+		hasErr := err != nil
+		if hasErr != tc.ExpectError {
+			t.Errorf("%s) Expected Error? %v, got error: %v", tn, tc.ExpectError, err)
+		}
+
+		// Check IDs
+		if len(plans) != tc.PlanCount {
+			t.Errorf("%s) Expected %d plans, but got %d (%v)", tn, tc.PlanCount, len(plans), plans)
+		}
+
+		// Reset Environment
+		viper.Set(service.UserDefinedPlansProperty(), nil)
+	}
+}
+
+func TestBrokerService_CatalogEntry(t *testing.T) {
+	cases := map[string]struct {
+		UserDefinition interface{}
+		UserPlans      interface{}
+		PlanCount      int
+		ExpectError    bool
+	}{
+		"no-customization": {
+			UserDefinition: nil,
+			UserPlans:      nil,
+			PlanCount:      0,
+			ExpectError:    false,
+		},
+		"custom-definition": {
+			UserDefinition: `{"id":"abcd-efgh-ijkl", "plans":[{"id":"zzz"}]}`,
+			UserPlans:      nil,
+			PlanCount:      1,
+			ExpectError:    false,
+		},
+		"custom-plans": {
+			UserDefinition: nil,
+			UserPlans:      `[{"id":"aaa"},{"id":"bbb"}]`,
+			PlanCount:      2,
+			ExpectError:    false,
+		},
+		"custom-plans-and-definition": {
+			UserDefinition: `{"id":"abcd-efgh-ijkl", "plans":[{"id":"zzz"}]}`,
+			UserPlans:      `[{"id":"aaa"},{"id":"bbb"}]`,
+			PlanCount:      3,
+			ExpectError:    false,
+		},
+		"bad-definition-json": {
+			UserDefinition: `333`,
+			UserPlans:      nil,
+			PlanCount:      0,
+			ExpectError:    true,
+		},
+		"bad-plan-json": {
+			UserDefinition: nil,
+			UserPlans:      `333`,
+			PlanCount:      0,
+			ExpectError:    true,
+		},
+	}
+
+	service := BrokerService{
+		Name: "left-handed-smoke-sifter",
+		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl"}`,
+	}
+
+	for tn, tc := range cases {
+		viper.Set(service.DefinitionProperty(), tc.UserDefinition)
+		viper.Set(service.UserDefinedPlansProperty(), tc.UserPlans)
+
+		srvc, err := service.CatalogEntry()
+		hasErr := err != nil
+		if hasErr != tc.ExpectError {
+			t.Errorf("%s) Expected Error? %v, got error: %v", tn, tc.ExpectError, err)
+		}
+
+		if err == nil && len(srvc.Plans) != tc.PlanCount {
+			t.Errorf("%s) Expected %d plans, but got %d (%+v)", tn, tc.PlanCount, len(srvc.Plans), srvc.Plans)
+		}
+	}
+
+	viper.Set(service.DefinitionProperty(), nil)
+	viper.Set(service.UserDefinedPlansProperty(), nil)
 }

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -36,11 +36,20 @@ func Register(service *BrokerService) {
 		log.Fatalf("Tried to register multiple instances of: %q", name)
 	}
 
-	brokerRegistry[name] = service
+	// Set up environment variables to be compatible with legacy tile.yml configurations.
+	// Bind a name of a service like google-datastore to an environment variable GOOGLE_DATASTORE
+	env := utils.PropertyToEnvUnprefixed(service.Name)
+	viper.BindEnv(service.DefinitionProperty(), env)
 
-	if err := service.init(); err != nil {
+	// set defaults
+	viper.SetDefault(service.EnabledProperty(), true)
+
+	// Test deserializing the user defined plans and service definition
+	if _, err := service.CatalogEntry(); err != nil {
 		log.Fatalf("Error registering service %q, %s", name, err)
 	}
+
+	brokerRegistry[name] = service
 }
 
 // GetEnabledServices returns a list of all registered brokers that the user
@@ -77,7 +86,9 @@ func MapServiceIdToName() map[string]string {
 	out := map[string]string{}
 
 	for _, svc := range brokerRegistry {
-		out[svc.CatalogEntry().ID] = svc.Name
+		if entry, err := svc.CatalogEntry(); err == nil {
+			out[entry.ID] = svc.Name
+		}
 	}
 
 	return out
@@ -90,38 +101,6 @@ type BrokerService struct {
 	BindInputVariables       []BrokerVariable
 	BindOutputVariables      []BrokerVariable
 	Examples                 []ServiceExample
-
-	// Not modifiable.
-	serviceDefinition models.Service
-	userDefinedPlans  []models.ServicePlan
-}
-
-func (svc *BrokerService) init() error {
-
-	definitionProperty := svc.DefinitionProperty()
-
-	// Set up environment variables to be compatible with legacy tile.yml configurations.
-	// Bind a name of a service like google-datastore to an environment variable GOOGLE_DATASTORE
-	env := utils.PropertyToEnvUnprefixed(svc.Name)
-	viper.BindEnv(definitionProperty, env)
-
-	// set defaults
-	viper.SetDefault(definitionProperty, svc.DefaultServiceDefinition)
-	viper.SetDefault(svc.EnabledProperty(), true)
-	viper.SetDefault(svc.UserDefinedPlansProperty(), "[]")
-
-	// Parse the service definition from the properties
-	rawDefinition := []byte(viper.GetString(definitionProperty))
-
-	var defn models.Service
-	if err := json.Unmarshal(rawDefinition, &defn); err != nil {
-		return err
-	}
-	svc.serviceDefinition = defn
-
-	// TODO Parse any user-defined plans and include them
-
-	return nil
 }
 
 // EnabledProperty computes the Viper property name for the boolean the user
@@ -151,17 +130,61 @@ func (svc *BrokerService) IsEnabled() bool {
 // CatalogEntry returns the service broker catalog entry for this service, it
 // has metadata about the service so operators and programmers know which
 // service and plan will work best for their purposes.
-func (svc *BrokerService) CatalogEntry() models.Service {
-	return svc.serviceDefinition
+func (svc *BrokerService) CatalogEntry() (*models.Service, error) {
+	sd, err := svc.ServiceDefinition()
+	if err != nil {
+		return nil, err
+	}
+
+	plans, err := svc.UserDefinedPlans()
+	if err != nil {
+		return nil, err
+	}
+
+	sd.Plans = append(sd.Plans, plans...)
+
+	return sd, nil
 }
 
 // GetPlanById finds a plan in this service by its UUID.
-func (svc *BrokerService) GetPlanById(planId string) *models.ServicePlan {
-	for _, plan := range svc.CatalogEntry().Plans {
+func (svc *BrokerService) GetPlanById(planId string) (*models.ServicePlan, error) {
+	catalogEntry, err := svc.CatalogEntry()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, plan := range catalogEntry.Plans {
 		if plan.ID == planId {
-			return &plan
+			return &plan, nil
 		}
 	}
 
-	return nil
+	return nil, fmt.Errorf("Plan ID %q could not be found", planId)
+}
+
+// UserDefinedPlans extracts user defined plans from the environment, failing if
+// the plans were not valid JSON.
+func (svc *BrokerService) UserDefinedPlans() ([]models.ServicePlan, error) {
+	plans := []models.ServicePlan{}
+
+	userPlanJson := viper.GetString(svc.UserDefinedPlansProperty())
+	if userPlanJson == "" {
+		return plans, nil
+	}
+
+	err := json.Unmarshal([]byte(userPlanJson), &plans)
+	return plans, err
+}
+
+// ServiceDefinition extracts service definition from the environment, failing
+// if the definition was not valid JSON.
+func (svc *BrokerService) ServiceDefinition() (*models.Service, error) {
+	jsonDefinition := viper.GetString(svc.DefinitionProperty())
+	if jsonDefinition == "" {
+		jsonDefinition = svc.DefaultServiceDefinition
+	}
+
+	var defn models.Service
+	err := json.Unmarshal([]byte(jsonDefinition), &defn)
+	return &defn, err
 }

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -165,11 +165,16 @@ func newExampleExecutor(client *Client, example broker.ServiceExample, service *
 		return nil, err
 	}
 
+	catalog, err := service.CatalogEntry()
+	if err != nil {
+		return nil, err
+	}
+
 	testid := rand.Uint32()
 
 	return &exampleExecutor{
 		Name:       fmt.Sprintf("%s/%s", service.Name, example.Name),
-		ServiceId:  service.CatalogEntry().ID,
+		ServiceId:  catalog.ID,
 		PlanId:     example.PlanId,
 		InstanceId: fmt.Sprintf("ex%d", testid),
 		BindingId:  fmt.Sprintf("ex%d", testid),

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -16,6 +16,7 @@ package generator
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
@@ -75,9 +76,14 @@ func GenerateForms() TileFormsSections {
 func GenerateEnableDisableForm() Form {
 	enablers := []FormProperty{}
 	for _, svc := range broker.GetAllServices() {
+		entry, err := svc.CatalogEntry()
+		if err != nil {
+			log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
+		}
+
 		enableForm := FormProperty{
 			Name:         strings.ToLower(utils.PropertyToEnv(svc.EnabledProperty())),
-			Label:        fmt.Sprintf("Let the broker create and bind %s instances", svc.CatalogEntry().Metadata.DisplayName),
+			Label:        fmt.Sprintf("Let the broker create and bind %s instances", entry.Metadata.DisplayName),
 			Type:         "boolean",
 			Default:      true,
 			Configurable: true,

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -27,7 +27,10 @@ func CatalogDocumentation() string {
 
 // generateServiceDocumentation creates documentation for a single catalog entry
 func generateServiceDocumentation(svc *broker.BrokerService) string {
-	catalog := svc.CatalogEntry()
+	catalog, err := svc.CatalogEntry()
+	if err != nil {
+		log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
+	}
 
 	vars := map[string]interface{}{
 		"catalog":            catalog,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -98,6 +98,7 @@ func PropertyToEnv(propertyName string) string {
 // environment variable using PropertyToEnvReplacer
 func PropertyToEnvUnprefixed(propertyName string) string {
 	return PropertyToEnvReplacer.Replace(strings.ToUpper(propertyName))
+}
 
 // SetParameter sets a value on a JSON raw message and returns a modified
 // version with the value set


### PR DESCRIPTION
Helps fix #157, #155 

We can now read plans from the environment/viper variable for a given broker and parse append them to the main catalog's plans. Plus, tests for the above.

This leads us down the path toward fixing #231 