### PR TITLE
Schema support

### DIFF
--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -59,8 +59,21 @@ func init() {
 			{
 				FieldName: "name",
 				Type:      broker.JsonTypeString,
-				Details:   "The name of the BigQuery dataset. Must be alphanumeric (plus underscores) and must be at most 1024 characters long.",
+				Details:   "The name of the BigQuery dataset.",
 				Default:   "a generated value",
+				Constraints: map[string]interface{}{
+					"pattern":   "^[A-Za-z0-9_]+$",
+					"maxLength": 1024,
+				},
+			},
+			{
+				FieldName: "location",
+				Type:      broker.JsonTypeString,
+				Details:   "The location of the BigQuery instance.",
+				Default:   "US",
+				Constraints: map[string]interface{}{
+					"examples": []string{"US", "EU", "asia-northeast1"},
+				},
 			},
 		},
 		DefaultRoleWhitelist: roleWhitelist,

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -73,6 +73,7 @@ func init() {
 				Details:   "The location of the BigQuery instance.",
 				Default:   "US",
 				Constraints: validation.NewConstraintBuilder().
+					Pattern("^[A-Za-z][-a-z0-9A-Z]+$").
 					Examples("US", "EU", "asia-northeast1").
 					Build(),
 			},

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -17,6 +17,7 @@ package bigquery
 import (
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 )
 
 func init() {
@@ -61,19 +62,19 @@ func init() {
 				Type:      broker.JsonTypeString,
 				Details:   "The name of the BigQuery dataset.",
 				Default:   "a generated value",
-				Constraints: map[string]interface{}{
-					"pattern":   "^[A-Za-z0-9_]+$",
-					"maxLength": 1024,
-				},
+				Constraints: validation.NewConstraintBuilder().
+					Pattern("^[A-Za-z0-9_]+$").
+					MaxLength(1024).
+					Build(),
 			},
 			{
 				FieldName: "location",
 				Type:      broker.JsonTypeString,
 				Details:   "The location of the BigQuery instance.",
 				Default:   "US",
-				Constraints: map[string]interface{}{
-					"examples": []string{"US", "EU", "asia-northeast1"},
-				},
+				Constraints: validation.NewConstraintBuilder().
+					Examples("US", "EU", "asia-northeast1").
+					Build(),
 			},
 		},
 		DefaultRoleWhitelist: roleWhitelist,

--- a/docs/use.md
+++ b/docs/use.md
@@ -15,7 +15,11 @@ A fast, economical and fully managed data warehouse for large-scale data analyti
 **Request Parameters**
 
 
- * `name` _string_ - The name of the BigQuery dataset. Must be alphanumeric (plus underscores) and must be at most 1024 characters long. Default: `a generated value`.
+ * `name` _string_ - The name of the BigQuery dataset. Default: `a generated value`.
+  * The string must have at most 1024 characters.
+  * The string must match the regular expression `^[A-Za-z0-9_]+$`.
+ * `location` _string_ - The location of the BigQuery instance. Default: `US`.
+  * Examples: [US EU asia-northeast1].
 
 
 ## Binding
@@ -197,8 +201,10 @@ Google Cloud SQL is a fully-managed MySQL database service.
  * `backup_start_time` _string_ - Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM. Default: `06:00`.
  * `binlog` _string_ - Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.
  * `activation_policy` _string_ - The activation policy specifies when the instance is activated; it is applicable only when the instance state is RUNNABLE. Default: `ON_DEMAND`.
+  * The value must be one of: [NEVER ON_DEMAND ALWAYS].
  * `authorized_networks` _string_ - A comma separated list without spaces. Default: `none`.
  * `replication_type` _string_ - The type of replication this instance uses. This can be either ASYNCHRONOUS or SYNCHRONOUS. Default: `SYNCHRONOUS`.
+  * The value must be one of: [SYNCHRONOUS ASYNCHRONOUS].
  * `auto_resize` _string_ - (only for 2nd generation instances) Configuration to increase storage size automatically. Default: `false`.
 
 
@@ -324,8 +330,10 @@ Google Cloud SQL is a fully-managed MySQL database service.
  * `backup_start_time` _string_ - Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM. Default: `06:00`.
  * `binlog` _string_ - Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.
  * `activation_policy` _string_ - The activation policy specifies when the instance is activated; it is applicable only when the instance state is RUNNABLE. Default: `ON_DEMAND`.
+  * The value must be one of: [ALWAYS NEVER ON_DEMAND].
  * `authorized_networks` _string_ - A comma separated list without spaces. Default: `none`.
  * `replication_type` _string_ - The type of replication this instance uses. This can be either ASYNCHRONOUS or SYNCHRONOUS. Default: `SYNCHRONOUS`.
