### PR TITLE
made JSON keys explicit for credentials

### DIFF
--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -186,13 +186,13 @@ func ServiceAccountName(bindingId string) string {
 
 type ServiceAccountInfo struct {
 	// the bits to save
-	Name      string
-	Email     string
-	UniqueId  string
-	ProjectId string
+	Name      string `json:"Name"`
+	Email     string `json:"Email"`
+	UniqueId  string `json:"UniqueId"`
+	ProjectId string `json:"ProjectId"`
 
 	// the bit to return
-	PrivateKeyData string
+	PrivateKeyData string `json:"PrivateKeyData"`
 }
 
 func ServiceAccountBindInputVariables() []broker.BrokerVariable {

--- a/brokerapi/brokers/account_managers/sql_account_manager.go
+++ b/brokerapi/brokers/account_managers/sql_account_manager.go
@@ -205,12 +205,12 @@ func (b *SqlAccountManager) BuildInstanceCredentials(bindRecord models.ServiceBi
 
 type SqlAccountInfo struct {
 	// the bits to return
-	Username   string
-	Password   string
-	CaCert     string
-	ClientCert string
-	ClientKey  string
+	Username   string `json:"Username"`
+	Password   string `json:"Password"`
+	CaCert     string `json:"CaCert"`
+	ClientCert string `json:"ClientCert"`
+	ClientKey  string `json:"ClientKey"`
 
 	// the bits to save
-	Sha1Fingerprint string
+	Sha1Fingerprint string `json:"Sha1Fingerprint"`
 }


### PR DESCRIPTION
Fixes #72 these have been updated to be consistently incorrect with their convention so they don't accidentally change in the future.

The existing e2e tests will validate that the keys are correct so no new testing is needed.