### PR TITLE
don't use panics as flow-control

### DIFF
--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -144,8 +144,16 @@ func (sam *ServiceAccountManager) DeleteCredentials(binding models.ServiceBindin
 }
 
 func (b *ServiceAccountManager) BuildInstanceCredentials(bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]string, error) {
-	bindDetails := bindRecord.GetOtherDetails()
-	instanceDetails := instanceRecord.GetOtherDetails()
+	bindDetails, err := bindRecord.GetOtherDetails()
+	if err != nil {
+		return nil, err
+	}
+
+	instanceDetails, err := instanceRecord.GetOtherDetails()
+	if err != nil {
+		return nil, err
+	}
+
 	return utils.MergeStringMaps(bindDetails, instanceDetails), nil
 }
 

--- a/brokerapi/brokers/account_managers/sql_account_manager.go
+++ b/brokerapi/brokers/account_managers/sql_account_manager.go
@@ -180,8 +180,15 @@ func (sam *SqlAccountManager) pollOperationUntilDone(op *googlecloudsql.Operatio
 }
 
 func (b *SqlAccountManager) BuildInstanceCredentials(bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]string, error) {
-	instanceDetails := instanceRecord.GetOtherDetails()
-	bindDetails := bindRecord.GetOtherDetails()
+	instanceDetails, err := instanceRecord.GetOtherDetails()
+	if err != nil {
+		return nil, err
+	}
+
+	bindDetails, err := bindRecord.GetOtherDetails()
+	if err != nil {
+		return nil, err
+	}
 
 	service, err := broker.GetServiceById(instanceRecord.ServiceId)
 	if err != nil {

--- a/brokerapi/brokers/broker_base/broker_base.go
+++ b/brokerapi/brokers/broker_base/broker_base.go
@@ -15,6 +15,8 @@
 package broker_base
 
 import (
+	"errors"
+
 	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 
@@ -68,5 +70,5 @@ func (b *BrokerBase) DeprovisionsAsync() bool {
 // determine if the workflow is a provision or deprovision flow based off the
 // type of the most recent operation.
 func (b *BrokerBase) LastOperationWasDelete(instanceId string) (bool, error) {
-	panic("Can't check last operation on a synchronous service")
+	return false, errors.New("can't check last operation on a synchronous service")
 }

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -396,7 +396,7 @@ func (gcpBroker *GCPServiceBroker) lastOperationAsync(instanceId string, service
 	// no error and we're done! Delete from the SB database if this was a delete flow and return success
 	deleteFlow, err := service.LastOperationWasDelete(instanceId)
 	if err != nil {
-		return brokerapi.LastOperation{State: brokerapi.Succeeded}, fmt.Errorf("Couldn't determine if provision or deprovision flow, this may leave orphaned resources, contact your operator for cleanup")
+		return brokerapi.LastOperation{State: brokerapi.Succeeded}, fmt.Errorf("Couldn't determine if provision or deprovision flow, this may leave orphaned resources, contact your operator for cleanup: %s", err)
 	}
 	if deleteFlow {
 		err = db_service.DeleteServiceInstanceDetailsById(instanceId)

--- a/brokerapi/brokers/models/db.go
+++ b/brokerapi/brokers/models/db.go
@@ -23,7 +23,7 @@ import (
 type ServiceBindingCredentials ServiceBindingCredentialsV1
 
 // GetOtherDetails returns an unmarshaled version of the OtherDetails field
-// or panics.
+// or errors.
 func (sbc ServiceBindingCredentials) GetOtherDetails() (map[string]string, error) {
 	var creds map[string]string
 	err := json.Unmarshal([]byte(sbc.OtherDetails), &creds)

--- a/brokerapi/brokers/models/db.go
+++ b/brokerapi/brokers/models/db.go
@@ -30,8 +30,7 @@ func (sbc ServiceBindingCredentials) GetOtherDetails() (map[string]string, error
 	return creds, err
 }
 
-// ServiceInstanceDetails returns an unmarshaled version of the OtherDetails field
-// or panics.
+// ServiceInstanceDetails holds information about provisioned services 
 type ServiceInstanceDetails ServiceInstanceDetailsV1
 
 // GetOtherDetails returns an unmarshaled version of the OtherDetails field

--- a/brokerapi/brokers/models/db.go
+++ b/brokerapi/brokers/models/db.go
@@ -24,12 +24,10 @@ type ServiceBindingCredentials ServiceBindingCredentialsV1
 
 // GetOtherDetails returns an unmarshaled version of the OtherDetails field
 // or panics.
-func (sbc ServiceBindingCredentials) GetOtherDetails() map[string]string {
+func (sbc ServiceBindingCredentials) GetOtherDetails() (map[string]string, error) {
 	var creds map[string]string
-	if err := json.Unmarshal([]byte(sbc.OtherDetails), &creds); err != nil {
-		panic(err)
-	}
-	return creds
+	err := json.Unmarshal([]byte(sbc.OtherDetails), &creds)
+	return creds, err
 }
 
 // ServiceInstanceDetails returns an unmarshaled version of the OtherDetails field
@@ -37,17 +35,15 @@ func (sbc ServiceBindingCredentials) GetOtherDetails() map[string]string {
 type ServiceInstanceDetails ServiceInstanceDetailsV1
 
 // GetOtherDetails returns an unmarshaled version of the OtherDetails field
-// or panics.
-func (si ServiceInstanceDetails) GetOtherDetails() map[string]string {
+// or errors.
+func (si ServiceInstanceDetails) GetOtherDetails() (map[string]string, error) {
 	var instanceDetails map[string]string
-	// if the instance has access details saved
-	if si.OtherDetails != "" {
-		if err := json.Unmarshal([]byte(si.OtherDetails), &instanceDetails); err != nil {
-			panic(err)
-		}
+	if si.OtherDetails == "" {
+		return instanceDetails, nil
 	}
-	return instanceDetails
 
+	err := json.Unmarshal([]byte(si.OtherDetails), &instanceDetails)
+	return instanceDetails, err
 }
 
 // ProvisionRequestDetails holds user-defined properties passed to a call

--- a/integration_tests/async_integration_test.go
+++ b/integration_tests/async_integration_test.go
@@ -87,11 +87,7 @@ var _ = Describe("AsyncIntegrationTests", func() {
 		fakes.SetUpTestServices()
 
 		brokerConfig, err = config.NewBrokerConfigFromEnv()
-
-		if err != nil {
-			logger.Error("error", err)
-			panic(err.Error())
-		}
+		Expect(err).NotTo(HaveOccurred())
 
 		instance_name = generateInstanceName(brokerConfig.ProjectId, "-")
 


### PR DESCRIPTION
Fixes #228. Rather than using `panic` as a flow-control device, use `error` instead.

This mostly affects tests, which I've updated and re-ran to validate.