### PR TITLE
Standardize copyright headers

### DIFF
--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package account_managers
 

--- a/brokerapi/brokers/account_managers/sql_account_manager.go
+++ b/brokerapi/brokers/account_managers/sql_account_manager.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package account_managers
 

--- a/brokerapi/brokers/api_service/broker.go
+++ b/brokerapi/brokers/api_service/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package api_service
 

--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/bigquery/broker.go
+++ b/brokerapi/brokers/bigquery/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package bigquery
 

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/bigtable/broker.go
+++ b/brokerapi/brokers/bigtable/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package bigtable
 

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/broker_base/broker_base.go
+++ b/brokerapi/brokers/broker_base/broker_base.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package broker_base
 

--- a/brokerapi/brokers/brokers_suite_test.go
+++ b/brokerapi/brokers/brokers_suite_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package brokers_test
 
 import (

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package brokers_test
 
 import (

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package cloudsql
 

--- a/brokerapi/brokers/cloudsql/common-definition.go
+++ b/brokerapi/brokers/cloudsql/common-definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/config/broker_config.go
+++ b/brokerapi/brokers/config/broker_config.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package config
 

--- a/brokerapi/brokers/datastore/broker.go
+++ b/brokerapi/brokers/datastore/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package datastore
 

--- a/brokerapi/brokers/datastore/definition.go
+++ b/brokerapi/brokers/datastore/definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package brokers
 

--- a/brokerapi/brokers/models/catalog.go
+++ b/brokerapi/brokers/models/catalog.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/models/db.go
+++ b/brokerapi/brokers/models/db.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,17 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package models
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
-	"time"
 )
 
 type ServiceBindingCredentials struct {

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/name_generator/name_generator.go
+++ b/brokerapi/brokers/name_generator/name_generator.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package name_generator
 
 import (

--- a/brokerapi/brokers/name_generator/name_generator_suite_test.go
+++ b/brokerapi/brokers/name_generator/name_generator_suite_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package name_generator_test
 
 import (

--- a/brokerapi/brokers/name_generator/name_generator_test.go
+++ b/brokerapi/brokers/name_generator/name_generator_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package name_generator_test
 
 import (

--- a/brokerapi/brokers/pubsub/broker.go
+++ b/brokerapi/brokers/pubsub/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package pubsub
 

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/spanner/broker.go
+++ b/brokerapi/brokers/spanner/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package spanner
 

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/stackdriver_debugger/broker.go
+++ b/brokerapi/brokers/stackdriver_debugger/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package stackdriver_debugger
 

--- a/brokerapi/brokers/stackdriver_debugger/definition.go
+++ b/brokerapi/brokers/stackdriver_debugger/definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/stackdriver_trace/broker.go
+++ b/brokerapi/brokers/stackdriver_trace/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package stackdriver_trace
 

--- a/brokerapi/brokers/stackdriver_trace/definition.go
+++ b/brokerapi/brokers/stackdriver_trace/definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/brokerapi/brokers/storage/broker.go
+++ b/brokerapi/brokers/storage/broker.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package storage
 

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/get_plan_info.go
+++ b/cmd/get_plan_info.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package cmd
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package cmd
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package cmd
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package cmd
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/db_service/db_service.go
+++ b/db_service/db_service.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package db_service
 

--- a/db_service/db_service_suite_test.go
+++ b/db_service/db_service_suite_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db_service
 
 import (
@@ -11,4 +25,3 @@ func TestDbService(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "DbService Suite")
 }
-

--- a/db_service/db_service_test.go
+++ b/db_service/db_service_test.go
@@ -1,15 +1,30 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db_service
 
 import (
-	"code.cloudfoundry.org/lager"
 	"database/sql"
 	"fmt"
+	"os"
+
+	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/fakes"
 	"github.com/jinzhu/gorm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"os"
 )
 
 func getLocalTestConnectionStr(dbName string) string {

--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package db_service
 

--- a/db_service/setup_db.go
+++ b/db_service/setup_db.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package db_service
 

--- a/fakes/fake_env_vars.go
+++ b/fakes/fake_env_vars.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fakes
 
 import "os"

--- a/fakes/fake_name_generator.go
+++ b/fakes/fake_name_generator.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fakes
 
 type StaticNameGenerator struct {

--- a/integration_tests/async_integration_test.go
+++ b/integration_tests/async_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package integration_tests
 

--- a/integration_tests/integration_suite_test.go
+++ b/integration_tests/integration_suite_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package integration_tests
 
 import (

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package integration_tests
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-//
 
 package main
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/broker/example.go
+++ b/pkg/broker/example.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/broker/variables.go
+++ b/pkg/broker/variables.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/client/broker-response.go
+++ b/pkg/client/broker-response.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (

--- a/pkg/generator/customization-md.go
+++ b/pkg/generator/customization-md.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -1,4 +1,4 @@
-// Copyright the Service Broker Project Authors.
+// Copyright 2018 the Service Broker Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -1,3 +1,17 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package generator
 
 import (

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,18 +1,16 @@
-/**
-# Copyright 2016 Google Inc. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-**/
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package utils
 


### PR DESCRIPTION
Standardize the copyright headers to all have the year and the same style. Fixes #229 