### PR TITLE
fix go_vet, ineffassign, and misspell errors

### DIFF
--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -423,7 +423,7 @@ func (b *CloudSQLBroker) ensureUsernamePassword(instanceID, bindingID string, de
 }
 
 // Bind creates a new username, password, and set of ssl certs for the given instance.
-// The function may be slow to return because CloudSQL operations are asyncronous.
+// The function may be slow to return because CloudSQL operations are asynchronous.
 // The default PCF service broker timeout may need to be raised to 90 or 120 seconds to accommodate the long bind time.
 func (b *CloudSQLBroker) Bind(instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
 

--- a/brokerapi/brokers/pubsub/broker.go
+++ b/brokerapi/brokers/pubsub/broker.go
@@ -45,7 +45,7 @@ type InstanceInformation struct {
 }
 
 // Provision creates a new Pub/Sub topic from the settings in the user-provided details and service plan.
-// If a subscription name is supplied, the funciton will also create a subscription for the topic.
+// If a subscription name is supplied, the function will also create a subscription for the topic.
 func (b *PubSubBroker) Provision(instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
 
 	var err error
@@ -85,7 +85,7 @@ func (b *PubSubBroker) Provision(instanceId string, details brokerapi.ProvisionD
 		TopicName: params["topic_name"],
 	}
 
-	if sub_name, ok := params["subscription_name"]; ok {
+	if subscriptionName, ok := params["subscription_name"]; ok {
 		var pushConfig googlepubsub.PushConfig
 		var ackDeadline = 10
 
@@ -110,7 +110,7 @@ func (b *PubSubBroker) Provision(instanceId string, details brokerapi.ProvisionD
 			AckDeadline: time.Duration(ackDeadline) * time.Second,
 		}
 
-		_, err = pubsubClient.CreateSubscription(ctx, sub_name, subsConfig)
+		_, err = pubsubClient.CreateSubscription(ctx, subscriptionName, subsConfig)
 		if err != nil {
 			return models.ServiceInstanceDetails{}, fmt.Errorf("Error creating subscription: %s", err)
 		}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -136,7 +136,7 @@ user-defined plans.
 	bindFlag(&bindingId, "bindingid", "GUID of the binding to work on (user defined)", bindCmd, unbindCmd)
 
 	for _, sc := range []*cobra.Command{provisionCmd, bindCmd} {
-		sc.Flags().StringVarP(&parametersJson, "params", "", "{}", "JSON string of user-defined paramaters to pass to the request")
+		sc.Flags().StringVarP(&parametersJson, "params", "", "{}", "JSON string of user-defined parameters to pass to the request")
 	}
 
 	runExamplesCmd.Flags().StringVarP(&serviceName, "service-name", "", "", "name of the service to run tests for")

--- a/cmd/get_plan_info.go
+++ b/cmd/get_plan_info.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"fmt"
+	"log"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
@@ -35,7 +35,7 @@ func init() {
 
 			var pds []*models.PlanDetailsV1
 			if err := db.Find(&pds).Error; err != nil {
-				fmt.Errorf("Could not retrieve plan details rows from db: %s", err)
+				log.Fatalf("Could not retrieve plan details rows from db: %s", err)
 			}
 
 			utils.PrettyPrintOrExit(pds)

--- a/integration_tests/async_integration_test.go
+++ b/integration_tests/async_integration_test.go
@@ -89,8 +89,8 @@ var _ = Describe("AsyncIntegrationTests", func() {
 		brokerConfig, err = config.NewBrokerConfigFromEnv()
 
 		if err != nil {
-			panic(err.Error())
 			logger.Error("error", err)
+			panic(err.Error())
 		}
 
 		instance_name = generateInstanceName(brokerConfig.ProjectId, "-")
@@ -172,6 +172,7 @@ var _ = Describe("AsyncIntegrationTests", func() {
 
 			// make sure google no longer has certs
 			certsList, err := sslService.List(brokerConfig.ProjectId, cloudsqlInstanceName).Do()
+			Expect(err).NotTo(HaveOccurred())
 			Expect(len(certsList.Items)).To(Equal(0))
 
 			// deprovision the instance
@@ -275,6 +276,7 @@ var _ = Describe("AsyncIntegrationTests", func() {
 
 			// make sure google no longer has certs
 			certsList, err := sslService.List(brokerConfig.ProjectId, cloudsqlInstanceName).Do()
+			Expect(err).NotTo(HaveOccurred())
 			Expect(len(certsList.Items)).To(Equal(0))
 
 			// deprovision the instance

--- a/pkg/broker/example.go
+++ b/pkg/broker/example.go
@@ -19,7 +19,7 @@ package broker
 type ServiceExample struct {
 	// Name is a human-readable name of the example.
 	Name string
-	// Descrpition is a long-form description of what this example is about.
+	// Description is a long-form description of what this example is about.
 	Description string
 	// PlanId is the plan this example will run against.
 	PlanId string


### PR DESCRIPTION
Part of #207 this fixes problems in our [go report card](https://goreportcard.com/report/github.com/GoogleCloudPlatform/gcp-service-broker).

Once this and #271 are in, we can also run gofmt for another part of #207.