### PR TITLE
IAM Whitelist

### DIFF
--- a/brokerapi/brokers/account_managers/iam.go
+++ b/brokerapi/brokers/account_managers/iam.go
@@ -1,0 +1,52 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account_managers
+
+import (
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+)
+
+// Merge multiple Bindings such that Bindings with the same Role result in
+// a single Binding with combined Members
+func mergeBindings(bindings []*cloudresourcemanager.Binding) []*cloudresourcemanager.Binding {
+	rb := []*cloudresourcemanager.Binding{}
+
+	for role, members := range rolesToMembersMap(bindings) {
+		if members.IsEmpty() {
+			continue
+		}
+
+		rb = append(rb, &cloudresourcemanager.Binding{
+			Role:    role,
+			Members: members.ToSlice(),
+		})
+	}
+
+	return rb
+}
+
+// Map a role to a map of members, allowing easy merging of multiple bindings.
+func rolesToMembersMap(bindings []*cloudresourcemanager.Binding) map[string]StringSet {
+	bm := make(map[string]StringSet)
+	for _, b := range bindings {
+		if set, ok := bm[b.Role]; ok {
+			set.Add(b.Members...)
+		} else {
+			bm[b.Role] = NewStringSet(b.Members...)
+		}
+	}
+
+	return bm
+}