+  * The value must be one of: [ASYNCHRONOUS SYNCHRONOUS].
  * `auto_resize` _string_ - (only for 2nd generation instances) Configuration to increase storage size automatically. Default: `false`.
 
 

--- a/docs/use.md
+++ b/docs/use.md
@@ -16,10 +16,10 @@ A fast, economical and fully managed data warehouse for large-scale data analyti
 
 
  * `name` _string_ - The name of the BigQuery dataset. Default: `a generated value`.
-  * The string must have at most 1024 characters.
-  * The string must match the regular expression `^[A-Za-z0-9_]+$`.
+    * The string must have at most 1024 characters.
+    * The string must match the regular expression `^[A-Za-z0-9_]+$`.
  * `location` _string_ - The location of the BigQuery instance. Default: `US`.
-  * Examples: [US EU asia-northeast1].
+    * Examples: [US EU asia-northeast1].
 
 
 ## Binding
@@ -201,10 +201,10 @@ Google Cloud SQL is a fully-managed MySQL database service.
  * `backup_start_time` _string_ - Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM. Default: `06:00`.
  * `binlog` _string_ - Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.
  * `activation_policy` _string_ - The activation policy specifies when the instance is activated; it is applicable only when the instance state is RUNNABLE. Default: `ON_DEMAND`.
-  * The value must be one of: [NEVER ON_DEMAND ALWAYS].
+    * The value must be one of: [ALWAYS NEVER ON_DEMAND].
  * `authorized_networks` _string_ - A comma separated list without spaces. Default: `none`.
  * `replication_type` _string_ - The type of replication this instance uses. This can be either ASYNCHRONOUS or SYNCHRONOUS. Default: `SYNCHRONOUS`.
-  * The value must be one of: [SYNCHRONOUS ASYNCHRONOUS].
+    * The value must be one of: [ASYNCHRONOUS SYNCHRONOUS].
  * `auto_resize` _string_ - (only for 2nd generation instances) Configuration to increase storage size automatically. Default: `false`.
 
 
@@ -330,10 +330,10 @@ Google Cloud SQL is a fully-managed MySQL database service.
  * `backup_start_time` _string_ - Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM. Default: `06:00`.
  * `binlog` _string_ - Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.
  * `activation_policy` _string_ - The activation policy specifies when the instance is activated; it is applicable only when the instance state is RUNNABLE. Default: `ON_DEMAND`.
-  * The value must be one of: [ALWAYS NEVER ON_DEMAND].
+    * The value must be one of: [ALWAYS NEVER ON_DEMAND].
  * `authorized_networks` _string_ - A comma separated list without spaces. Default: `none`.
  * `replication_type` _string_ - The type of replication this instance uses. This can be either ASYNCHRONOUS or SYNCHRONOUS. Default: `SYNCHRONOUS`.
-  * The value must be one of: [ASYNCHRONOUS SYNCHRONOUS].
+    * The value must be one of: [ASYNCHRONOUS SYNCHRONOUS].
  * `auto_resize` _string_ - (only for 2nd generation instances) Configuration to increase storage size automatically. Default: `false`.
 
 

--- a/docs/use.md
+++ b/docs/use.md
@@ -20,6 +20,7 @@ A fast, economical and fully managed data warehouse for large-scale data analyti
     * The string must match the regular expression `^[A-Za-z0-9_]+$`.
  * `location` _string_ - The location of the BigQuery instance. Default: `US`.
     * Examples: [US EU asia-northeast1].
+    * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
 
 
 ## Binding

--- a/pkg/broker/variables.go
+++ b/pkg/broker/variables.go
@@ -37,4 +37,40 @@ type BrokerVariable struct {
 	// If there are a limited number of valid values for this field then
 	// Enum will hold them in value:friendly name pairs
 	Enum map[interface{}]string
+	// Constraints holds JSON Schema validations defined for this variable.
+	// Keys are valid JSON Schema validation keywords, and values are their
+	// associated values.
+	Constraints map[string]interface{}
+}
+
+// ToSchema converts the BrokerVariable into the value part of a JSON Scheama
+func (bv *BrokerVariable) ToSchema() map[string]interface{} {
+	schema := map[string]interface{}{}
+
+	for k, v := range bv.Constraints {
+		schema[k] = v
+	}
+
+	if len(bv.Enum) > 0 {
+		enumeration := []interface{}{}
+		for k, _ := range bv.Enum {
+			enumeration = append(enumeration, k)
+		}
+
+		schema["enum"] = enumeration
+	}
+
+	if bv.Details != "" {
+		schema["description"] = bv.Details
+	}
+
+	if bv.Type != "" {
+		schema["type"] = bv.Type
+	}
+
+	if bv.Default != nil {
+		schema["default"] = bv.Default
+	}
+
+	return schema
 }

