### PR TITLE
fix custom plan handling

### DIFF
--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -208,9 +208,10 @@ func RunMigrations(db *gorm.DB) error {
 
 	// drops plan details table
 	migrations[2] = func() error {
-		if err := db.Exec(`DROP TABLE plan_details`).Error; err != nil {
-			return err
-		}
+		// NOOP migration, this was used to drop the plan_details table, but
+		// there's more of a disincentive than incentive to do that because it could
+		// leave operators wiping out plain details accidentally and not being able
+		// to recover if they don't follow the upgrade path.
 		return nil
 	}
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -139,7 +139,7 @@ func TestBrokerService_UserDefinedPlans(t *testing.T) {
 			ExpectError: false,
 		},
 		"single-plan": {
-			Value:       `[{"id":"aaa"}]`,
+			Value:       `[{"id":"aaa","name":"aaa","instances":"3"}]`,
 			PlanIds:     map[string]bool{"aaa": true},
 			ExpectError: false,
 		},
@@ -149,15 +149,37 @@ func TestBrokerService_UserDefinedPlans(t *testing.T) {
 			ExpectError: true,
 		},
 		"multiple-plans": {
-			Value:       `[{"id":"aaa"},{"id":"bbb"}]`,
+			Value:       `[{"id":"aaa","name":"aaa","instances":"3"},{"id":"bbb","name":"bbb","instances":"3"}]`,
 			PlanIds:     map[string]bool{"aaa": true, "bbb": true},
 			ExpectError: false,
+		},
+		"missing-name": {
+			Value:       `[{"id":"aaa","instances":"3"}]`,
+			PlanIds:     map[string]bool{},
+			ExpectError: true,
+		},
+		"missing-id": {
+			Value:       `[{"name":"aaa","instances":"3"}]`,
+			PlanIds:     map[string]bool{},
+			ExpectError: true,
+		},
+		"missing-instances": {
+			Value:       `[{"name":"aaa","id":"aaa"}]`,
+			PlanIds:     map[string]bool{},
+			ExpectError: true,
 		},
 	}
 
 	service := BrokerService{
 		Name: "left-handed-smoke-sifter",
-		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl"}`,
+		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl", "name":"lhss"}`,
+		PlanVariables: []BrokerVariable{
+			BrokerVariable{
+				Required:  true,
+				FieldName: "instances",
+				Type:      JsonTypeString,
+			},
+		},
 	}
 
 	for tn, tc := range cases {
@@ -168,6 +190,7 @@ func TestBrokerService_UserDefinedPlans(t *testing.T) {
 		hasErr := err != nil
 		if hasErr != tc.ExpectError {
 			t.Errorf("%s) Expected Error? %v, got error: %v", tn, tc.ExpectError, err)
+			continue
 		}
 
 		// Check IDs
@@ -200,20 +223,20 @@ func TestBrokerService_CatalogEntry(t *testing.T) {
 			ExpectError:    false,
 		},
 		"custom-definition": {
-			UserDefinition: `{"id":"abcd-efgh-ijkl", "plans":[{"id":"zzz"}]}`,
+			UserDefinition: `{"id":"abcd-efgh-ijkl", "plans":[{"id":"zzz","name":"zzz"}]}`,
 			UserPlans:      nil,
 			PlanIds:        map[string]bool{"zzz": true},
 			ExpectError:    false,
 		},
 		"custom-plans": {
 			UserDefinition: nil,
-			UserPlans:      `[{"id":"aaa"},{"id":"bbb"}]`,
+			UserPlans:      `[{"id":"aaa","name":"aaa"},{"id":"bbb","name":"bbb"}]`,
 			PlanIds:        map[string]bool{"aaa": true, "bbb": true},
 			ExpectError:    false,
 		},
 		"custom-plans-and-definition": {
-			UserDefinition: `{"id":"abcd-efgh-ijkl", "plans":[{"id":"zzz"}]}`,
-			UserPlans:      `[{"id":"aaa"},{"id":"bbb"}]`,
+			UserDefinition: `{"id":"abcd-efgh-ijkl", "plans":[{"id":"zzz","name":"zzz"}]}`,
+			UserPlans:      `[{"id":"aaa","name":"aaa"},{"id":"bbb","name":"bbb"}]`,
 			PlanIds:        map[string]bool{"aaa": true, "bbb": true, "zzz": true},
 			ExpectError:    false,
 		},

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -116,3 +116,39 @@ func SetParameter(input json.RawMessage, key string, value interface{}) (json.Ra
 
 	return json.Marshal(params)
 }
+
+// UnmarshalObjectRemaidner unmarshals an object into v and returns the
+// remaining key/value pairs as a JSON string by doing a set difference.
+func UnmarshalObjectRemainder(data []byte, v interface{}) ([]byte, error) {
+	if err := json.Unmarshal(data, v); err != nil {
+		return nil, err
+	}
+
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonDiff(data, encoded)
+}
+
+func jsonDiff(superset, subset json.RawMessage) ([]byte, error) {
+	usedKeys := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(subset, &usedKeys); err != nil {
+		return nil, err
+	}
+
+	allKeys := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(superset, &allKeys); err != nil {
+		return nil, err
+	}
+
+	remainder := make(map[string]json.RawMessage)
+	for key, value := range allKeys {
+		if _, ok := usedKeys[key]; !ok {
+			remainder[key] = value
+		}
+	}
+
+	return json.Marshal(remainder)
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -14,7 +14,9 @@
 
 package utils
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func ExamplePropertyToEnv() {
 	env := PropertyToEnv("my.property.key-value")
@@ -41,4 +43,20 @@ func ExampleSetParameter() {
 
 	// Output: {"foo":42}, <nil>
 	// {"replace":"new"}, <nil>
+}
+
+func ExampleUnmarshalObjectRemainder() {
+	var obj struct {
+		A string `json:"a_str"`
+		B int
+	}
+
+	remainder, err := UnmarshalObjectRemainder([]byte(`{"a_str":"hello", "B": 33, "C": 123}`), &obj)
+	fmt.Printf("%s, %v\n", string(remainder), err)
+
+	remainder, err = UnmarshalObjectRemainder([]byte(`{"a_str":"hello", "B": 33}`), &obj)
+	fmt.Printf("%s, %v\n", string(remainder), err)
+
+	// Output: {"C":123}, <nil>
+	// {}, <nil>
 }


### PR DESCRIPTION
This re-implements code that was earlier deleted as part of #155.

The code was originally removed because there were plans to refactor the way operators would enter plans.
More code was removed as part of #167 and #164 which obscured that this wasn't fully completed until later in this development cycle.

The end result being:

- Operators can continue to use the same user-defined plans they were before 4.0
- Plans are now roughly checked for validity
- We have tests for the plans
- We don't delete the table of stored plans which operators might be relying on (if they tried to upgrade in place, all their database plans would have been lost) so they can use the export command even after an upgrade to get themselves back into a valid state

Fixes #147 along the way