--- a/brokerapi/brokers/account_managers/iam_test.go
+++ b/brokerapi/brokers/account_managers/iam_test.go
@@ -1,0 +1,80 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account_managers
+
+import (
+	"testing"
+
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func TestIamMergeBindings(t *testing.T) {
+	table := map[string]struct {
+		input  []*cloudresourcemanager.Binding
+		expect map[string][]string
+	}{
+		"combine matching roles": {
+			input: []*cloudresourcemanager.Binding{
+				{Role: "role-1", Members: []string{"m1"}},
+				{Role: "role-1", Members: []string{"m2"}},
+			},
+			expect: map[string][]string{
+				"role-1": []string{"m1", "m2"},
+			},
+		},
+		"deduplicates members": {
+			input: []*cloudresourcemanager.Binding{
+				{Role: "role-1", Members: []string{"m1"}},
+				{Role: "role-1", Members: []string{"m1"}},
+			},
+			expect: map[string][]string{
+				"role-1": []string{"m1"},
+			},
+		},
+		"removes roles with no members": {
+			input: []*cloudresourcemanager.Binding{
+				{Role: "role-1", Members: []string{}},
+			},
+			expect: map[string][]string{},
+		},
+		"does not merge different roles": {
+			input: []*cloudresourcemanager.Binding{
+				{Role: "role-1", Members: []string{"m1", "m2"}},
+				{Role: "role-2", Members: []string{"m1", "m3"}},
+			},
+			expect: map[string][]string{
+				"role-1": []string{"m1", "m2"},
+				"role-2": []string{"m1", "m3"},
+			},
+		},
+	}
+
+	for tn, tc := range table {
+		merged := mergeBindings(tc.input)
+
+		if len(merged) != len(tc.expect) {
+			t.Errorf("%s) expected %d merged bindings, got: %d", tn, len(tc.expect), len(merged))
+		}
+
+		for _, binding := range merged {
+			expset := NewStringSet(tc.expect[binding.Role]...)
+			gotset := NewStringSet(binding.Members...)
+
+			if !expset.Equals(gotset) {
+				t.Errorf("%s) expected %v members in %s role, got %v", tn, expset.ToSlice(), binding.Role, gotset.ToSlice())
+			}
+		}
+	}
+}

--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -42,10 +42,20 @@ type ServiceAccountManager struct {
 
 // If roleWhitelist is specified, then the extracted role is validated against it and an error is returned if
 // the role is not contained within the whitelist
-func (sam *ServiceAccountManager) CreateCredentials(bindingID string, details brokerapi.BindDetails, roleWhitelist []string) (models.ServiceBindingCredentials, error) {
+func (sam *ServiceAccountManager) CreateCredentials(instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
 	role, err := sam.ExtractRole(details)
 	if err != nil {
 		return models.ServiceBindingCredentials{}, err
+	}
+
+	bkr, err := broker.GetServiceById(details.ServiceID)
+	if err != nil {
+		return models.ServiceBindingCredentials{}, err
+	}
+
+	roleWhitelist := []string{}
+	if bkr.IsRoleWhitelistEnabled() {
+		roleWhitelist = bkr.ServiceAccountRoleWhitelist
 	}
 
 	if !whitelistAllows(roleWhitelist, role) {

--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -43,7 +43,7 @@ type ServiceAccountManager struct {
 // If roleWhitelist is specified, then the extracted role is validated against it and an error is returned if
 // the role is not contained within the whitelist
 func (sam *ServiceAccountManager) CreateCredentials(instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
-	role, err := sam.ExtractRole(details)
+	role, err := extractRole(details)
 	if err != nil {
 		return models.ServiceBindingCredentials{}, err
 	}
@@ -65,7 +65,7 @@ func (sam *ServiceAccountManager) CreateCredentials(instanceID string, bindingID
 	return sam.CreateAccountWithRoles(bindingID, []string{role})
 }
 
-func (sam *ServiceAccountManager) ExtractRole(details brokerapi.BindDetails) (string, error) {
+func extractRole(details brokerapi.BindDetails) (string, error) {
 	bindParameters := map[string]interface{}{}
 	if err := json.Unmarshal(details.RawParameters, &bindParameters); err != nil {
 		return "", err
@@ -296,12 +296,16 @@ func ServiceAccountBindOutputVariables() []broker.BrokerVariable {
 	}
 }
 
-func whitelistAllows(whitelist []string, needle string) bool {
+func whitelistAllows(whitelist []string, role string) bool {
+	if len(whitelist) == 0 {
+		return true
+	}
+
 	for _, s := range whitelist {
-		if s == needle {
+		if s == role {
 			return true
 		}
 	}
 
-	return len(whitelist) > 0
+	return false
 }

--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -40,88 +40,56 @@ type ServiceAccountManager struct {
 	HttpConfig *jwt.Config
 }
 
-// creates a new service account for the given binding id with the role listed in details.Parameters["role"]
-func (sam *ServiceAccountManager) CreateCredentials(instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
-	client := sam.HttpConfig.Client(context.Background())
+// If roleWhitelist is specified, then the extracted role is validated against it and an error is returned if
+// the role is not contained within the whitelist
+func (sam *ServiceAccountManager) CreateCredentials(bindingID string, details brokerapi.BindDetails, roleWhitelist []string) (models.ServiceBindingCredentials, error) {
+	role, err := sam.ExtractRole(details)
+	if err != nil {
+		return models.ServiceBindingCredentials{}, err
+	}
 
+	if !whitelistAllows(roleWhitelist, role) {
+		return models.ServiceBindingCredentials{}, fmt.Errorf("The role %s is not allowed for this service. You must use one of %v.", role, roleWhitelist)
+	}
+
+	return sam.CreateAccountWithRoles(bindingID, []string{role})
+}
+
+func (sam *ServiceAccountManager) ExtractRole(details brokerapi.BindDetails) (string, error) {
 	bindParameters := map[string]interface{}{}
 	if err := json.Unmarshal(details.RawParameters, &bindParameters); err != nil {
-		return models.ServiceBindingCredentials{}, err
+		return "", err
 	}
 
 	role, ok := bindParameters["role"].(string)
 	if !ok {
-		return models.ServiceBindingCredentials{}, errors.New("Error getting role as string from request")
+		return "", errors.New("Error getting role as string from request")
 	}
 
-	someName := ServiceAccountName(bindingID)
-	var resourceName = projectResourcePrefix + sam.ProjectId
-	var err error
+	return role, nil
+}
 
-	iamService, err := iam.New(client)
-	if err != nil {
-		return models.ServiceBindingCredentials{}, fmt.Errorf("Error creating new iam service: %s", err)
-	}
-	saService := iam.NewProjectsServiceAccountsService(iamService)
-
+// CreateAccountWithRoles creates a service account with a name based on bindingID, JSON key and grants it zero or more roles
+// the roles MUST be missing the roles/ prefix.
+func (sam *ServiceAccountManager) CreateAccountWithRoles(bindingID string, roles []string) (models.ServiceBindingCredentials, error) {
 	// create and save account
-	newSARequest := iam.CreateServiceAccountRequest{
-		AccountId: someName,
-		ServiceAccount: &iam.ServiceAccount{
-			DisplayName: someName,
-		},
-	}
-
-	newSA, err := saService.Create(resourceName, &newSARequest).Do()
+	newSA, err := sam.createServiceAccount(bindingID)
 	if err != nil {
-		return models.ServiceBindingCredentials{}, fmt.Errorf("Error creating service account: %s", err)
+		return models.ServiceBindingCredentials{}, err
 	}
 
 	// adjust account permissions
 	// roles defined here: https://cloud.google.com/iam/docs/understanding-roles?hl=en_US#curated_roles
-	cloudresService, err := cloudres.New(client)
-	if err != nil {
-		return models.ServiceBindingCredentials{}, fmt.Errorf("Error creating new cloud resource management service: %s", err)
-	}
-
-	currPolicy, err := cloudresService.Projects.GetIamPolicy(sam.ProjectId, &cloudres.GetIamPolicyRequest{}).Do()
-	if err != nil {
-		return models.ServiceBindingCredentials{}, fmt.Errorf("Error getting current project iam policy: %s", err)
-	}
-
-	// seems not really necessary, but collapse the bindings into single role entries just in case.
-	var existingBinding *cloudres.Binding
-
-	for _, binding := range currPolicy.Bindings {
-		if binding.Role == roleResourcePrefix+role {
-			existingBinding = binding
+	for _, role := range roles {
+		if err := sam.grantRoleToAccount(role, newSA); err != nil {
+			return models.ServiceBindingCredentials{}, err
 		}
-	}
-
-	if existingBinding != nil {
-		existingBinding.Members = append(existingBinding.Members, saResourcePrefix+newSA.Email)
-	} else {
-		existingBinding = &cloudres.Binding{
-			Members: []string{saResourcePrefix + newSA.Email},
-			Role:    roleResourcePrefix + role,
-		}
-		b := append(currPolicy.Bindings, existingBinding)
-		currPolicy.Bindings = b
-	}
-
-	newPolicyRequest := cloudres.SetIamPolicyRequest{
-		Policy: currPolicy,
-	}
-	_, err = cloudresService.Projects.SetIamPolicy(sam.ProjectId, &newPolicyRequest).Do()
-	if err != nil {
-		return models.ServiceBindingCredentials{}, fmt.Errorf("ERROR assigning policy to service account: %s", err)
 	}
 
 	// create and save key
-	saKeyService := iam.NewProjectsServiceAccountsKeysService(iamService)
-	newSAKey, err := saKeyService.Create(newSA.Name, &iam.CreateServiceAccountKeyRequest{}).Do()
+	newSAKey, err := sam.createServiceAccountKey(newSA)
 	if err != nil {
-		return models.ServiceBindingCredentials{}, fmt.Errorf("ERROR creating new service account key: %s", err)
+		return models.ServiceBindingCredentials{}, fmt.Errorf("Error creating new service account key: %s", err)
 	}
 
 	newSAInfo := ServiceAccountInfo{
@@ -142,7 +110,6 @@ func (sam *ServiceAccountManager) CreateCredentials(instanceID string, bindingID
 	}
 
 	return newCreds, nil
-
 }
 
 // deletes the given service account from Google
@@ -184,6 +151,82 @@ func ServiceAccountName(bindingId string) string {
 	}
 }
 
+func (sam *ServiceAccountManager) createServiceAccount(bindingID string) (*iam.ServiceAccount, error) {
+	client := sam.HttpConfig.Client(context.Background())
+	iamService, err := iam.New(client)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating new IAM service: %s", err)
+	}
+
+	someName := ServiceAccountName(bindingID)
+	resourceName := projectResourcePrefix + sam.ProjectId
+
+	// create and save account
+	newSARequest := iam.CreateServiceAccountRequest{
+		AccountId: someName,
+		ServiceAccount: &iam.ServiceAccount{
+			DisplayName: someName,
+		},
+	}
+
+	return iam.NewProjectsServiceAccountsService(iamService).Create(resourceName, &newSARequest).Do()
+}
+
+func (sam *ServiceAccountManager) createServiceAccountKey(account *iam.ServiceAccount) (*iam.ServiceAccountKey, error) {
+	client := sam.HttpConfig.Client(context.Background())
+	iamService, err := iam.New(client)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating new IAM service: %s", err)
+	}
+
+	saKeyService := iam.NewProjectsServiceAccountsKeysService(iamService)
+	return saKeyService.Create(account.Name, &iam.CreateServiceAccountKeyRequest{}).Do()
+}
+
+func (sam *ServiceAccountManager) grantRoleToAccount(role string, account *iam.ServiceAccount) error {
+	client := sam.HttpConfig.Client(context.Background())
+
+	cloudresService, err := cloudres.New(client)
+	if err != nil {
+		return fmt.Errorf("Error creating new cloud resource management service: %s", err)
+	}
+
+	currPolicy, err := cloudresService.Projects.GetIamPolicy(sam.ProjectId, &cloudres.GetIamPolicyRequest{}).Do()
+	if err != nil {
+		return fmt.Errorf("Error getting current project iam policy: %s", err)
+	}
+
+	// seems not really necessary, but collapse the bindings into single role entries just in case.
+	var existingBinding *cloudres.Binding
+
+	for _, binding := range currPolicy.Bindings {
+		if binding.Role == roleResourcePrefix+role {
+			existingBinding = binding
+		}
+	}
+
+	if existingBinding != nil {
+		existingBinding.Members = append(existingBinding.Members, saResourcePrefix+account.Email)
+	} else {
+		existingBinding = &cloudres.Binding{
+			Members: []string{saResourcePrefix + account.Email},
+			Role:    roleResourcePrefix + role,
+		}
+		b := append(currPolicy.Bindings, existingBinding)
+		currPolicy.Bindings = b
+	}
+
+	newPolicyRequest := cloudres.SetIamPolicyRequest{
+		Policy: currPolicy,
+	}
+	_, err = cloudresService.Projects.SetIamPolicy(sam.ProjectId, &newPolicyRequest).Do()
+	if err != nil {
+		return fmt.Errorf("Error assigning policy to service account: %s", err)
+	}
+
+	return nil
+}
+
 type ServiceAccountInfo struct {
 	// the bits to save
 	Name      string
@@ -195,13 +238,19 @@ type ServiceAccountInfo struct {
 	PrivateKeyData string
 }
 
-func ServiceAccountBindInputVariables() []broker.BrokerVariable {
+func ServiceAccountBindInputVariables(roleWhitelist []string) []broker.BrokerVariable {
+	whitelistMap := make(map[interface{}]string)
+	for _, role := range roleWhitelist {
+		whitelistMap[role] = role
+	}
+
 	return []broker.BrokerVariable{
 		broker.BrokerVariable{
 			Required:  true,
 			FieldName: "role",
 			Type:      broker.JsonTypeString,
 			Details:   `The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for available roles.`,
+			Enum:      whitelistMap,
 		},
 	}
 }
@@ -235,4 +284,14 @@ func ServiceAccountBindOutputVariables() []broker.BrokerVariable {
 			Details:   "Unique and stable id of the service account",
 		},
 	}
+}
+
+func whitelistAllows(whitelist []string, needle string) bool {
+	for _, s := range whitelist {
+		if s == needle {
+			return true
+		}
+	}
+
+	return len(whitelist) > 0
 }

--- a/brokerapi/brokers/account_managers/service_account_manager_test.go
+++ b/brokerapi/brokers/account_managers/service_account_manager_test.go
@@ -1,0 +1,79 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account_managers
+
+import (
+	"testing"
+
+	"github.com/pivotal-cf/brokerapi"
+)
+
+func TestWhitelistAllows(t *testing.T) {
+	cases := map[string]struct {
+		Whitelist []string
+		Role      string
+		Expected  bool
+	}{
+		"Empty Whitelist": {
+			Whitelist: []string{},
+			Role:      "test",
+			Expected:  true,
+		},
+		"Contained": {
+			Whitelist: []string{"foo", "bar", "bazz"},
+			Role:      "bar",
+			Expected:  true,
+		},
+		"Not Contained": {
+			Whitelist: []string{"foo", "bar", "bazz"},
+			Role:      "bazzz",
+			Expected:  false,
+		},
+	}
+
+	for name, testcase := range cases {
+		actual := whitelistAllows(testcase.Whitelist, testcase.Role)
+		if actual != testcase.Expected {
+			t.Errorf("%s) test failed expected? %v actual: %v, test: %#v", name, testcase.Expected, actual, testcase)
+		}
+	}
+}
+
+func TestExtractRole(t *testing.T) {
+	cases := map[string]struct {
+		Details      string
+		ExpectedRole string
+		ShouldError  bool
+	}{
+		"Positive":     {`{"role":"foo"}`, "foo", false},
+		"Bad Json":     {`}}`, "", true},
+		"Missing Role": {`{"ROLE":"bar"}`, "", true},
+		"bad type":     {`{"role":1234}`, "", true},
+	}
+
+	for name, testcase := range cases {
+		details := brokerapi.BindDetails{RawParameters: []byte(testcase.Details)}
+		role, err := extractRole(details)
+
+		if role != testcase.ExpectedRole {
+			t.Errorf("%s) expected role: %q actual: %q", name, testcase.ExpectedRole, role)
+		}
+
+		wasError := err != nil
+		if wasError != testcase.ShouldError {
+			t.Errorf("%s) expected error? %v got: %s", name, testcase.ShouldError, err)
+		}
+	}
+}

--- a/brokerapi/brokers/account_managers/service_account_manager_test.go
+++ b/brokerapi/brokers/account_managers/service_account_manager_test.go
@@ -29,7 +29,7 @@ func TestWhitelistAllows(t *testing.T) {
 		"Empty Whitelist": {
 			Whitelist: []string{},
 			Role:      "test",
-			Expected:  true,
+			Expected:  false,
 		},
 		"Contained": {
 			Whitelist: []string{"foo", "bar", "bazz"},

--- a/brokerapi/brokers/account_managers/set.go
+++ b/brokerapi/brokers/account_managers/set.go
@@ -1,0 +1,61 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account_managers
+
+import "reflect"
+
+// NewStringSet creates a new string set with the given contents.
+func NewStringSet(contents ...string) StringSet {
+	set := StringSet{}
+	set.Add(contents...)
+	return set
+}
+
+// StringSet is a set data structure for strings
+type StringSet map[string]bool
+
+// Add puts one or more elements into the set.
+func (set StringSet) Add(str ...string) {
+	for _, s := range str {
+		set[s] = true
+	}
+}
+
+// ToSlice converts the set to a slice with undefined contents order.
+func (set StringSet) ToSlice() []string {
+	out := []string{}
+	for k, _ := range set {
+		out = append(out, k)
+	}
+
+	return out
+}
+
+// IsEmpty determines if the set has zero elements.
+func (set StringSet) IsEmpty() bool {
+	return len(set) == 0
+}
+
+// Equals compares the contents of the two sets and returns true if they are
+// the same.
+func (set StringSet) Equals(other StringSet) bool {
+	return reflect.DeepEqual(set, other)
+}
+
+// Contains performs a set membership check.
+func (set StringSet) Contains(other string) bool {
+	_, ok := set[other]
+	return ok
+}

--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -59,7 +59,7 @@ func init() {
     }
 		`,
 		ProvisionInputVariables:     []broker.BrokerVariable{},
-		ServiceAccountRoleWhitelist: roleWhitelist,
+		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables:         accountmanagers.ServiceAccountBindOutputVariables(),
 		Examples: []broker.ServiceExample{

--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -19,16 +19,16 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
-var roleWhitelist = []string{
-	"ml.developer",
-	"ml.viewer",
-	"ml.modelOwner",
-	"ml.modelUser",
-	"ml.jobOwner",
-	"ml.operationOwner",
-}
-
 func init() {
+	roleWhitelist := []string{
+		"ml.developer",
+		"ml.viewer",
+		"ml.modelOwner",
+		"ml.modelUser",
+		"ml.jobOwner",
+		"ml.operationOwner",
+	}
+
 	bs := &broker.BrokerService{
 		Name: "google-ml-apis",
 		DefaultServiceDefinition: `

--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -19,6 +19,15 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
+var roleWhitelist = []string{
+	"ml.developer",
+	"ml.viewer",
+	"ml.modelOwner",
+	"ml.modelUser",
+	"ml.jobOwner",
+	"ml.operationOwner",
+}
+
 func init() {
 	bs := &broker.BrokerService{
 		Name: "google-ml-apis",
@@ -49,9 +58,10 @@ func init() {
       ]
     }
 		`,
-		ProvisionInputVariables: []broker.BrokerVariable{},
-		BindInputVariables:      accountmanagers.ServiceAccountBindInputVariables(),
-		BindOutputVariables:     accountmanagers.ServiceAccountBindOutputVariables(),
+		ProvisionInputVariables:     []broker.BrokerVariable{},
+		ServiceAccountRoleWhitelist: roleWhitelist,
+		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
+		BindOutputVariables:         accountmanagers.ServiceAccountBindOutputVariables(),
 		Examples: []broker.ServiceExample{
 			broker.ServiceExample{
 				Name:            "Basic Configuration",

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -19,15 +19,15 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
-var roleWhitelist = []string{
-	"bigquery.dataViewer",
-	"bigquery.dataEditor",
-	"bigquery.dataOwner",
-	"bigquery.user",
-	"bigquery.jobUser",
-}
-
 func init() {
+	roleWhitelist := []string{
+		"bigquery.dataViewer",
+		"bigquery.dataEditor",
+		"bigquery.dataOwner",
+		"bigquery.user",
+		"bigquery.jobUser",
+	}
+
 	bs := &broker.BrokerService{
 		Name: "google-bigquery",
 		DefaultServiceDefinition: `{

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -63,7 +63,7 @@ func init() {
 				Default:   "a generated value",
 			},
 		},
-		ServiceAccountRoleWhitelist: roleWhitelist,
+		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -19,6 +19,14 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
+var roleWhitelist = []string{
+	"bigquery.dataViewer",
+	"bigquery.dataEditor",
+	"bigquery.dataOwner",
+	"bigquery.user",
+	"bigquery.jobUser",
+}
+
 func init() {
 	bs := &broker.BrokerService{
 		Name: "google-bigquery",
@@ -55,7 +63,8 @@ func init() {
 				Default:   "a generated value",
 			},
 		},
-		BindInputVariables: accountmanagers.ServiceAccountBindInputVariables(),
+		ServiceAccountRoleWhitelist: roleWhitelist,
+		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "dataset_id",

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -19,13 +19,13 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
-var roleWhitelist = []string{
-	"bigtable.user",
-	"bigtable.reader",
-	"bigtable.viewer",
-}
-
 func init() {
+	roleWhitelist := []string{
+		"bigtable.user",
+		"bigtable.reader",
+		"bigtable.viewer",
+	}
+
 	bs := &broker.BrokerService{
 		Name: "google-bigtable",
 		DefaultServiceDefinition: `{

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -19,6 +19,12 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
+var roleWhitelist = []string{
+	"bigtable.user",
+	"bigtable.reader",
+	"bigtable.viewer",
+}
+
 func init() {
 	bs := &broker.BrokerService{
 		Name: "google-bigtable",
@@ -86,12 +92,9 @@ func init() {
 				Details:   "The zone the data will reside in.",
 				Default:   "us-east1-b",
 			},
-			// NOTE: the following variables are defined in the original documentation
-			// but do not seem to be editable by users (only operators)
-			// - storage_type (one of "SSD" or "HDD", defaults to "SSD")
-			// - num_nodes (defaults to 3)
 		},
-		BindInputVariables: accountmanagers.ServiceAccountBindInputVariables(),
+		ServiceAccountRoleWhitelist: roleWhitelist,
+		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "instance_id",

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -93,7 +93,7 @@ func init() {
 				Default:   "us-east1-b",
 			},
 		},
-		ServiceAccountRoleWhitelist: roleWhitelist,
+		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{

--- a/brokerapi/brokers/broker_base/broker_base.go
+++ b/brokerapi/brokers/broker_base/broker_base.go
@@ -16,28 +16,33 @@ package broker_base
 
 import (
 	"code.cloudfoundry.org/lager"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	registry "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+
 	"github.com/pivotal-cf/brokerapi"
 	"golang.org/x/oauth2/jwt"
 )
 
 type BrokerBase struct {
-	AccountManager models.AccountManager
+	AccountManager *account_managers.ServiceAccountManager
 	HttpConfig     *jwt.Config
 	ProjectId      string
 	Logger         lager.Logger
 }
 
 func (b *BrokerBase) Bind(instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
-
-	// Create account
-	newBinding, err := b.AccountManager.CreateCredentials(instanceID, bindingID, details, models.ServiceInstanceDetails{})
-
+	bkr, err := registry.GetServiceById(details.ServiceID)
 	if err != nil {
 		return models.ServiceBindingCredentials{}, err
 	}
 
-	return newBinding, nil
+	whitelist := []string{}
+	if bkr.IsRoleWhitelistEnabled() {
+		whitelist = bkr.ServiceAccountRoleWhitelist
+	}
+
+	return b.AccountManager.CreateCredentials(bindingID, details, whitelist)
 }
 
 func (b *BrokerBase) BuildInstanceCredentials(bindDetails models.ServiceBindingCredentials, instanceDetails models.ServiceInstanceDetails) (map[string]string, error) {
@@ -45,13 +50,7 @@ func (b *BrokerBase) BuildInstanceCredentials(bindDetails models.ServiceBindingC
 }
 
 func (b *BrokerBase) Unbind(creds models.ServiceBindingCredentials) error {
-
-	err := b.AccountManager.DeleteCredentials(creds)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return b.AccountManager.DeleteCredentials(creds)
 }
 
 // Does nothing but return an error because Base services are provisioned synchronously so this method should not be called

--- a/brokerapi/brokers/broker_base/broker_base.go
+++ b/brokerapi/brokers/broker_base/broker_base.go
@@ -18,7 +18,6 @@ import (
 	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
-	registry "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 
 	"github.com/pivotal-cf/brokerapi"
 	"golang.org/x/oauth2/jwt"
@@ -32,17 +31,7 @@ type BrokerBase struct {
 }
 
 func (b *BrokerBase) Bind(instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
-	bkr, err := registry.GetServiceById(details.ServiceID)
-	if err != nil {
-		return models.ServiceBindingCredentials{}, err
-	}
-
-	whitelist := []string{}
-	if bkr.IsRoleWhitelistEnabled() {
-		whitelist = bkr.ServiceAccountRoleWhitelist
-	}
-
-	return b.AccountManager.CreateCredentials(bindingID, details, whitelist)
+	return b.AccountManager.CreateCredentials(instanceID, bindingID, details, models.ServiceInstanceDetails{})
 }
 
 func (b *BrokerBase) BuildInstanceCredentials(bindDetails models.ServiceBindingCredentials, instanceDetails models.ServiceInstanceDetails) (map[string]string, error) {

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/name_generator"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
@@ -41,7 +40,7 @@ type CloudSQLBroker struct {
 	ProjectId        string
 	Logger           lager.Logger
 	AccountManager   models.AccountManager
-	SaAccountManager *account_managers.ServiceAccountManager
+	SaAccountManager models.AccountManager
 }
 
 type InstanceInformation struct {
@@ -459,6 +458,7 @@ func (b *CloudSQLBroker) Bind(instanceID, bindingID string, details brokerapi.Bi
 	}
 
 	saCredBytes, err := b.SaAccountManager.CreateCredentials(instanceID, bindingID, details, models.ServiceInstanceDetails{})
+
 	if err != nil {
 		return models.ServiceBindingCredentials{}, err
 	}

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -453,23 +453,12 @@ func (b *CloudSQLBroker) Bind(instanceID, bindingID string, details brokerapi.Bi
 		return models.ServiceBindingCredentials{}, err
 	}
 
-	bkr, err := broker.GetServiceById(details.ServiceID)
-	if err != nil {
-		return models.ServiceBindingCredentials{}, err
-	}
-
-	whitelist := []string{}
-	if bkr.IsRoleWhitelistEnabled() {
-		whitelist = bkr.ServiceAccountRoleWhitelist
-	}
-
 	sqlCredBytes, err := b.AccountManager.CreateCredentials(instanceID, bindingID, details, cloudDb)
 	if err != nil {
 		return models.ServiceBindingCredentials{}, err
 	}
 
-	saCredBytes, err := b.SaAccountManager.CreateCredentials(bindingID, details, whitelist)
-
+	saCredBytes, err := b.SaAccountManager.CreateCredentials(instanceID, bindingID, details, models.ServiceInstanceDetails{})
 	if err != nil {
 		return models.ServiceBindingCredentials{}, err
 	}

--- a/brokerapi/brokers/cloudsql/common-definition.go
+++ b/brokerapi/brokers/cloudsql/common-definition.go
@@ -19,7 +19,13 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
-var commonBindVariables = append(accountmanagers.ServiceAccountBindInputVariables(),
+var roleWhitelist = []string{
+	"cloudsql.editor",
+	"cloudsql.viewer",
+	"cloudsql.client",
+}
+
+var commonBindVariables = append(accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 	broker.BrokerVariable{
 		FieldName: "jdbc_uri_format",
 		Type:      broker.JsonTypeString,

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -174,7 +174,7 @@ func init() {
 				]
 		}`,
 		ProvisionInputVariables:     commonProvisionVariables,
-		ServiceAccountRoleWhitelist: roleWhitelist,
+		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:          commonBindVariables,
 		BindOutputVariables:         commonBindOutputVariables,
 		PlanVariables: []broker.BrokerVariable{

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -173,9 +173,10 @@ func init() {
 				    }
 				]
 		}`,
-		ProvisionInputVariables: commonProvisionVariables,
-		BindInputVariables:      commonBindVariables,
-		BindOutputVariables:     commonBindOutputVariables,
+		ProvisionInputVariables:     commonProvisionVariables,
+		ServiceAccountRoleWhitelist: roleWhitelist,
+		BindInputVariables:          commonBindVariables,
+		BindOutputVariables:         commonBindOutputVariables,
 		PlanVariables: []broker.BrokerVariable{
 			broker.BrokerVariable{
 				FieldName: "tier",

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -128,9 +128,10 @@ func init() {
 				    }
 				]
     }`,
-		ProvisionInputVariables: commonProvisionVariables,
-		BindInputVariables:      commonBindVariables,
-		BindOutputVariables:     commonBindOutputVariables,
+		ProvisionInputVariables:     commonProvisionVariables,
+		ServiceAccountRoleWhitelist: roleWhitelist,
+		BindInputVariables:          commonBindVariables,
+		BindOutputVariables:         commonBindOutputVariables,
 		PlanVariables: []broker.BrokerVariable{
 			broker.BrokerVariable{
 				FieldName: "tier",

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -129,7 +129,7 @@ func init() {
 				]
     }`,
 		ProvisionInputVariables:     commonProvisionVariables,
-		ServiceAccountRoleWhitelist: roleWhitelist,
+		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:          commonBindVariables,
 		BindOutputVariables:         commonBindOutputVariables,
 		PlanVariables: []broker.BrokerVariable{

--- a/brokerapi/brokers/datastore/broker.go
+++ b/brokerapi/brokers/datastore/broker.go
@@ -17,15 +17,11 @@ package datastore
 import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
 )
 
 type DatastoreBroker struct {
 	broker_base.BrokerBase
-}
-
-type InstanceInformation struct {
 }
 
 // No-op, no service is required for Datastore
@@ -40,18 +36,5 @@ func (b *DatastoreBroker) Deprovision(instanceID string, details brokerapi.Depro
 
 // Creates a service account with access to Datastore
 func (b *DatastoreBroker) Bind(instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
-	out, err := utils.SetParameter(details.RawParameters, "role", "datastore.user")
-	if err != nil {
-		return models.ServiceBindingCredentials{}, err
-	}
-	details.RawParameters = out
-
-	// Create account
-	newBinding, err := b.AccountManager.CreateCredentials(instanceID, bindingID, details, models.ServiceInstanceDetails{})
-
-	if err != nil {
-		return models.ServiceBindingCredentials{}, err
-	}
-
-	return newBinding, nil
+	return b.AccountManager.CreateAccountWithRoles(instanceID, []string{"datastore.user"})
 }

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -90,7 +90,7 @@ again during that time (on a best-effort basis).
 				Default: "10",
 			},
 		},
-		ServiceAccountRoleWhitelist: roleWhitelist,
+		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -17,6 +17,13 @@ package pubsub
 import "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 import accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 
+var roleWhitelist = []string{
+	"pubsub.publisher",
+	"pubsub.subscriber",
+	"pubsub.viewer",
+	"pubsub.editor",
+}
+
 func init() {
 	bs := &broker.BrokerService{
 		Name: "google-pubsub",
@@ -83,7 +90,8 @@ again during that time (on a best-effort basis).
 				Default: "10",
 			},
 		},
-		BindInputVariables: accountmanagers.ServiceAccountBindInputVariables(),
+		ServiceAccountRoleWhitelist: roleWhitelist,
+		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "subscription_name",

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -17,14 +17,14 @@ package pubsub
 import "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 import accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 
-var roleWhitelist = []string{
-	"pubsub.publisher",
-	"pubsub.subscriber",
-	"pubsub.viewer",
-	"pubsub.editor",
-}
-
 func init() {
+	roleWhitelist := []string{
+		"pubsub.publisher",
+		"pubsub.subscriber",
+		"pubsub.viewer",
+		"pubsub.editor",
+	}
+
 	bs := &broker.BrokerService{
 		Name: "google-pubsub",
 		DefaultServiceDefinition: `{

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -17,6 +17,13 @@ package spanner
 import "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 import accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 
+var roleWhitelist = []string{
+	"spanner.databaseAdmin",
+	"spanner.databaseReader",
+	"spanner.databaseUser",
+	"spanner.viewer",
+}
+
 func init() {
 	bs := &broker.BrokerService{
 		Name: "google-spanner",
@@ -72,7 +79,8 @@ func init() {
 				Details:   `The location of the Spanner instance.`,
 			},
 		},
-		BindInputVariables: accountmanagers.ServiceAccountBindInputVariables(),
+		ServiceAccountRoleWhitelist: roleWhitelist,
+		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "instance_id",

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -79,7 +79,7 @@ func init() {
 				Details:   `The location of the Spanner instance.`,
 			},
 		},
-		ServiceAccountRoleWhitelist: roleWhitelist,
+		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -17,14 +17,14 @@ package spanner
 import "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 import accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 
-var roleWhitelist = []string{
-	"spanner.databaseAdmin",
-	"spanner.databaseReader",
-	"spanner.databaseUser",
-	"spanner.viewer",
-}
-
 func init() {
+	roleWhitelist := []string{
+		"spanner.databaseAdmin",
+		"spanner.databaseReader",
+		"spanner.databaseUser",
+		"spanner.viewer",
+	}
+
 	bs := &broker.BrokerService{
 		Name: "google-spanner",
 		DefaultServiceDefinition: `

--- a/brokerapi/brokers/stackdriver_debugger/broker.go
+++ b/brokerapi/brokers/stackdriver_debugger/broker.go
@@ -17,15 +17,11 @@ package stackdriver_debugger
 import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
 )
 
 type StackdriverDebuggerBroker struct {
 	broker_base.BrokerBase
-}
-
-type InstanceInformation struct {
 }
 
 // No-op, no service is required for the Debugger
@@ -40,18 +36,5 @@ func (b *StackdriverDebuggerBroker) Deprovision(instanceID string, details broke
 
 // Creates a service account with access to Stackdriver Debugger
 func (b *StackdriverDebuggerBroker) Bind(instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
-	out, err := utils.SetParameter(details.RawParameters, "role", "clouddebugger.agent")
-	if err != nil {
-		return models.ServiceBindingCredentials{}, err
-	}
-	details.RawParameters = out
-
-	// Create account
-	newBinding, err := b.AccountManager.CreateCredentials(instanceID, bindingID, details, models.ServiceInstanceDetails{})
-
-	if err != nil {
-		return models.ServiceBindingCredentials{}, err
-	}
-
-	return newBinding, nil
+	return b.AccountManager.CreateAccountWithRoles(bindingID, []string{"clouddebugger.agent"})
 }

--- a/brokerapi/brokers/stackdriver_trace/broker.go
+++ b/brokerapi/brokers/stackdriver_trace/broker.go
@@ -17,15 +17,11 @@ package stackdriver_trace
 import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
 )
 
 type StackdriverTraceBroker struct {
 	broker_base.BrokerBase
-}
-
-type InstanceInformation struct {
 }
 
 // No-op, no serivce is required for Stackdriver Trace
@@ -40,18 +36,5 @@ func (b *StackdriverTraceBroker) Deprovision(instanceID string, details brokerap
 
 // Creates a service account with access to Stackdriver Trace
 func (b *StackdriverTraceBroker) Bind(instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
-	out, err := utils.SetParameter(details.RawParameters, "role", "cloudtrace.agent")
-	if err != nil {
-		return models.ServiceBindingCredentials{}, err
-	}
-	details.RawParameters = out
-
-	// Create account
-	newBinding, err := b.AccountManager.CreateCredentials(instanceID, bindingID, details, models.ServiceInstanceDetails{})
-
-	if err != nil {
-		return models.ServiceBindingCredentials{}, err
-	}
-
-	return newBinding, nil
+	return b.AccountManager.CreateAccountWithRoles(bindingID, []string{"cloudtrace.agent"})
 }

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -17,6 +17,12 @@ package storage
 import "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 import accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 
+var roleWhitelist = []string{
+	"storage.objectCreator",
+	"storage.objectViewer",
+	"storage.objectAdmin",
+}
+
 func init() {
 	bs := &broker.BrokerService{
 		Name: "google-storage",
@@ -75,7 +81,8 @@ func init() {
 				Details:   `The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. See https://cloud.google.com/storage/docs/bucket-locations`,
 			},
 		},
-		BindInputVariables: accountmanagers.ServiceAccountBindInputVariables(),
+		ServiceAccountRoleWhitelist: roleWhitelist,
+		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "bucket_name",

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -81,7 +81,7 @@ func init() {
 				Details:   `The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. See https://cloud.google.com/storage/docs/bucket-locations`,
 			},
 		},
-		ServiceAccountRoleWhitelist: roleWhitelist,
+		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:          accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -17,13 +17,13 @@ package storage
 import "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 import accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 
-var roleWhitelist = []string{
-	"storage.objectCreator",
-	"storage.objectViewer",
-	"storage.objectAdmin",
-}
-
 func init() {
+	roleWhitelist := []string{
+		"storage.objectCreator",
+		"storage.objectViewer",
+		"storage.objectAdmin",
+	}
+
 	bs := &broker.BrokerService{
 		Name: "google-storage",
 		DefaultServiceDefinition: `{

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,3 +1,4 @@
+
 # Installation Customization
 
 This file documents the various environment variables you can set to change the functionality of the service broker.
@@ -268,6 +269,118 @@ You can configure the following environment variables:
 </ul>
 
 <b><tt>GSB_SERVICE_GOOGLE_STORAGE_ENABLED</tt></b> - <i>boolean</i> - Let the broker create and bind Google Cloud Storage instances
+
+
+
+
+
+<ul>
+  <li><b>Required</b></li>
+
+
+  <li>Default: <code>true</code></li>
+</ul>
+
+
+
+## Role Whitelisting
+
+Enable or disable role whitelisting
+
+You can configure the following environment variables:
+
+<b><tt>GSB_SERVICE_GOOGLE_BIGQUERY_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google BigQuery instances
+
+
+
+
+
+<ul>
+  <li><b>Required</b></li>
+
+
+  <li>Default: <code>true</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_BIGTABLE_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google Bigtable instances
+
+
+
+
+
+<ul>
+  <li><b>Required</b></li>
+
+
+  <li>Default: <code>true</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google CloudSQL MySQL instances
+
+
+
+
+
+<ul>
+  <li><b>Required</b></li>
+
+
+  <li>Default: <code>true</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google CloudSQL PostgreSQL instances
+
+
+
+
+
+<ul>
+  <li><b>Required</b></li>
+
+
+  <li>Default: <code>true</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_ML_APIS_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google Machine Learning APIs instances
+
+
+
+
+
+<ul>
+  <li><b>Required</b></li>
+
+
+  <li>Default: <code>true</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_PUBSUB_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google PubSub instances
+
+
+
+
+
+<ul>
+  <li><b>Required</b></li>
+
+
+  <li>Default: <code>true</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_SPANNER_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google Spanner instances
+
+
+
+
+
+<ul>
+  <li><b>Required</b></li>
+
+
+  <li>Default: <code>true</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_STORAGE_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google Cloud Storage instances
 
 
 
@@ -703,7 +816,7 @@ For example:
   <td><i>string</i></td>
   <td>Tier</td>
   <td>
-  a string of the form db-custom-[CPUS]-[MEMORY_MBS], where memory is at least 3840
+  A string of the form db-custom-[CPUS]-[MEMORY_MBS], where memory is at least 3840
 
 
 <ul>

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,4 +1,3 @@
-
 # Installation Customization
 
 This file documents the various environment variables you can set to change the functionality of the service broker.
@@ -289,9 +288,9 @@ Enable or disable role whitelisting
 
 You can configure the following environment variables:
 
-<b><tt>GSB_SERVICE_GOOGLE_BIGQUERY_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google BigQuery instances
+<b><tt>GSB_SERVICE_GOOGLE_BIGQUERY_WHITELIST</tt></b> - <i>string</i> - Role whitelist for Google BigQuery instances
 
-
+A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service
 
 
 
@@ -299,12 +298,12 @@ You can configure the following environment variables:
   <li><b>Required</b></li>
 
 
-  <li>Default: <code>true</code></li>
+  <li>Default: <code>bigquery.dataViewer,bigquery.dataEditor,bigquery.dataOwner,bigquery.user,bigquery.jobUser</code></li>
 </ul>
 
-<b><tt>GSB_SERVICE_GOOGLE_BIGTABLE_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google Bigtable instances
+<b><tt>GSB_SERVICE_GOOGLE_BIGTABLE_WHITELIST</tt></b> - <i>string</i> - Role whitelist for Google Bigtable instances
 
-
+A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service
 
 
 
@@ -312,12 +311,12 @@ You can configure the following environment variables:
   <li><b>Required</b></li>
 
 
-  <li>Default: <code>true</code></li>
+  <li>Default: <code>bigtable.user,bigtable.reader,bigtable.viewer</code></li>
 </ul>
 
-<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google CloudSQL MySQL instances
+<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_WHITELIST</tt></b> - <i>string</i> - Role whitelist for Google CloudSQL MySQL instances
 
-
+A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service
 
 
 
@@ -325,12 +324,12 @@ You can configure the following environment variables:
   <li><b>Required</b></li>
 
 
-  <li>Default: <code>true</code></li>
+  <li>Default: <code>cloudsql.editor,cloudsql.viewer,cloudsql.client</code></li>
 </ul>
 
-<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google CloudSQL PostgreSQL instances
+<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_WHITELIST</tt></b> - <i>string</i> - Role whitelist for Google CloudSQL PostgreSQL instances
 
-
+A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service
 
 
 
@@ -338,12 +337,12 @@ You can configure the following environment variables:
   <li><b>Required</b></li>
 
 
-  <li>Default: <code>true</code></li>
+  <li>Default: <code>cloudsql.editor,cloudsql.viewer,cloudsql.client</code></li>
 </ul>
 
-<b><tt>GSB_SERVICE_GOOGLE_ML_APIS_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google Machine Learning APIs instances
+<b><tt>GSB_SERVICE_GOOGLE_ML_APIS_WHITELIST</tt></b> - <i>string</i> - Role whitelist for Google Machine Learning APIs instances
 
-
+A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service
 
 
 
@@ -351,12 +350,12 @@ You can configure the following environment variables:
   <li><b>Required</b></li>
 
 
-  <li>Default: <code>true</code></li>
+  <li>Default: <code>ml.developer,ml.viewer,ml.modelOwner,ml.modelUser,ml.jobOwner,ml.operationOwner</code></li>
 </ul>
 
-<b><tt>GSB_SERVICE_GOOGLE_PUBSUB_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google PubSub instances
+<b><tt>GSB_SERVICE_GOOGLE_PUBSUB_WHITELIST</tt></b> - <i>string</i> - Role whitelist for Google PubSub instances
 
-
+A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service
 
 
 
@@ -364,12 +363,12 @@ You can configure the following environment variables:
   <li><b>Required</b></li>
 
 
-  <li>Default: <code>true</code></li>
+  <li>Default: <code>pubsub.publisher,pubsub.subscriber,pubsub.viewer,pubsub.editor</code></li>
 </ul>
 
-<b><tt>GSB_SERVICE_GOOGLE_SPANNER_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google Spanner instances
+<b><tt>GSB_SERVICE_GOOGLE_SPANNER_WHITELIST</tt></b> - <i>string</i> - Role whitelist for Google Spanner instances
 
-
+A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service
 
 
 
@@ -377,12 +376,12 @@ You can configure the following environment variables:
   <li><b>Required</b></li>
 
 
-  <li>Default: <code>true</code></li>
+  <li>Default: <code>spanner.databaseAdmin,spanner.databaseReader,spanner.databaseUser,spanner.viewer</code></li>
 </ul>
 
-<b><tt>GSB_SERVICE_GOOGLE_STORAGE_WHITELIST_ENABLED</tt></b> - <i>boolean</i> - Use a builtin whitelist of roles to limit what developers can do on binding Google Cloud Storage instances
+<b><tt>GSB_SERVICE_GOOGLE_STORAGE_WHITELIST</tt></b> - <i>string</i> - Role whitelist for Google Cloud Storage instances
 
-
+A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service
 
 
 
@@ -390,7 +389,7 @@ You can configure the following environment variables:
   <li><b>Required</b></li>
 
 
-  <li>Default: <code>true</code></li>
+  <li>Default: <code>storage.objectCreator,storage.objectViewer,storage.objectAdmin</code></li>
 </ul>
 
 

--- a/docs/use.md
+++ b/docs/use.md
@@ -23,7 +23,7 @@ A fast, economical and fully managed data warehouse for large-scale data analyti
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for available roles.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'bigquery.dataViewer', 'bigquery.dataEditor', 'bigquery.dataOwner', 'bigquery.user', 'bigquery.jobUser'
 
 **Response Parameters**
 
@@ -96,7 +96,7 @@ A high performance NoSQL database service for large analytical and operational w
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for available roles.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'bigtable.user', 'bigtable.reader', 'bigtable.viewer'
 
 **Response Parameters**
 
@@ -183,7 +183,7 @@ Google Cloud SQL is a fully-managed MySQL database service
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for available roles.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'cloudsql.editor', 'cloudsql.viewer', 'cloudsql.client'
  * `jdbc_uri_format` _string_ - if `true`, `uri` field will contain a JDBC formatted URI Default: `false`
  * `username` _string_ - The SQL username for the account Default: `a generated value`
  * `password` _string_ - The SQL password for the account Default: `a generated value`
@@ -298,7 +298,7 @@ Google Cloud SQL is a fully-managed MySQL database service
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for available roles.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'cloudsql.editor', 'cloudsql.viewer', 'cloudsql.client'
  * `jdbc_uri_format` _string_ - if `true`, `uri` field will contain a JDBC formatted URI Default: `false`
  * `username` _string_ - The SQL username for the account Default: `a generated value`
  * `password` _string_ - The SQL password for the account Default: `a generated value`
@@ -459,7 +459,7 @@ _No parameters supported._
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for available roles.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'ml.developer', 'ml.viewer', 'ml.modelOwner', 'ml.modelUser', 'ml.jobOwner', 'ml.operationOwner'
 
 **Response Parameters**
 
@@ -530,7 +530,7 @@ A global service for real-time and reliable messaging and streaming data
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for available roles.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'pubsub.publisher', 'pubsub.subscriber', 'pubsub.viewer', 'pubsub.editor'
 
 **Response Parameters**
 
@@ -604,7 +604,7 @@ The first horizontally scalable, globally consistent, relational database servic
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for available roles.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'spanner.databaseAdmin', 'spanner.databaseReader', 'spanner.databaseUser', 'spanner.viewer'
 
 **Response Parameters**
 
@@ -802,7 +802,7 @@ A Powerful, Simple and Cost Effective Object Storage Service
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for available roles.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'storage.objectCreator', 'storage.objectViewer', 'storage.objectAdmin'
 
 **Response Parameters**
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -51,6 +51,16 @@ func ExampleBrokerService_UserDefinedPlansProperty() {
 	// Output: service.left-handed-smoke-sifter.plans
 }
 
+func ExampleBrokerService_RoleWhitelistProperty() {
+	service := BrokerService{
+		Name: "left-handed-smoke-sifter",
+	}
+
+	fmt.Println(service.RoleWhitelistProperty())
+
+	// Output: service.left-handed-smoke-sifter.whitelist.enabled
+}
+
 func ExampleBrokerService_IsEnabled() {
 	service := BrokerService{
 		Name: "left-handed-smoke-sifter",
@@ -61,6 +71,21 @@ func ExampleBrokerService_IsEnabled() {
 
 	viper.Set(service.EnabledProperty(), false)
 	fmt.Println(service.IsEnabled())
+
+	// Output: true
+	// false
+}
+
+func ExampleBrokerService_IsRoleWhitelistEnabled() {
+	service := BrokerService{
+		Name: "left-handed-smoke-sifter",
+		ServiceAccountRoleWhitelist: []string{"a", "b", "c"},
+	}
+	viper.Set(service.RoleWhitelistProperty(), true)
+	fmt.Println(service.IsRoleWhitelistEnabled())
+
+	viper.Set(service.RoleWhitelistProperty(), false)
+	fmt.Println(service.IsRoleWhitelistEnabled())
 
 	// Output: true
 	// false

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -58,7 +58,7 @@ func ExampleBrokerService_RoleWhitelistProperty() {
 
 	fmt.Println(service.RoleWhitelistProperty())
 
-	// Output: service.left-handed-smoke-sifter.whitelist.enabled
+	// Output: service.left-handed-smoke-sifter.whitelist
 }
 
 func ExampleBrokerService_IsEnabled() {
@@ -78,17 +78,31 @@ func ExampleBrokerService_IsEnabled() {
 
 func ExampleBrokerService_IsRoleWhitelistEnabled() {
 	service := BrokerService{
-		Name: "left-handed-smoke-sifter",
-		ServiceAccountRoleWhitelist: []string{"a", "b", "c"},
+		Name:                 "left-handed-smoke-sifter",
+		DefaultRoleWhitelist: []string{"a", "b", "c"},
 	}
-	viper.Set(service.RoleWhitelistProperty(), true)
 	fmt.Println(service.IsRoleWhitelistEnabled())
 
-	viper.Set(service.RoleWhitelistProperty(), false)
+	service.DefaultRoleWhitelist = nil
 	fmt.Println(service.IsRoleWhitelistEnabled())
 
 	// Output: true
 	// false
+}
+
+func ExampleBrokerService_RoleWhitelist() {
+	service := BrokerService{
+		Name:                 "my-service",
+		DefaultRoleWhitelist: []string{"a", "b", "c"},
+	}
+	viper.Set(service.RoleWhitelistProperty(), "")
+	fmt.Println(service.RoleWhitelist())
+
+	viper.Set(service.RoleWhitelistProperty(), "x,y,z")
+	fmt.Println(service.RoleWhitelist())
+
+	// Output: [a b c]
+	// [x y z]
 }
 
 func ExampleBrokerService_TileUserDefinedPlansVariable() {

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -44,9 +44,7 @@ func Register(service *BrokerService) {
 
 	// set defaults
 	viper.SetDefault(service.EnabledProperty(), true)
-	if service.ServiceAccountRoleWhitelist == nil {
-		viper.SetDefault(service.RoleWhitelistProperty(), true)
-	}
+	viper.SetDefault(service.RoleWhitelistProperty(), true)
 
 	// Test deserializing the user defined plans and service definition
 	if _, err := service.CatalogEntry(); err != nil {
@@ -103,14 +101,13 @@ func GetServiceById(id string) (*BrokerService, error) {
 }
 
 type BrokerService struct {
-	Name                     string
-	DefaultServiceDefinition string
-	ProvisionInputVariables  []BrokerVariable
-	BindInputVariables       []BrokerVariable
-	BindOutputVariables      []BrokerVariable
-	PlanVariables            []BrokerVariable
-	Examples                 []ServiceExample
-	// does this broker service allow users to limit roles to only safe ones?
+	Name                        string
+	DefaultServiceDefinition    string
+	ProvisionInputVariables     []BrokerVariable
+	BindInputVariables          []BrokerVariable
+	BindOutputVariables         []BrokerVariable
+	PlanVariables               []BrokerVariable
+	Examples                    []ServiceExample
 	ServiceAccountRoleWhitelist []string
 }
 
@@ -135,7 +132,7 @@ func (svc *BrokerService) UserDefinedPlansProperty() string {
 // RoleWhitelistProperty computes the Viper property name for the boolean the user
 // can set to enable or disable the role whitelist.
 func (svc *BrokerService) RoleWhitelistProperty() string {
-	return fmt.Sprintf("service.%s.enable-role-whitelist", svc.Name)
+	return fmt.Sprintf("service.%s.whitelist.enabled", svc.Name)
 }
 
 // TileUserDefinedPlansVariable returns the name of the user defined plans
@@ -160,7 +157,9 @@ func (svc *BrokerService) IsEnabled() bool {
 // IsRoleWhitelistEnabled returns false if the operator has explicitly disabled
 // the role whitelist for this service or true otherwise.
 func (svc *BrokerService) IsRoleWhitelistEnabled() bool {
-	return viper.GetBool(svc.RoleWhitelistProperty())
+	whitelistExists := len(svc.ServiceAccountRoleWhitelist) > 0
+	userEnabled := viper.GetBool(svc.RoleWhitelistProperty())
+	return whitelistExists && userEnabled
 }
 
 // CatalogEntry returns the service broker catalog entry for this service, it

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -44,6 +44,9 @@ func Register(service *BrokerService) {
 
 	// set defaults
 	viper.SetDefault(service.EnabledProperty(), true)
+	if service.ServiceAccountRoleWhitelist == nil {
+		viper.SetDefault(service.RoleWhitelistProperty(), true)
+	}
 
 	// Test deserializing the user defined plans and service definition
 	if _, err := service.CatalogEntry(); err != nil {
@@ -107,6 +110,8 @@ type BrokerService struct {
 	BindOutputVariables      []BrokerVariable
 	PlanVariables            []BrokerVariable
 	Examples                 []ServiceExample
+	// does this broker service allow users to limit roles to only safe ones?
+	ServiceAccountRoleWhitelist []string
 }
 
 // EnabledProperty computes the Viper property name for the boolean the user
@@ -127,6 +132,12 @@ func (svc *BrokerService) UserDefinedPlansProperty() string {
 	return fmt.Sprintf("service.%s.plans", svc.Name)
 }
 
+// RoleWhitelistProperty computes the Viper property name for the boolean the user
+// can set to enable or disable the role whitelist.
+func (svc *BrokerService) RoleWhitelistProperty() string {
+	return fmt.Sprintf("service.%s.enable-role-whitelist", svc.Name)
+}
+
 // TileUserDefinedPlansVariable returns the name of the user defined plans
 // variable for the broker tile.
 func (svc *BrokerService) TileUserDefinedPlansVariable() string {
@@ -144,6 +155,12 @@ func (svc *BrokerService) TileUserDefinedPlansVariable() string {
 // or true otherwise.
 func (svc *BrokerService) IsEnabled() bool {
 	return viper.GetBool(svc.EnabledProperty())
+}
+
+// IsRoleWhitelistEnabled returns false if the operator has explicitly disabled
+// the role whitelist for this service or true otherwise.
+func (svc *BrokerService) IsRoleWhitelistEnabled() bool {
+	return viper.GetBool(svc.RoleWhitelistProperty())
 }
 
 // CatalogEntry returns the service broker catalog entry for this service, it

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -44,7 +44,6 @@ func Register(service *BrokerService) {
 
 	// set defaults
 	viper.SetDefault(service.EnabledProperty(), true)
-	viper.SetDefault(service.RoleWhitelistProperty(), true)
 
 	// Test deserializing the user defined plans and service definition
 	if _, err := service.CatalogEntry(); err != nil {
@@ -101,14 +100,14 @@ func GetServiceById(id string) (*BrokerService, error) {
 }
 
 type BrokerService struct {
-	Name                        string
-	DefaultServiceDefinition    string
-	ProvisionInputVariables     []BrokerVariable
-	BindInputVariables          []BrokerVariable
-	BindOutputVariables         []BrokerVariable
-	PlanVariables               []BrokerVariable
-	Examples                    []ServiceExample
-	ServiceAccountRoleWhitelist []string
+	Name                     string
+	DefaultServiceDefinition string
+	ProvisionInputVariables  []BrokerVariable
+	BindInputVariables       []BrokerVariable
+	BindOutputVariables      []BrokerVariable
+	PlanVariables            []BrokerVariable
+	Examples                 []ServiceExample
+	DefaultRoleWhitelist     []string
 }
 
 // EnabledProperty computes the Viper property name for the boolean the user
@@ -132,7 +131,19 @@ func (svc *BrokerService) UserDefinedPlansProperty() string {
 // RoleWhitelistProperty computes the Viper property name for the boolean the user
 // can set to enable or disable the role whitelist.
 func (svc *BrokerService) RoleWhitelistProperty() string {
-	return fmt.Sprintf("service.%s.whitelist.enabled", svc.Name)
+	return fmt.Sprintf("service.%s.whitelist", svc.Name)
+}
+
+// RoleWhitelist returns the whitelist of roles the operator has allowed or the
+// default if it is blank.
+func (svc *BrokerService) RoleWhitelist() []string {
+	rawWhitelist := viper.GetString(svc.RoleWhitelistProperty())
+	wl := strings.Split(rawWhitelist, ",")
+	if strings.TrimSpace(rawWhitelist) != "" {
+		return wl
+	}
+
+	return svc.DefaultRoleWhitelist
 }
 
 // TileUserDefinedPlansVariable returns the name of the user defined plans
@@ -154,12 +165,10 @@ func (svc *BrokerService) IsEnabled() bool {
 	return viper.GetBool(svc.EnabledProperty())
 }
 
-// IsRoleWhitelistEnabled returns false if the operator has explicitly disabled
-// the role whitelist for this service or true otherwise.
+// IsRoleWhitelistEnabled returns false if the service has no default whitelist
+// meaning it does not allow any roles.
 func (svc *BrokerService) IsRoleWhitelistEnabled() bool {
-	whitelistExists := len(svc.ServiceAccountRoleWhitelist) > 0
-	userEnabled := viper.GetBool(svc.RoleWhitelistProperty())
-	return whitelistExists && userEnabled
+	return len(svc.DefaultRoleWhitelist) > 0
 }
 
 // CatalogEntry returns the service broker catalog entry for this service, it

--- a/pkg/generator/customization-md.go
+++ b/pkg/generator/customization-md.go
@@ -164,5 +164,17 @@ func GenerateCustomizationMd() string {
 		log.Fatalf("Error rendering template: %s", err)
 	}
 
-	return buf.String()
+	return cleanMdOutput(buf.String())
+}
+
+// Remove trailing whitespace from the document and every line
+func cleanMdOutput(text string) string {
+	text = strings.TrimSpace(text)
+
+	lines := strings.Split(text, "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimRight(l, " \t")
+	}
+
+	return strings.Join(lines, "\n")
 }

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -70,6 +70,7 @@ func GenerateForms() TileFormsSections {
 			GenerateServiceAccountForm(),
 			GenerateDatabaseForm(),
 			GenerateEnableDisableForm(),
+			GenerateRoleWhitelistForm(),
 		},
 
 		ServicePlanForms: GenerateServicePlanForms(),
@@ -100,6 +101,37 @@ func GenerateEnableDisableForm() Form {
 		Name:        "enable_disable",
 		Label:       "Enable Services",
 		Description: "Enable or disable services",
+		Properties:  enablers,
+	}
+}
+
+func GenerateRoleWhitelistForm() Form {
+	enablers := []FormProperty{}
+	for _, svc := range broker.GetAllServices() {
+		entry, err := svc.CatalogEntry()
+		if err != nil {
+			log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
+		}
+
+		if svc.ServiceAccountRoleWhitelist != nil {
+			continue
+		}
+
+		enableForm := FormProperty{
+			Name:         strings.ToLower(utils.PropertyToEnv(svc.RoleWhitelistProperty())),
+			Label:        fmt.Sprintf("Use a builtin whitelist of roles to limit what developers can do on binding %s instances", entry.Metadata.DisplayName),
+			Type:         "boolean",
+			Default:      true,
+			Configurable: true,
+		}
+
+		enablers = append(enablers, enableForm)
+	}
+
+	return Form{
+		Name:        "role_whitelists",
+		Label:       "Role Whitelisting",
+		Description: "Enable or disable role whitelisting",
 		Properties:  enablers,
 	}
 }

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -105,6 +105,9 @@ func GenerateEnableDisableForm() Form {
 	}
 }
 
+// GenerateRoleWhitelistForm generates a form for users to enable/disable the
+// whitelist validation for new service accounts bound to the service.
+// They are opt-out and on by default for safety.
 func GenerateRoleWhitelistForm() Form {
 	enablers := []FormProperty{}
 	for _, svc := range broker.GetAllServices() {

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -116,15 +116,16 @@ func GenerateRoleWhitelistForm() Form {
 			log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
 		}
 
-		if len(svc.ServiceAccountRoleWhitelist) == 0 {
+		if !svc.IsRoleWhitelistEnabled() {
 			continue
 		}
 
 		enableForm := FormProperty{
 			Name:         strings.ToLower(utils.PropertyToEnv(svc.RoleWhitelistProperty())),
-			Label:        fmt.Sprintf("Use a builtin whitelist of roles to limit what developers can do on binding %s instances", entry.Metadata.DisplayName),
-			Type:         "boolean",
-			Default:      true,
+			Label:        fmt.Sprintf("Role whitelist for %s instances", entry.Metadata.DisplayName),
+			Description:  "A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service",
+			Type:         "string",
+			Default:      strings.Join(svc.DefaultRoleWhitelist, ","),
 			Configurable: true,
 		}
 

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -116,7 +116,7 @@ func GenerateRoleWhitelistForm() Form {
 			log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
 		}
 
-		if svc.ServiceAccountRoleWhitelist != nil {
+		if len(svc.ServiceAccountRoleWhitelist) == 0 {
 			continue
 		}
 

--- a/tile.yml
+++ b/tile.yml
@@ -68,6 +68,11 @@ forms:
     default: "3306"
     label: Database port (defaults to 3306)
     configurable: true
+  - name: db_name
+    type: string
+    default: servicebroker
+    label: Database name
+    configurable: true
   - name: ca_cert
     type: text
     label: Server CA cert
@@ -142,7 +147,101 @@ forms:
     default: true
     label: Let the broker create and bind Google Cloud Storage instances
     configurable: true
+- name: role_whitelists
+  label: Role Whitelisting
+  description: Enable or disable role whitelisting
+  properties:
+  - name: gsb_service_google_bigquery_whitelist_enabled
+    type: boolean
+    default: true
+    label: Use a builtin whitelist of roles to limit what developers can do on binding
+      Google BigQuery instances
+    configurable: true
+  - name: gsb_service_google_bigtable_whitelist_enabled
+    type: boolean
+    default: true
+    label: Use a builtin whitelist of roles to limit what developers can do on binding
+      Google Bigtable instances
+    configurable: true
+  - name: gsb_service_google_cloudsql_mysql_whitelist_enabled
+    type: boolean
+    default: true
+    label: Use a builtin whitelist of roles to limit what developers can do on binding
+      Google CloudSQL MySQL instances
+    configurable: true
+  - name: gsb_service_google_cloudsql_postgres_whitelist_enabled
+    type: boolean
+    default: true
+    label: Use a builtin whitelist of roles to limit what developers can do on binding
+      Google CloudSQL PostgreSQL instances
+    configurable: true
+  - name: gsb_service_google_ml_apis_whitelist_enabled
+    type: boolean
+    default: true
+    label: Use a builtin whitelist of roles to limit what developers can do on binding
+      Google Machine Learning APIs instances
+    configurable: true
+  - name: gsb_service_google_pubsub_whitelist_enabled
+    type: boolean
+    default: true
+    label: Use a builtin whitelist of roles to limit what developers can do on binding
+      Google PubSub instances
+    configurable: true
+  - name: gsb_service_google_spanner_whitelist_enabled
+    type: boolean
+    default: true
+    label: Use a builtin whitelist of roles to limit what developers can do on binding
+      Google Spanner instances
+    configurable: true
+  - name: gsb_service_google_storage_whitelist_enabled
+    type: boolean
+    default: true
+    label: Use a builtin whitelist of roles to limit what developers can do on binding
+      Google Cloud Storage instances
+    configurable: true
 service_plan_forms:
+- name: bigtable_custom_plans
+  label: Google Bigtable Custom Plans
+  description: Generate custom plans for Google Bigtable
+  optional: true
+  properties:
+  - name: display_name
+    type: string
+    label: Display Name
+    description: Display name
+    configurable: true
+  - name: description
+    type: string
+    label: Plan description
+    description: Plan description
+    configurable: true
+  - name: service
+    type: dropdown_select
+    default: b8e19880-ac58-42ef-b033-f7cd9c94d1fe
+    label: Service
+    description: The service this plan is associated with
+    options:
+    - name: b8e19880-ac58-42ef-b033-f7cd9c94d1fe
+      label: Google Bigtable
+  - name: storage_type
+    type: dropdown_select
+    default: SSD
+    label: Storage Type
+    description: Either HDD or SSD (see https://cloud.google.com/bigtable/pricing
+      for more information)
+    configurable: true
+    options:
+    - name: SSD
+      label: SSD - Solid-state Drive
+    - name: HDD
+      label: HDD - Hard Disk Drive
+  - name: num_nodes
+    type: string
+    default: "3"
+    label: Num Nodes
+    description: Number of Nodes, Between 3 and 30 (see https://cloud.google.com/bigtable/pricing
+      for more information)
+    configurable: true
 - name: cloudsql_mysql_custom_plans
   label: Google CloudSQL MySQL Custom Plans
   description: Generate custom plans for Google CloudSQL MySQL
@@ -160,6 +259,7 @@ service_plan_forms:
     configurable: true
   - name: service
     type: dropdown_select
+    default: 4bc59b9a-8520-409f-85da-1c7552315863
     label: Service
     description: The service this plan is associated with
     options:
@@ -178,10 +278,10 @@ service_plan_forms:
     description: Select a pricing plan (only for 1st generation instances)
     configurable: true
     options:
-    - name: PER_USE
-      label: Per-Use
     - name: PACKAGE
       label: Package
+    - name: PER_USE
+      label: Per-Use
     optional: true
   - name: max_disk_size
     type: string
@@ -208,6 +308,7 @@ service_plan_forms:
     configurable: true
   - name: service
     type: dropdown_select
+    default: cbad6d78-a73c-432d-b8ff-b219a17a803a
     label: Service
     description: The service this plan is associated with
     options:
@@ -216,7 +317,7 @@ service_plan_forms:
   - name: tier
     type: string
     label: Tier
-    description: a string of the form db-custom-[CPUS]-[MEMORY_MBS], where memory
+    description: A string of the form db-custom-[CPUS]-[MEMORY_MBS], where memory
       is at least 3840
     configurable: true
   - name: pricing_plan
@@ -232,47 +333,6 @@ service_plan_forms:
     default: "10"
     label: Max Disk Size
     description: Maximum disk size in GB (10 minimum/default)
-    configurable: true
-- name: bigtable_custom_plans
-  label: Google Bigtable Custom Plans
-  description: Generate custom plans for Google Bigtable
-  optional: true
-  properties:
-  - name: display_name
-    type: string
-    label: Display Name
-    description: Display name
-    configurable: true
-  - name: description
-    type: string
-    label: Plan description
-    description: Plan description
-    configurable: true
-  - name: service
-    type: dropdown_select
-    label: Service
-    description: The service this plan is associated with
-    options:
-    - name: b8e19880-ac58-42ef-b033-f7cd9c94d1fe
-      label: Google Bigtable
-  - name: storage_type
-    type: dropdown_select
-    default: SSD
-    label: Storage Type
-    description: Either HDD or SSD (see https://cloud.google.com/bigtable/pricing
-      for more information)
-    configurable: true
-    options:
-    - name: HDD
-      label: HDD - Hard Disk Drive
-    - name: SSD
-      label: SSD - Solid-state Drive
-  - name: num_nodes
-    type: string
-    default: "3"
-    label: Num Nodes
-    description: Number of Nodes, Between 3 and 30 (see https://cloud.google.com/bigtable/pricing
-      for more information)
     configurable: true
 - name: spanner_custom_plans
   label: Google Spanner Custom Plans
@@ -291,6 +351,7 @@ service_plan_forms:
     configurable: true
   - name: service
     type: dropdown_select
+    default: 51b3e27e-d323-49ce-8c5f-1211e6409e82
     label: Service
     description: The service this plan is associated with
     options:

--- a/tile.yml
+++ b/tile.yml
@@ -151,53 +151,61 @@ forms:
   label: Role Whitelisting
   description: Enable or disable role whitelisting
   properties:
-  - name: gsb_service_google_bigquery_whitelist_enabled
-    type: boolean
-    default: true
-    label: Use a builtin whitelist of roles to limit what developers can do on binding
-      Google BigQuery instances
+  - name: gsb_service_google_bigquery_whitelist
+    type: string
+    default: bigquery.dataViewer,bigquery.dataEditor,bigquery.dataOwner,bigquery.user,bigquery.jobUser
+    label: Role whitelist for Google BigQuery instances
+    description: A comma delimited list of roles (minus the role/ prefix) that can
+      be used when creating bound users for this service
     configurable: true
-  - name: gsb_service_google_bigtable_whitelist_enabled
-    type: boolean
-    default: true
-    label: Use a builtin whitelist of roles to limit what developers can do on binding
-      Google Bigtable instances
+  - name: gsb_service_google_bigtable_whitelist
+    type: string
+    default: bigtable.user,bigtable.reader,bigtable.viewer
+    label: Role whitelist for Google Bigtable instances
+    description: A comma delimited list of roles (minus the role/ prefix) that can
+      be used when creating bound users for this service
     configurable: true
-  - name: gsb_service_google_cloudsql_mysql_whitelist_enabled
-    type: boolean
-    default: true
-    label: Use a builtin whitelist of roles to limit what developers can do on binding
-      Google CloudSQL MySQL instances
+  - name: gsb_service_google_cloudsql_mysql_whitelist
+    type: string
+    default: cloudsql.editor,cloudsql.viewer,cloudsql.client
+    label: Role whitelist for Google CloudSQL MySQL instances
+    description: A comma delimited list of roles (minus the role/ prefix) that can
+      be used when creating bound users for this service
     configurable: true
-  - name: gsb_service_google_cloudsql_postgres_whitelist_enabled
-    type: boolean
-    default: true
-    label: Use a builtin whitelist of roles to limit what developers can do on binding
-      Google CloudSQL PostgreSQL instances
+  - name: gsb_service_google_cloudsql_postgres_whitelist
+    type: string
+    default: cloudsql.editor,cloudsql.viewer,cloudsql.client
+    label: Role whitelist for Google CloudSQL PostgreSQL instances
+    description: A comma delimited list of roles (minus the role/ prefix) that can
+      be used when creating bound users for this service
     configurable: true
-  - name: gsb_service_google_ml_apis_whitelist_enabled
-    type: boolean
-    default: true
-    label: Use a builtin whitelist of roles to limit what developers can do on binding
-      Google Machine Learning APIs instances
+  - name: gsb_service_google_ml_apis_whitelist
+    type: string
+    default: ml.developer,ml.viewer,ml.modelOwner,ml.modelUser,ml.jobOwner,ml.operationOwner
+    label: Role whitelist for Google Machine Learning APIs instances
+    description: A comma delimited list of roles (minus the role/ prefix) that can
+      be used when creating bound users for this service
     configurable: true
-  - name: gsb_service_google_pubsub_whitelist_enabled
-    type: boolean
-    default: true
-    label: Use a builtin whitelist of roles to limit what developers can do on binding
-      Google PubSub instances
+  - name: gsb_service_google_pubsub_whitelist
+    type: string
+    default: pubsub.publisher,pubsub.subscriber,pubsub.viewer,pubsub.editor
+    label: Role whitelist for Google PubSub instances
+    description: A comma delimited list of roles (minus the role/ prefix) that can
+      be used when creating bound users for this service
     configurable: true
-  - name: gsb_service_google_spanner_whitelist_enabled
-    type: boolean
-    default: true
-    label: Use a builtin whitelist of roles to limit what developers can do on binding
-      Google Spanner instances
+  - name: gsb_service_google_spanner_whitelist
+    type: string
+    default: spanner.databaseAdmin,spanner.databaseReader,spanner.databaseUser,spanner.viewer
+    label: Role whitelist for Google Spanner instances
+    description: A comma delimited list of roles (minus the role/ prefix) that can
+      be used when creating bound users for this service
     configurable: true
-  - name: gsb_service_google_storage_whitelist_enabled
-    type: boolean
-    default: true
-    label: Use a builtin whitelist of roles to limit what developers can do on binding
-      Google Cloud Storage instances
+  - name: gsb_service_google_storage_whitelist
+    type: string
+    default: storage.objectCreator,storage.objectViewer,storage.objectAdmin
+    label: Role whitelist for Google Cloud Storage instances
+    description: A comma delimited list of roles (minus the role/ prefix) that can
+      be used when creating bound users for this service
     configurable: true
 service_plan_forms:
 - name: bigtable_custom_plans
@@ -278,10 +286,10 @@ service_plan_forms:
     description: Select a pricing plan (only for 1st generation instances)
     configurable: true
     options:
-    - name: PACKAGE
-      label: Package
     - name: PER_USE
       label: Per-Use
+    - name: PACKAGE
+      label: Package
     optional: true
   - name: max_disk_size
     type: string


### PR DESCRIPTION
Created a whitelist of roles per service that can ensure nobody can bind to them with roles outside of the list. Can be selectively disabled per-service. The whitelists include non-legacy curated roles that do not have admin access over instances of the service.

The solution of looking up the role so late isn't ideal, but the circle-y imports will be fixed when the client gets refactored as part of 4.2.

Example bad request and response for GCS:

```
$ ./gcp-service-broker client bind --instanceid gcswl --params '{"role":"ml.admin"}' --serviceid b9e4332e-b42b-4680-bda5-ea1506797474 --config ../minimal.yml --planid e1d11f65-da66-46ad-977c-6d56513baf43 --bindingid bgcswlbad2
{
    "url": "http://user:pass@localhost:8000/v2/service_instances/gcswl/service_bindings/bgcswlbad2",
    "http_method": "PUT",
    "status_code": 500,
    "response": {
        "description": "The role ml.admin is not allowed for this service. You must use one of [storage.objectCreator storage.objectViewer storage.objectAdmin]."
    }
}
```

Another major feature of this PR is that the service account manager has been broken into multiple phases so we can start to bind/create service accounts with 0 or more roles. This opens up a clean-ish path toward fixing #170 

Fixes #257 