--- a/pkg/broker/variables.go
+++ b/pkg/broker/variables.go
@@ -14,6 +14,11 @@
 
 package broker
 
+import (
+	"fmt"
+	"sort"
+)
+
 const (
 	JsonTypeString  JsonType = "string"
 	JsonTypeNumeric JsonType = "number"
@@ -56,6 +61,11 @@ func (bv *BrokerVariable) ToSchema() map[string]interface{} {
 		for k, _ := range bv.Enum {
 			enumeration = append(enumeration, k)
 		}
+
+		// Sort enumerations lexocographically for documentation consistency.
+		sort.Slice(enumeration, func(i int, j int) bool {
+			return fmt.Sprintf("%v", enumeration[i]) < fmt.Sprintf("%v", enumeration[j])
+		})
 
 		schema["enum"] = enumeration
 	}

--- a/pkg/broker/variables.go
+++ b/pkg/broker/variables.go
@@ -17,6 +17,8 @@ package broker
 import (
 	"fmt"
 	"sort"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 )
 
 const (
@@ -67,19 +69,19 @@ func (bv *BrokerVariable) ToSchema() map[string]interface{} {
 			return fmt.Sprintf("%v", enumeration[i]) < fmt.Sprintf("%v", enumeration[j])
 		})
 
-		schema["enum"] = enumeration
+		schema[validation.KeyEnum] = enumeration
 	}
 
 	if bv.Details != "" {
-		schema["description"] = bv.Details
+		schema[validation.KeyDescription] = bv.Details
 	}
 
 	if bv.Type != "" {
-		schema["type"] = bv.Type
+		schema[validation.KeyType] = bv.Type
 	}
 
 	if bv.Default != nil {
-		schema["default"] = bv.Default
+		schema[validation.KeyDefault] = bv.Default
 	}
 
 	return schema

--- a/pkg/broker/variables.go
+++ b/pkg/broker/variables.go
@@ -47,10 +47,11 @@ type BrokerVariable struct {
 	// Constraints holds JSON Schema validations defined for this variable.
 	// Keys are valid JSON Schema validation keywords, and values are their
 	// associated values.
+	// http://json-schema.org/latest/json-schema-validation.html
 	Constraints map[string]interface{}
 }
 
