### PR TITLE
added label support for bigquery, cloudsql, spanner and gcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The ability to turn on/off services via environment variable.
 - Default plans for Spanner, BigTable, and CloudSQL.
 - Whitelists for bindings so only certain "safe" roles can be chosen by end-users.
+- Automatic labeling of resources with organizaiton GUID, space GUID, and instance ID to BigQuery, CloudSQL, Spanner, and GCS.
 
 ### Deprecated
 - Running the service by executing the main executable. Use the `serve` sub-command instead.

--- a/brokerapi/brokers/bigquery/broker.go
+++ b/brokerapi/brokers/bigquery/broker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/name_generator"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
 	googlebigquery "google.golang.org/api/bigquery/v2"
 )
@@ -68,6 +69,7 @@ func (b *BigQueryBroker) Provision(instanceId string, details brokerapi.Provisio
 		DatasetReference: &googlebigquery.DatasetReference{
 			DatasetId: params["name"],
 		},
+		Labels: utils.ExtractDefaultLabels(instanceId, details),
 	}
 	new_dataset, err := service.Datasets.Insert(b.ProjectId, &d).Do()
 	if err != nil {

--- a/brokerapi/brokers/spanner/broker.go
+++ b/brokerapi/brokers/spanner/broker.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/name_generator"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
 	"google.golang.org/api/option"
 	instancepb "google.golang.org/genproto/googleapis/spanner/admin/instance/v1"
@@ -94,6 +95,7 @@ func (s *SpannerBroker) Provision(instanceId string, details brokerapi.Provision
 			DisplayName: displayName,
 			NodeCount:   int32(numNodes),
 			Config:      loc,
+			Labels:      utils.ExtractDefaultLabels(instanceId, details),
 		},
 	})
 	if err != nil {

--- a/brokerapi/brokers/storage/broker.go
+++ b/brokerapi/brokers/storage/broker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/name_generator"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
@@ -77,6 +78,7 @@ func (b *StorageBroker) Provision(instanceId string, details brokerapi.Provision
 		Name:         params["name"],
 		StorageClass: storageClass,
 		Location:     loc,
+		Labels:       utils.ExtractDefaultLabels(instanceId, details),
 	}
 
 	// create the bucket. Nil uses default bucket attributes

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,0 +1,25 @@
+# Billing
+
+The GCP Service Broker automatically labels supported resources with organization GUID, space GUID and instance ID.
+
+When these supported services are provisioned, they will have the following labels populated with information from the request:
+
+ * `pcf-organization-guid`
+ * `pcf-space-guid`
+ * `pcf-instance-id`
+
+GCP labels have a more restricted character set than the Service Broker so unsupported characters will be mapped to the underscore character (`_`).
+
+## Support
+
+The following resources support these automatically generated labels:
+
+ * BigQuery
+ * CloudSQL (PostgreSQL and MySQL)
+ * Cloud Storage
+ * Spanner
+
+## Usage
+
+You can use these labels with the [BigQuery Billing Export](https://cloud.google.com/billing/docs/how-to/bq-examples)
+to create reports about which organizations and spaces are incurring cost in your GCP project.


### PR DESCRIPTION
Related to #251. Add labels to services that support them indicating the organization ID, space ID and instance ID to better support billing.