### PR TITLE
Simplify API handler

### DIFF
--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -43,7 +43,7 @@ import (
 
 var _ = Describe("Brokers", func() {
 	var (
-		gcpBroker                *GCPAsyncServiceBroker
+		gcpBroker                *GCPServiceBroker
 		brokerConfig             *config.BrokerConfig
 		err                      error
 		logger                   lager.Logger

--- a/brokerapi/brokers/config/broker_config.go
+++ b/brokerapi/brokers/config/broker_config.go
@@ -15,9 +15,6 @@
 package config
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
@@ -31,44 +28,30 @@ type BrokerConfig struct {
 }
 
 func NewBrokerConfigFromEnv() (*BrokerConfig, error) {
-	var err error
-	bc := BrokerConfig{}
-	creds, err := bc.GetCredentialsFromEnv()
-
+	projectId, err := utils.GetDefaultProjectId()
 	if err != nil {
-		return &BrokerConfig{}, err
+		return nil, err
 	}
-	bc.ProjectId = creds.ProjectId
+
 	conf, err := utils.GetAuthedConfig()
 	if err != nil {
-		return &BrokerConfig{}, err
+		return nil, err
 	}
-	bc.HttpConfig = conf
-	bc.Catalog, err = bc.InitCatalogFromEnv()
+
+	catalog, err := initCatalogFromEnv()
 	if err != nil {
-		return &BrokerConfig{}, err
+		return nil, err
 	}
 
-	return &bc, nil
-}
-
-// reads the service account json string from the environment variable ROOT_SERVICE_ACCOUNT_JSON, writes it to a file,
-// and then exports the file location to the environment variable GOOGLE_APPLICATION_CREDENTIALS, making it visible to
-// all google cloud apis
-func (bc *BrokerConfig) GetCredentialsFromEnv() (models.GCPCredentials, error) {
-	var err error
-	g := models.GCPCredentials{}
-
-	rootCreds := models.GetServiceAccountJson()
-	if err = json.Unmarshal([]byte(rootCreds), &g); err != nil {
-		return models.GCPCredentials{}, fmt.Errorf("Error unmarshalling service account json: %s", err)
-	}
-
-	return g, nil
+	return &BrokerConfig{
+		Catalog:    catalog,
+		ProjectId:  projectId,
+		HttpConfig: conf,
+	}, nil
 }
 
 // pulls SERVICES, PLANS, and environment variables to construct catalog
-func (bc *BrokerConfig) InitCatalogFromEnv() (map[string]models.Service, error) {
+func initCatalogFromEnv() (map[string]models.Service, error) {
 	serviceMap := make(map[string]models.Service)
 
 	for _, service := range broker.GetEnabledServices() {

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/pivotal-cf/brokerapi"
-	"github.com/spf13/viper"
 )
 
 //go:generate counterfeiter . ServiceBrokerHelper
@@ -48,19 +47,6 @@ type ServiceAccountManager interface {
 	CreateAccountWithRoles(bindingID string, roles []string) (ServiceBindingCredentials, error)
 }
 
-type GCPCredentials struct {
-	Type                string `json:"type"`
-	ProjectId           string `json:"project_id"`
-	PrivateKeyId        string `json:"private_key_id"`
-	PrivateKey          string `json:"private_key"`
-	ClientEmail         string `json:"client_email"`
-	ClientId            string `json:"client_id"`
-	AuthUri             string `json:"auth_uri"`
-	TokenUri            string `json:"token_uri"`
-	AuthProviderCertUrl string `json:"auth_provider_x509_cert_url"`
-	ClientCertUrl       string `json:"client_x509_cert_url"`
-}
-
 // This custom user agent string is added to provision calls so that Google can track the aggregated use of this tool
 // We can better advocate for devoting resources to supporting cloud foundry and this service broker if we can show
 // good usage statistics for it, so if you feel the need to fork this repo, please leave this string in place!
@@ -83,12 +69,3 @@ const StackdriverTraceName = "google-stackdriver-trace"
 const StackdriverDebuggerName = "google-stackdriver-debugger"
 const StackdriverProfilerName = "google-stackdriver-profiler"
 const DatastoreName = "google-datastore"
-const rootSaEnvVar = "ROOT_SERVICE_ACCOUNT_JSON"
-
-func init() {
-	viper.BindEnv("google.account", rootSaEnvVar)
-}
-
-func GetServiceAccountJson() string {
-	return viper.GetString("google.account")
-}

--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -63,9 +63,9 @@ func RunMigrations(db *gorm.DB) error {
 			return nil
 		}
 
-		serviceAccount := make(map[string]string)
-		if err := json.Unmarshal([]byte(models.GetServiceAccountJson()), &serviceAccount); err != nil {
-			return fmt.Errorf("Could not unmarshal service account details. %v", err)
+		projectId, err := utils.GetDefaultProjectId()
+		if err != nil {
+			return fmt.Errorf("couldn't get Project ID for database upgrades %s", err)
 		}
 
 		for _, pr := range prs {
@@ -95,7 +95,7 @@ func RunMigrations(db *gorm.DB) error {
 					return fmt.Errorf("Error creating new CloudSQL Client: %s", err)
 				}
 				dbService := googlecloudsql.NewInstancesService(sqlService)
-				clouddb, err := dbService.Get(serviceAccount["project_id"], od["instance_name"]).Do()
+				clouddb, err := dbService.Get(projectId, od["instance_name"]).Do()
 				if err != nil {
 					return fmt.Errorf("Error getting instance from api: %s", err)
 				}

--- a/integration_tests/async_integration_test.go
+++ b/integration_tests/async_integration_test.go
@@ -40,7 +40,7 @@ import (
 	instancepb "google.golang.org/genproto/googleapis/spanner/admin/instance/v1"
 )
 
-func pollLastOrTimeout(gcpb *GCPAsyncServiceBroker, instanceId string) error {
+func pollLastOrTimeout(gcpb *GCPServiceBroker, instanceId string) error {
 	var err error
 	timeout := time.After(10 * time.Minute)
 	tick := time.Tick(30 * time.Second)
@@ -63,7 +63,7 @@ func pollLastOrTimeout(gcpb *GCPAsyncServiceBroker, instanceId string) error {
 
 var _ = Describe("AsyncIntegrationTests", func() {
 	var (
-		gcpBroker            *GCPAsyncServiceBroker
+		gcpBroker            *GCPServiceBroker
 		brokerConfig         *config.BrokerConfig
 		err                  error
 		logger               lager.Logger

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -77,7 +77,7 @@ func getAndUnmarshalInstanceDetails(instanceId string) map[string]string {
 	return instanceDetails
 }
 
-func testGenericService(brokerConfig *config.BrokerConfig, gcpBroker *GCPAsyncServiceBroker, params *genericService) {
+func testGenericService(brokerConfig *config.BrokerConfig, gcpBroker *GCPServiceBroker, params *genericService) {
 	// If the service already exists (eg, failed previous test), clean it up before the run
 	if params.serviceExistsFn != nil && params.serviceExistsFn(false) {
 		params.cleanupFn()
@@ -166,7 +166,7 @@ func testGenericService(brokerConfig *config.BrokerConfig, gcpBroker *GCPAsyncSe
 }
 
 // For services that only create a service account and bind those credentials.
-func testIamBasedService(brokerConfig *config.BrokerConfig, gcpBroker *GCPAsyncServiceBroker, params *iamService) {
+func testIamBasedService(brokerConfig *config.BrokerConfig, gcpBroker *GCPServiceBroker, params *iamService) {
 	genericServiceParams := &genericService{
 		serviceId:        params.serviceId,
 		planId:           params.planId,
@@ -203,7 +203,7 @@ func generateInstanceName(projectId string, sep string) string {
 var _ = Describe("LiveIntegrationTests", func() {
 	var (
 		brokerConfig        *config.BrokerConfig
-		gcpBroker           *GCPAsyncServiceBroker
+		gcpBroker           *GCPServiceBroker
 		err                 error
 		logger              lager.Logger
 		serviceNameToId     map[string]string = make(map[string]string)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"fmt"
+	"os"
 )
 
 func ExamplePropertyToEnv() {
@@ -59,4 +60,14 @@ func ExampleUnmarshalObjectRemainder() {
 
 	// Output: {"C":123}, <nil>
 	// {}, <nil>
+}
+
+func ExampleGetDefaultProjectId() {
+	os.Setenv("ROOT_SERVICE_ACCOUNT_JSON", `{"project_id": "my-project-123"}`)
+	defer os.Unsetenv("ROOT_SERVICE_ACCOUNT_JSON")
+
+	projectId, err := GetDefaultProjectId()
+	fmt.Printf("%s, %v\n", projectId, err)
+
+	// Output: my-project-123, <nil>
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -63,7 +63,17 @@ func ExampleUnmarshalObjectRemainder() {
 }
 
 func ExampleGetDefaultProjectId() {
-	os.Setenv("ROOT_SERVICE_ACCOUNT_JSON", `{"project_id": "my-project-123"}`)
+	serviceAccountJson := `{
+	  "//": "Dummy account from https://github.com/GoogleCloudPlatform/google-cloud-java/google-cloud-clients/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java",
+	  "private_key_id": "somekeyid",
+	  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC+K2hSuFpAdrJI\nnCgcDz2M7t7bjdlsadsasad+fvRSW6TjNQZ3p5LLQY1kSZRqBqylRkzteMOyHgaR\n0Pmxh3ILCND5men43j3h4eDbrhQBuxfEMalkG92sL+PNQSETY2tnvXryOvmBRwa/\nQP/9dJfIkIDJ9Fw9N4Bhhhp6mCcRpdQjV38H7JsyJ7lih/oNjECgYAt\nknddadwkwewcVxHFhcZJO+XWf6ofLUXpRwiTZakGMn8EE1uVa2LgczOjwWHGi99MFjxSer5m9\n1tCa3/KEGKiS/YL71JvjwX3mb+cewlkcmweBKZHM2JPTk0ZednFSpVZMtycjkbLa\ndYOS8V85AgMBewECggEBAKksaldajfDZDV6nGqbFjMiizAKJolr/M3OQw16K6o3/\n0S31xIe3sSlgW0+UbYlF4U8KifhManD1apVSC3csafaspP4RZUHFhtBywLO9pR5c\nr6S5aLp+gPWFyIp1pfXbWGvc5VY/v9x7ya1VEa6rXvLsKupSeWAW4tMj3eo/64ge\nsdaceaLYw52KeBYiT6+vpsnYrEkAHO1fF/LavbLLOFJmFTMxmsNaG0tuiJHgjshB\n82DpMCbXG9YcCgI/DbzuIjsdj2JC1cascSP//3PmefWysucBQe7Jryb6NQtASmnv\nCdDw/0jmZTEjpe4S1lxfHplAhHFtdgYTvyYtaLZiVVkCgYEA8eVpof2rceecw/I6\n5ng1q3Hl2usdWV/4mZMvR0fOemacLLfocX6IYxT1zA1FFJlbXSRsJMf/Qq39mOR2\nSpW+hr4jCoHeRVYLgsbggtrevGmILAlNoqCMpGZ6vDmJpq6ECV9olliDvpPgWOP+\nmYPDreFBGxWvQrADNbRt2dmGsrsCgYEAyUHqB2wvJHFqdmeBsaacewzV8x9WgmeX\ngUIi9REwXlGDW0Mz50dxpxcKCAYn65+7TCnY5O/jmL0VRxU1J2mSWyWTo1C+17L0\n3fUqjxL1pkefwecxwecvC+gFFYdJ4CQ/MHHXU81Lwl1iWdFCd2UoGddYaOF+KNeM\nHC7cmqra+JsCgYEAlUNywzq8nUg7282E+uICfCB0LfwejuymR93CtsFgb7cRd6ak\nECR8FGfCpH8ruWJINllbQfcHVCX47ndLZwqv3oVFKh6pAS/vVI4dpOepP8++7y1u\ncoOvtreXCX6XqfrWDtKIvv0vjlHBhhhp6mCcRpdQjV38H7JsyJ7lih/oNjECgYAt\nkndj5uNl5SiuVxHFhcZJO+XWf6ofLUregtevZakGMn8EE1uVa2AY7eafmoU/nZPT\n00YB0TBATdCbn/nBSuKDESkhSg9s2GEKQZG5hBmL5uCMfo09z3SfxZIhJdlerreP\nJ7gSidI12N+EZxYd4xIJh/HFDgp7RRO87f+WJkofMQKBgGTnClK1VMaCRbJZPriw\nEfeFCoOX75MxKwXs6xgrw4W//AYGGUjDt83lD6AZP6tws7gJ2IwY/qP7+lyhjEqN\nHtfPZRGFkGZsdaksdlaksd323423d+15/UvrlRSFPNj1tWQmNKkXyRDW4IG1Oa2p\nrALStNBx5Y9t0/LQnFI4w3aG\n-----END PRIVATE KEY-----\n",
+	  "client_email": "someclientid@developer.gserviceaccount.com",
+	  "client_id": "someclientid.apps.googleusercontent.com",
+	  "type": "service_account",
+	  "project_id": "my-project-123"
+	}`
+
+	os.Setenv("ROOT_SERVICE_ACCOUNT_JSON", serviceAccountJson)
 	defer os.Unsetenv("ROOT_SERVICE_ACCOUNT_JSON")
 
 	projectId, err := GetDefaultProjectId()


### PR DESCRIPTION
This is purely a refactor with no functionality changes expected.

- Added comments to the handler.
- Brought logging into line with the REST API (what is logged will match what is passed in the URL).
- Removed unnecessary GCPAsyncServiceBroker.
- Simplified and de-duplicated Project ID detection.