-// ToSchema converts the BrokerVariable into the value part of a JSON Scheama
+// ToSchema converts the BrokerVariable into the value part of a JSON Schema.
 func (bv *BrokerVariable) ToSchema() map[string]interface{} {
 	schema := map[string]interface{}{}
 

--- a/pkg/broker/variables_test.go
+++ b/pkg/broker/variables_test.go
@@ -1,0 +1,82 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBrokerVariable_ToSchema(t *testing.T) {
+	cases := map[string]struct {
+		BrokerVar BrokerVariable
+		Expected  map[string]interface{}
+	}{
+		"blank": {
+			BrokerVariable{}, map[string]interface{}{},
+		},
+		"enums get copied": {
+			BrokerVariable{Enum: map[interface{}]string{"a": "description", "b": "description"}},
+			map[string]interface{}{
+				"enum": []interface{}{"a", "b"},
+			},
+		},
+		"details are copied": {
+			BrokerVariable{Details: "more information"},
+			map[string]interface{}{
+				"description": "more information",
+			},
+		},
+		"type is copied": {
+			BrokerVariable{Type: JsonTypeString},
+			map[string]interface{}{
+				"type": JsonTypeString,
+			},
+		},
+		"default is copied": {
+			BrokerVariable{Default: "some-value"},
+			map[string]interface{}{
+				"default": "some-value",
+			},
+		},
+		"full test": {
+			BrokerVariable{
+				Default: "some-value",
+				Type:    JsonTypeString,
+				Details: "more information",
+				Enum:    map[interface{}]string{"a": "description", "b": "description"},
+				Constraints: map[string]interface{}{
+					"examples": []string{"SAMPLEA", "SAMPLEB"},
+				},
+			},
+			map[string]interface{}{
+				"default":     "some-value",
+				"type":        JsonTypeString,
+				"description": "more information",
+				"enum":        []interface{}{"a", "b"},
+				"examples":    []string{"SAMPLEA", "SAMPLEB"},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual := tc.BrokerVar.ToSchema()
+			if !reflect.DeepEqual(actual, tc.Expected) {
+				t.Errorf("Expected ToSchema to be: %v, got: %v", tc.Expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/broker/variables_test.go
+++ b/pkg/broker/variables_test.go
@@ -56,7 +56,7 @@ func TestBrokerVariable_ToSchema(t *testing.T) {
 				Default: "some-value",
 				Type:    JsonTypeString,
 				Details: "more information",
-				Enum:    map[interface{}]string{"a": "description", "b": "description"},
+				Enum:    map[interface{}]string{"b": "description", "a": "description"},
 				Constraints: map[string]interface{}{
 					"examples": []string{"SAMPLEA", "SAMPLEB"},
 				},

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -195,45 +195,48 @@ func varNotes(variable broker.BrokerVariable) string {
 	return out
 }
 
+type constraintFormatter struct {
+	SchemaKey string
+	DocString string
+}
+
+// We use an anonymous struct rather than a map to get a strict ordering of
+// constraints so they are generated consistently in documentation.
+// Not all JSON Schema constraints can be cleanly expressed in this format,
+// nor do we use them all so some are missing.
+var constraintFormatters = []constraintFormatter{
+	// Schema Annotations
+	{validation.KeyExamples, "Examples: %+v."},
+
+	// Validation for any instance type
+	{validation.KeyEnum, "The value must be one of: %+v."},
+	{validation.KeyConst, "The value must be: `%v`."},
+
+	// Validation keywords for numeric instances
+	{validation.KeyMultipleOf, "The value must be a multiple of %v."},
+	{validation.KeyMaximum, "The value must be less than or equal to %v."},
+	{validation.KeyExclusiveMaximum, "The value must be strictly less than %v."},
+	{validation.KeyMinimum, "The value must be greater than or equal to %v."},
+	{validation.KeyExclusiveMaximum, "The value must be strictly greater than %v."},
+
+	// Validation keywords for strings
+	{validation.KeyMaxLength, "The string must have at most %v characters."},
+	{validation.KeyMinLength, "The string must have at least %v characters."},
+	{validation.KeyPattern, "The string must match the regular expression `%v`."},
+
+	// Validation keywords for arrays
+	{validation.KeyMaxItems, "The array must have at most %v items."},
+	{validation.KeyMinItems, "The array must have at least %v items."},
+
+	// Validation keywords for objects
+	{validation.KeyMaxProperties, "The object must have at most %v properties."},
+	{validation.KeyMinProperties, "The object must have at least %v properties."},
+	{validation.KeyRequired, "The following properties are required: %v."},
+	{validation.KeyPropertyNames, "Property names must match the JSON Schema: `%+v`."},
+}
+
 // constraintsToDoc converts a map of JSON Schema validation key/values to human-readable bullet points.
 func constraintsToDoc(schema map[string]interface{}) []string {
-	// We use an anonymous struct rather than a map to get a strict ordering of
-	// constraints so they are generated consistently in documentation.
-	// Not all JSON Schema constraints can be cleanly expressed in this format,
-	// nor do we use them all so some are missing.
-	constraintFormatters := []struct {
-		SchemaKey string
-		DocString string
-	}{
-		// Schema Annotations
-		{validation.KeyExamples, "Examples: %+v."},
-
-		// Validation for any instance type
-		{validation.KeyEnum, "The value must be one of: %+v."},
-		{validation.KeyConst, "The value must be: `%v`."},
-
-		// Validation keywords for numeric instances
-		{validation.KeyMultipleOf, "The value must be a multiple of %v."},
-		{validation.KeyMaximum, "The value must be less than or equal to %v."},
-		{validation.KeyExclusiveMaximum, "The value must be strictly less than %v."},
-		{validation.KeyMinimum, "The value must be greater than or equal to %v."},
-		{validation.KeyExclusiveMaximum, "The value must be strictly greater than %v."},
-
-		// Validation keywords for strings
-		{validation.KeyMaxLength, "The string must have at most %v characters."},
-		{validation.KeyMinLength, "The string must have at least %v characters."},
-		{validation.KeyPattern, "The string must match the regular expression `%v`."},
-
-		// Validation keywords for arrays
-		{validation.KeyMaxItems, "The array must have at most %v items."},
-		{validation.KeyMinItems, "The array must have at least %v items."},
-
-		// Validation keywords for objects
-		{validation.KeyMaxProperties, "The object must have at most %v properties."},
-		{validation.KeyMinProperties, "The object must have at least %v properties."},
-		{validation.KeyRequired, "The following properties are required: %v."},
-		{validation.KeyPropertyNames, "Property names must match the JSON Schema: `%+v`."},
-	}
 
 	var bullets []string
 	for _, formatter := range constraintFormatters {

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -185,7 +185,63 @@ func varNotes(variable broker.BrokerVariable) string {
 		out += fmt.Sprintf(" Default: `%v`.", variable.Default)
 	}
 
+	bullets := constraintsToDoc(variable.ToSchema())
+	if len(bullets) > 0 {
+		out += "\n  * "
+		out += strings.Join(bullets, "\n  * ")
+	}
+
 	return out
+}
+
+// constraintsToDoc converts a map of JSON Schema validation key/values to human-readable bullet points.
+func constraintsToDoc(schema map[string]interface{}) []string {
+	// We use an anonymous struct rather than a map to get a strict ordering of
+	// constraints so they are generated consistently in documentation.
+	// Not all JSON Schema constraints can be cleanly expressed in this format,
+	// nor do we use them all so some are missing.
+	constraintFormatters := []struct {
+		SchemaKey string
+		DocString string
+	}{
+		// Schema Annotations
+		{"examples", "Examples: %+v."},
+
+		// Validation for any instance type
+		{"enum", "The value must be one of: %+v."},
+		{"const", "The value must be: `%v`."},
+
+		// Validation keywords for numeric instances
+		{"multipleOf", "The value must be a multiple of %v."},
+		{"maximum", "The value must be less than or equal to %v."},
+		{"exclusiveMaximum", "The value must be strictly less than %v."},
+		{"minimum", "The value must be greater than or equal to %v."},
+		{"exclusiveMinimum", "The value must be strictly greater than %v."},
+
+		// Validation keywords for strings
+		{"maxLength", "The string must have at most %v characters."},
+		{"minLength", "The string must have at least %v characters."},
+		{"pattern", "The string must match the regular expression `%v`."},
+
+		// Validation keywords for arrays
+		{"maxItems", "The array must have at most %v items."},
+		{"minItems", "The array must have at least %v items."},
+
+		// Validation keywords for objects
+		{"maxProperties", "The object must have at most %v properties."},
+		{"minProperties", "The object must have at least %v properties."},
+		{"required", "The following properties are required: %v."},
+		{"propertyNames", "Property names must match the JSON Schema: `%+v`."},
+	}
+
+	var bullets []string
+	for _, formatter := range constraintFormatters {
+		if v, ok := schema[formatter.SchemaKey]; ok {
+			bullets = append(bullets, fmt.Sprintf(formatter.DocString, v))
+		}
+	}
+
+	return bullets
 }
 
 // cleanLines concatenates multiple lines of text, trimming any leading/trailing

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -195,48 +195,45 @@ func varNotes(variable broker.BrokerVariable) string {
 	return out
 }
 
-type constraintFormatter struct {
-	SchemaKey string
-	DocString string
-}
-
-// We use an anonymous struct rather than a map to get a strict ordering of
-// constraints so they are generated consistently in documentation.
-// Not all JSON Schema constraints can be cleanly expressed in this format,
-// nor do we use them all so some are missing.
-var constraintFormatters = []constraintFormatter{
-	// Schema Annotations
-	{validation.KeyExamples, "Examples: %+v."},
-
-	// Validation for any instance type
-	{validation.KeyEnum, "The value must be one of: %+v."},
-	{validation.KeyConst, "The value must be: `%v`."},
-
-	// Validation keywords for numeric instances
-	{validation.KeyMultipleOf, "The value must be a multiple of %v."},
-	{validation.KeyMaximum, "The value must be less than or equal to %v."},
-	{validation.KeyExclusiveMaximum, "The value must be strictly less than %v."},
-	{validation.KeyMinimum, "The value must be greater than or equal to %v."},
-	{validation.KeyExclusiveMaximum, "The value must be strictly greater than %v."},
-
-	// Validation keywords for strings
-	{validation.KeyMaxLength, "The string must have at most %v characters."},
-	{validation.KeyMinLength, "The string must have at least %v characters."},
-	{validation.KeyPattern, "The string must match the regular expression `%v`."},
-
-	// Validation keywords for arrays
-	{validation.KeyMaxItems, "The array must have at most %v items."},
-	{validation.KeyMinItems, "The array must have at least %v items."},
-
-	// Validation keywords for objects
-	{validation.KeyMaxProperties, "The object must have at most %v properties."},
-	{validation.KeyMinProperties, "The object must have at least %v properties."},
-	{validation.KeyRequired, "The following properties are required: %v."},
-	{validation.KeyPropertyNames, "Property names must match the JSON Schema: `%+v`."},
-}
-
 // constraintsToDoc converts a map of JSON Schema validation key/values to human-readable bullet points.
 func constraintsToDoc(schema map[string]interface{}) []string {
+	// We use an anonymous struct rather than a map to get a strict ordering of
+	// constraints so they are generated consistently in documentation.
+	// Not all JSON Schema constraints can be cleanly expressed in this format,
+	// nor do we use them all so some are missing.
+	constraintFormatters := []struct {
+		SchemaKey string
+		DocString string
+	}{
+		// Schema Annotations
+		{validation.KeyExamples, "Examples: %+v."},
+
+		// Validation for any instance type
+		{validation.KeyEnum, "The value must be one of: %+v."},
+		{validation.KeyConst, "The value must be: `%v`."},
+
+		// Validation keywords for numeric instances
+		{validation.KeyMultipleOf, "The value must be a multiple of %v."},
+		{validation.KeyMaximum, "The value must be less than or equal to %v."},
+		{validation.KeyExclusiveMaximum, "The value must be strictly less than %v."},
+		{validation.KeyMinimum, "The value must be greater than or equal to %v."},
+		{validation.KeyExclusiveMaximum, "The value must be strictly greater than %v."},
+
+		// Validation keywords for strings
+		{validation.KeyMaxLength, "The string must have at most %v characters."},
+		{validation.KeyMinLength, "The string must have at least %v characters."},
+		{validation.KeyPattern, "The string must match the regular expression `%v`."},
+
+		// Validation keywords for arrays
+		{validation.KeyMaxItems, "The array must have at most %v items."},
+		{validation.KeyMinItems, "The array must have at least %v items."},
+
+		// Validation keywords for objects
+		{validation.KeyMaxProperties, "The object must have at most %v properties."},
+		{validation.KeyMinProperties, "The object must have at least %v properties."},
+		{validation.KeyRequired, "The following properties are required: %v."},
+		{validation.KeyMaxProperties, "Property names must match the JSON Schema: `%+v`."},
+	}
 
 	var bullets []string
 	for _, formatter := range constraintFormatters {

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -23,6 +23,7 @@ import (
 	"text/template"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 )
 
 // CatalogDocumentation generates markdown documentation for an entire service
@@ -205,33 +206,33 @@ func constraintsToDoc(schema map[string]interface{}) []string {
 		DocString string
 	}{
 		// Schema Annotations
-		{"examples", "Examples: %+v."},
+		{validation.KeyExamples, "Examples: %+v."},
 
 		// Validation for any instance type
-		{"enum", "The value must be one of: %+v."},
-		{"const", "The value must be: `%v`."},
+		{validation.KeyEnum, "The value must be one of: %+v."},
+		{validation.KeyConst, "The value must be: `%v`."},
 
 		// Validation keywords for numeric instances
-		{"multipleOf", "The value must be a multiple of %v."},
-		{"maximum", "The value must be less than or equal to %v."},
-		{"exclusiveMaximum", "The value must be strictly less than %v."},
-		{"minimum", "The value must be greater than or equal to %v."},
-		{"exclusiveMinimum", "The value must be strictly greater than %v."},
+		{validation.KeyMultipleOf, "The value must be a multiple of %v."},
+		{validation.KeyMaximum, "The value must be less than or equal to %v."},
+		{validation.KeyExclusiveMaximum, "The value must be strictly less than %v."},
+		{validation.KeyMinimum, "The value must be greater than or equal to %v."},
+		{validation.KeyExclusiveMaximum, "The value must be strictly greater than %v."},
 
 		// Validation keywords for strings
-		{"maxLength", "The string must have at most %v characters."},
-		{"minLength", "The string must have at least %v characters."},
-		{"pattern", "The string must match the regular expression `%v`."},
+		{validation.KeyMaxLength, "The string must have at most %v characters."},
+		{validation.KeyMinLength, "The string must have at least %v characters."},
+		{validation.KeyPattern, "The string must match the regular expression `%v`."},
 
 		// Validation keywords for arrays
-		{"maxItems", "The array must have at most %v items."},
-		{"minItems", "The array must have at least %v items."},
+		{validation.KeyMaxItems, "The array must have at most %v items."},
+		{validation.KeyMinItems, "The array must have at least %v items."},
 
 		// Validation keywords for objects
-		{"maxProperties", "The object must have at most %v properties."},
-		{"minProperties", "The object must have at least %v properties."},
-		{"required", "The following properties are required: %v."},
-		{"propertyNames", "Property names must match the JSON Schema: `%+v`."},
+		{validation.KeyMaxProperties, "The object must have at most %v properties."},
+		{validation.KeyMinProperties, "The object must have at least %v properties."},
+		{validation.KeyRequired, "The following properties are required: %v."},
+		{validation.KeyPropertyNames, "Property names must match the JSON Schema: `%+v`."},
 	}
 
 	var bullets []string

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -187,8 +187,8 @@ func varNotes(variable broker.BrokerVariable) string {
 
 	bullets := constraintsToDoc(variable.ToSchema())
 	if len(bullets) > 0 {
-		out += "\n  * "
-		out += strings.Join(bullets, "\n  * ")
+		out += "\n    * "
+		out += strings.Join(bullets, "\n    * ")
 	}
 
 	return out

--- a/pkg/validation/constraint_builder.go
+++ b/pkg/validation/constraint_builder.go
@@ -38,7 +38,8 @@ const (
 )
 
 //  NewConstraintBuilder creates a builder for JSON Schema compliant constraint
-// lists.
+// lists. See http://json-schema.org/latest/json-schema-validation.html
+// for types of validation available.
 func NewConstraintBuilder() ConstraintBuilder {
 	return ConstraintBuilder{}
 }

--- a/pkg/validation/constraint_builder.go
+++ b/pkg/validation/constraint_builder.go
@@ -1,0 +1,185 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+const (
+	KeyDefault          = "default"
+	KeyExamples         = "examples"
+	KeyDescription      = "description"
+	KeyType             = "type"
+	KeyConst            = "const"
+	KeyEnum             = "enum"
+	KeyMultipleOf       = "multipleOf"
+	KeyMaximum          = "maximum"
+	KeyMinimum          = "minimum"
+	KeyExclusiveMaximum = "exclusiveMaximum"
+	KeyExclusiveMinimum = "exclusiveMinimum"
+	KeyMaxLength        = "maxLength"
+	KeyMinLength        = "minLength"
+	KeyPattern          = "pattern"
+	KeyMaxItems         = "maxItems"
+	KeyMinItems         = "minItems"
+	KeyMaxProperties    = "maxProperties"
+	KeyMinProperties    = "minProperties"
+	KeyRequired         = "required"
+	KeyPropertyNames    = "propertyNames"
+)
+
+//  NewConstraintBuilder creates a builder for JSON Schema compliant constraint
+// lists.
+func NewConstraintBuilder() ConstraintBuilder {
+	return ConstraintBuilder{}
+}
+
+// A builder for JSON Schema compliant constraint lists
+type ConstraintBuilder map[string]interface{}
+
+// Type adds a type constrinat.
+func (cb ConstraintBuilder) Type(t string) ConstraintBuilder {
+	cb[KeyType] = t
+	return cb
+}
+
+// Description adds a human-readable description
+func (cb ConstraintBuilder) Description(desc string) ConstraintBuilder {
+	cb[KeyDescription] = desc
+
+	return cb
+}
+
+// Examples adds one or more examples
+func (cb ConstraintBuilder) Examples(ex ...interface{}) ConstraintBuilder {
+	cb[KeyExamples] = ex
+
+	return cb
+}
+
+// Const adds a constraint that the field must equal this value.
+func (cb ConstraintBuilder) Const(value interface{}) ConstraintBuilder {
+	cb[KeyConst] = value
+
+	return cb
+}
+
+// Enum adds a constraint that the field must be one of these values.
+func (cb ConstraintBuilder) Enum(value ...interface{}) ConstraintBuilder {
+	cb[KeyEnum] = value
+
+	return cb
+}
+
+// MultipleOf adds a constraint that the field must be a multiple of this integer.
+func (cb ConstraintBuilder) MultipleOf(value int) ConstraintBuilder {
+	cb[KeyMultipleOf] = value
+
+	return cb
+}
+
+// Minimum adds a constraint that the field must be greater than or equal to
+// this number.
+func (cb ConstraintBuilder) Minimum(value int) ConstraintBuilder {
+	cb[KeyMinimum] = value
+
+	return cb
+}
+
+// Maximum adds a constraint that the field must be less than or equal to
+// this number.
+func (cb ConstraintBuilder) Maximum(value int) ConstraintBuilder {
+	cb[KeyMaximum] = value
+
+	return cb
+}
+
+// ExclusiveMaximum adds a constraint that the field must be less than this number.
+func (cb ConstraintBuilder) ExclusiveMaximum(value int) ConstraintBuilder {
+	cb[KeyExclusiveMaximum] = value
+
+	return cb
+}
+
+// ExclusiveMinimum adds a constraint that the field must be greater than this number.
+func (cb ConstraintBuilder) ExclusiveMinimum(value int) ConstraintBuilder {
+	cb[KeyExclusiveMinimum] = value
+
+	return cb
+}
+
+// MaxLength adds a constraint that the string field must have at most this many characters.
+func (cb ConstraintBuilder) MaxLength(value int) ConstraintBuilder {
+	cb[KeyMaxLength] = value
+
+	return cb
+}
+
+// MinLength adds a constraint that the string field must have at least this many characters.
+func (cb ConstraintBuilder) MinLength(value int) ConstraintBuilder {
+	cb[KeyMinLength] = value
+
+	return cb
+}
+
+// Pattern adds a constraint that the string must match the given pattern.
+func (cb ConstraintBuilder) Pattern(value string) ConstraintBuilder {
+	cb[KeyPattern] = value
+
+	return cb
+}
+
+// MaxItems adds a constraint that the array must have at most this many items.
+func (cb ConstraintBuilder) MaxItems(value int) ConstraintBuilder {
+	cb[KeyMaxItems] = value
+
+	return cb
+}
+
+// MinItems adds a constraint that the array must have at least this many items.
+func (cb ConstraintBuilder) MinItems(value int) ConstraintBuilder {
+	cb[KeyMinItems] = value
+
+	return cb
+}
+
+// KeyMaxProperties adds a constraint that the object must have at most this many keys.
+func (cb ConstraintBuilder) MaxProperties(value int) ConstraintBuilder {
+	cb[KeyMaxProperties] = value
+
+	return cb
+}
+
+// MinProperties adds a constraint that the object must have at least this many keys.
+func (cb ConstraintBuilder) MinProperties(value int) ConstraintBuilder {
+	cb[KeyMinProperties] = value
+
+	return cb
+}
+
+// Required adds a constraint that the object must have at least these keys.
+func (cb ConstraintBuilder) Required(properties ...string) ConstraintBuilder {
+	cb[KeyRequired] = properties
+
+	return cb
+}
+
+// PropertyNames adds a constraint that the object property names must match the given schema.
+func (cb ConstraintBuilder) PropertyNames(properties map[string]interface{}) ConstraintBuilder {
+	cb[KeyPropertyNames] = properties
+
+	return cb
+}
+
+func (cb ConstraintBuilder) Build() map[string]interface{} {
+	return cb
+}

--- a/pkg/validation/constraint_builder_test.go
+++ b/pkg/validation/constraint_builder_test.go
@@ -1,0 +1,125 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConstraintBuilder(t *testing.T) {
+
+	// NOTE: Keep keys strings rather than constants in Expected so we can also
+	// validate that our constants don't get changed.
+	cases := map[string]struct {
+		Constraints ConstraintBuilder
+		Expected    map[string]interface{}
+	}{
+		"empty": {
+			Constraints: NewConstraintBuilder().Build(),
+			Expected:    map[string]interface{}{},
+		},
+		"annotations": {
+			Constraints: NewConstraintBuilder().
+				Description("desc").
+				Examples("exa", "exb").
+				Type("string"),
+			Expected: map[string]interface{}{
+				"description": "desc",
+				"examples":    []interface{}{"exa", "exb"},
+				"type":        "string",
+			},
+		},
+
+		"any type": {
+			Constraints: NewConstraintBuilder().
+				Enum("a", "b", "c").
+				Const("exa"),
+			Expected: map[string]interface{}{
+				"enum":  []interface{}{"a", "b", "c"},
+				"const": "exa",
+			},
+		},
+
+		"numeric": {
+			Constraints: NewConstraintBuilder().
+				Maximum(3).
+				Minimum(1).
+				ExclusiveMaximum(4).
+				ExclusiveMinimum(0).
+				MultipleOf(1),
+			Expected: map[string]interface{}{
+				"maximum":          3,
+				"minimum":          1,
+				"exclusiveMaximum": 4,
+				"exclusiveMinimum": 0,
+				"multipleOf":       1,
+			},
+		},
+
+		"strings": {
+			Constraints: NewConstraintBuilder().
+				MaxLength(30).
+				MinLength(10).
+				Pattern("^[A-Za-z]+[A-Za-z0-9]+$"),
+			Expected: map[string]interface{}{
+				"maxLength": 30,
+				"minLength": 10,
+				"pattern":   "^[A-Za-z]+[A-Za-z0-9]+$",
+			},
+		},
+
+		"arrays": {
+			Constraints: NewConstraintBuilder().
+				MaxItems(30).
+				MinItems(10),
+			Expected: map[string]interface{}{
+				"maxItems": 30,
+				"minItems": 10,
+			},
+		},
+
+		"objects": {
+			Constraints: NewConstraintBuilder().
+				MaxProperties(30).
+				MinProperties(10).
+				Required("a", "b", "c").
+				PropertyNames(map[string]interface{}{"type": "string"}),
+			Expected: map[string]interface{}{
+				"maxProperties": 30,
+				"minProperties": 10,
+				"required":      []string{"a", "b", "c"},
+				"propertyNames": map[string]interface{}{"type": "string"},
+			},
+		},
+
+		"secondOverwritesFirst": {
+			Constraints: NewConstraintBuilder().MaxLength(3).MaxLength(5).Build(),
+			Expected: map[string]interface{}{
+				KeyMaxLength: 5,
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual := tc.Constraints.Build()
+
+			if !reflect.DeepEqual(tc.Expected, actual) {
+				t.Errorf("Error constructing constraints, expected: %#v got: %#v", tc.Expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Start adding JSON Schema support to the broker. This commit tests the waters for the general approach.

After annotating the rest of the fields, we'll be able to push validation up into the broker to fail faster, have more complete documentation, and (possibly) expose the schemas like the OSB Spec recommends.

This work also opens up the way for improving/implementing:

* #243 - we'll be able to validate operator overrides
* #254 - existing brokers will behave the same way as the new ones
* #251 - we can now support more interesting types
* #250 - we can start mashing up variables earlier because tests are explicit
* #79 - we can generate these based on the schema for some forms
* #224 - these constraints will be explicit in the schema and not tested/accommodated for in multiple places