### PR TITLE
add support for operator overloading of provision defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unresolved]
 
+### Added
+- Ability for operators to override the provision defaults with fixed values.
+- New form to let operators set provision defaults.
+
 ## [4.0.0] - 2018-10-01
 
 ### Added

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -367,6 +367,102 @@ Enable compatibility with the GCP Service Broker v3.x. Before version 4.0, each 
 
 
 
+## Default Overrides
+
+Override the default values your users get when provisioning.
+
+You can configure the following environment variables:
+
+<b><tt>GSB_SERVICE_GOOGLE_BIGQUERY_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google BigQuery instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_BIGTABLE_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google Bigtable instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google CloudSQL MySQL instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google CloudSQL PostgreSQL instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_ML_APIS_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google Machine Learning APIs instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_PUBSUB_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google PubSub instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_SPANNER_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google Spanner instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_STORAGE_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google Cloud Storage instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+
+
 
 ## Custom Plans
 

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -138,6 +138,18 @@ func (svc *BrokerService) RoleWhitelistProperty() string {
 	return fmt.Sprintf("service.%s.whitelist", svc.Name)
 }
 
+// ProvisionDefaultOverrideProperty returns the Viper property name for the
+// object users can set to override the default values on provision.
+func (svc *BrokerService) ProvisionDefaultOverrideProperty() string {
+	return fmt.Sprintf("service.%s.provision.defaults", svc.Name)
+}
+
+// ProvisionDefaultOverrides returns the deserialized JSON object for the
+// operator-provided property overrides.
+func (svc *BrokerService) ProvisionDefaultOverrides() map[string]interface{} {
+	return viper.GetStringMap(svc.ProvisionDefaultOverrideProperty())
+}
+
 // RoleWhitelist returns the whitelist of roles the operator has allowed or the
 // default if it is blank.
 func (svc *BrokerService) RoleWhitelist() []string {
@@ -324,6 +336,7 @@ func (svc *BrokerService) ProvisionVariables(instanceId string, details brokerap
 	defaults := svc.provisionDefaults()
 
 	return varcontext.Builder().
+		MergeMap(svc.ProvisionDefaultOverrides()).
 		MergeJsonObject(details.GetRawParameters()).
 		MergeDefaults(defaults).
 		MergeMap(plan.GetServiceProperties()).

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -72,6 +72,7 @@ func GenerateForms() TileFormsSections {
 			generateEnableDisableForm(),
 			generateRoleWhitelistForm(),
 			generateCompatibilityForm(),
+			generateDefaultOverrideForm(),
 		},
 
 		ServicePlanForms: generateServicePlanForms(),
@@ -138,6 +139,40 @@ func generateRoleWhitelistForm() Form {
 		Label:       "Role Whitelisting",
 		Description: "Enable or disable role whitelisting.",
 		Properties:  enablers,
+	}
+}
+
+// generateDefaultOverrideForm generates a form for users to override the
+// defaults in a plan.
+func generateDefaultOverrideForm() Form {
+	formElements := []FormProperty{}
+	for _, svc := range broker.GetAllServices() {
+		entry, err := svc.CatalogEntry()
+		if err != nil {
+			log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
+		}
+
+		if !svc.IsRoleWhitelistEnabled() {
+			continue
+		}
+
+		formElement := FormProperty{
+			Name:         strings.ToLower(utils.PropertyToEnv(svc.ProvisionDefaultOverrideProperty())),
+			Label:        fmt.Sprintf("Provision default override %s instances.", entry.Metadata.DisplayName),
+			Description:  "A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.",
+			Type:         "text",
+			Default:      "{}",
+			Configurable: true,
+		}
+
+		formElements = append(formElements, formElement)
+	}
+
+	return Form{
+		Name:        "default_override",
+		Label:       "Default Overrides",
+		Description: "Override the default values your users get when provisioning.",
+		Properties:  formElements,
 	}
 }
 

--- a/tile.yml
+++ b/tile.yml
@@ -45,7 +45,7 @@ forms:
 - name: root_service_account
   label: Root Service Account
   description: Please paste in the contents of the json keyfile (un-encoded) for your
-    service account with owner credentials
+    service account with owner credentials.
   properties:
   - name: root_service_account_json
     type: text
@@ -53,7 +53,7 @@ forms:
     configurable: true
 - name: database_properties
   label: Database Properties
-  description: Connection details for the backing database for the service broker
+  description: Connection details for the backing database for the service broker.
   properties:
   - name: db_host
     type: string
@@ -96,127 +96,127 @@ forms:
     optional: true
 - name: enable_disable
   label: Enable Services
-  description: Enable or disable services
+  description: Enable or disable services.
   properties:
   - name: gsb_service_google_bigquery_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Google BigQuery instances
+    label: Let the broker create and bind Google BigQuery instances.
     configurable: true
   - name: gsb_service_google_bigtable_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Google Bigtable instances
+    label: Let the broker create and bind Google Bigtable instances.
     configurable: true
   - name: gsb_service_google_cloudsql_mysql_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Google CloudSQL MySQL instances
+    label: Let the broker create and bind Google CloudSQL MySQL instances.
     configurable: true
   - name: gsb_service_google_cloudsql_postgres_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Google CloudSQL PostgreSQL instances
+    label: Let the broker create and bind Google CloudSQL PostgreSQL instances.
     configurable: true
   - name: gsb_service_google_datastore_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Google Cloud Datastore instances
+    label: Let the broker create and bind Google Cloud Datastore instances.
     configurable: true
   - name: gsb_service_google_ml_apis_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Google Machine Learning APIs instances
+    label: Let the broker create and bind Google Machine Learning APIs instances.
     configurable: true
   - name: gsb_service_google_pubsub_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Google PubSub instances
+    label: Let the broker create and bind Google PubSub instances.
     configurable: true
   - name: gsb_service_google_spanner_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Google Spanner instances
+    label: Let the broker create and bind Google Spanner instances.
     configurable: true
   - name: gsb_service_google_stackdriver_debugger_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Stackdriver Debugger instances
+    label: Let the broker create and bind Stackdriver Debugger instances.
     configurable: true
   - name: gsb_service_google_stackdriver_profiler_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Stackdriver Profiler instances
+    label: Let the broker create and bind Stackdriver Profiler instances.
     configurable: true
   - name: gsb_service_google_stackdriver_trace_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Stackdriver Trace instances
+    label: Let the broker create and bind Stackdriver Trace instances.
     configurable: true
   - name: gsb_service_google_storage_enabled
     type: boolean
     default: true
-    label: Let the broker create and bind Google Cloud Storage instances
+    label: Let the broker create and bind Google Cloud Storage instances.
     configurable: true
 - name: role_whitelists
   label: Role Whitelisting
-  description: Enable or disable role whitelisting
+  description: Enable or disable role whitelisting.
   properties:
   - name: gsb_service_google_bigquery_whitelist
     type: string
     default: bigquery.dataViewer,bigquery.dataEditor,bigquery.dataOwner,bigquery.user,bigquery.jobUser
-    label: Role whitelist for Google BigQuery instances
+    label: Role whitelist for Google BigQuery instances.
     description: A comma delimited list of roles (minus the role/ prefix) that can
-      be used when creating bound users for this service
+      be used when creating bound users for this service.
     configurable: true
   - name: gsb_service_google_bigtable_whitelist
     type: string
     default: bigtable.user,bigtable.reader,bigtable.viewer
-    label: Role whitelist for Google Bigtable instances
+    label: Role whitelist for Google Bigtable instances.
     description: A comma delimited list of roles (minus the role/ prefix) that can
-      be used when creating bound users for this service
+      be used when creating bound users for this service.
     configurable: true
   - name: gsb_service_google_cloudsql_mysql_whitelist
     type: string
     default: cloudsql.editor,cloudsql.viewer,cloudsql.client
-    label: Role whitelist for Google CloudSQL MySQL instances
+    label: Role whitelist for Google CloudSQL MySQL instances.
     description: A comma delimited list of roles (minus the role/ prefix) that can
-      be used when creating bound users for this service
+      be used when creating bound users for this service.
     configurable: true
   - name: gsb_service_google_cloudsql_postgres_whitelist
     type: string
     default: cloudsql.editor,cloudsql.viewer,cloudsql.client
-    label: Role whitelist for Google CloudSQL PostgreSQL instances
+    label: Role whitelist for Google CloudSQL PostgreSQL instances.
     description: A comma delimited list of roles (minus the role/ prefix) that can
-      be used when creating bound users for this service
+      be used when creating bound users for this service.
     configurable: true
   - name: gsb_service_google_ml_apis_whitelist
     type: string
     default: ml.developer,ml.viewer,ml.modelOwner,ml.modelUser,ml.jobOwner,ml.operationOwner
-    label: Role whitelist for Google Machine Learning APIs instances
+    label: Role whitelist for Google Machine Learning APIs instances.
     description: A comma delimited list of roles (minus the role/ prefix) that can
-      be used when creating bound users for this service
+      be used when creating bound users for this service.
     configurable: true
   - name: gsb_service_google_pubsub_whitelist
     type: string
     default: pubsub.publisher,pubsub.subscriber,pubsub.viewer,pubsub.editor
-    label: Role whitelist for Google PubSub instances
+    label: Role whitelist for Google PubSub instances.
     description: A comma delimited list of roles (minus the role/ prefix) that can
-      be used when creating bound users for this service
+      be used when creating bound users for this service.
     configurable: true
   - name: gsb_service_google_spanner_whitelist
     type: string
     default: spanner.databaseAdmin,spanner.databaseReader,spanner.databaseUser,spanner.viewer
-    label: Role whitelist for Google Spanner instances
+    label: Role whitelist for Google Spanner instances.
     description: A comma delimited list of roles (minus the role/ prefix) that can
-      be used when creating bound users for this service
+      be used when creating bound users for this service.
     configurable: true
   - name: gsb_service_google_storage_whitelist
     type: string
     default: storage.objectCreator,storage.objectViewer,storage.objectAdmin
-    label: Role whitelist for Google Cloud Storage instances
+    label: Role whitelist for Google Cloud Storage instances.
     description: A comma delimited list of roles (minus the role/ prefix) that can
-      be used when creating bound users for this service
+      be used when creating bound users for this service.
     configurable: true
 - name: compatibility
   label: Compatibility
@@ -232,27 +232,87 @@ forms:
       is using the correct plan GUID. If the service does not use the correct GUID,
       the request will fail with a message about how to upgrade.
     configurable: true
+- name: default_override
+  label: Default Overrides
+  description: Override the default values your users get when provisioning.
+  properties:
+  - name: gsb_service_google_bigquery_provision_defaults
+    type: text
+    default: '{}'
+    label: Provision default override Google BigQuery instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_bigtable_provision_defaults
+    type: text
+    default: '{}'
+    label: Provision default override Google Bigtable instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_cloudsql_mysql_provision_defaults
+    type: text
+    default: '{}'
+    label: Provision default override Google CloudSQL MySQL instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_cloudsql_postgres_provision_defaults
+    type: text
+    default: '{}'
+    label: Provision default override Google CloudSQL PostgreSQL instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_ml_apis_provision_defaults
+    type: text
+    default: '{}'
+    label: Provision default override Google Machine Learning APIs instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_pubsub_provision_defaults
+    type: text
+    default: '{}'
+    label: Provision default override Google PubSub instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_spanner_provision_defaults
+    type: text
+    default: '{}'
+    label: Provision default override Google Spanner instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_storage_provision_defaults
+    type: text
+    default: '{}'
+    label: Provision default override Google Cloud Storage instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      provision property and values are the alternative default.
+    configurable: true
 service_plan_forms:
 - name: bigtable_custom_plans
   label: Google Bigtable Custom Plans
-  description: Generate custom plans for Google Bigtable
+  description: Generate custom plans for Google Bigtable.
   optional: true
   properties:
   - name: display_name
     type: string
     label: Display Name
-    description: Display name
+    description: Name of the plan to be displayed to users.
     configurable: true
   - name: description
     type: string
     label: Plan description
-    description: Plan description
+    description: The description of the plan shown to users.
     configurable: true
   - name: service
     type: dropdown_select
     default: b8e19880-ac58-42ef-b033-f7cd9c94d1fe
     label: Service
-    description: The service this plan is associated with
+    description: The service this plan is associated with.
     options:
     - name: b8e19880-ac58-42ef-b033-f7cd9c94d1fe
       label: Google Bigtable
@@ -260,8 +320,8 @@ service_plan_forms:
     type: dropdown_select
     default: SSD
     label: Storage Type
-    description: Either HDD or SSD (see https://cloud.google.com/bigtable/pricing
-      for more information)
+    description: 'Either HDD or SSD. See: https://cloud.google.com/bigtable/pricing
+      for more information.'
     configurable: true
     options:
     - name: SSD
@@ -272,29 +332,29 @@ service_plan_forms:
     type: string
     default: "3"
     label: Num Nodes
-    description: Number of Nodes, Between 3 and 30 (see https://cloud.google.com/bigtable/pricing
-      for more information)
+    description: 'Number of nodes, between 3 and 30. See: https://cloud.google.com/bigtable/pricing
+      for more information.'
     configurable: true
 - name: cloudsql_mysql_custom_plans
   label: Google CloudSQL MySQL Custom Plans
-  description: Generate custom plans for Google CloudSQL MySQL
+  description: Generate custom plans for Google CloudSQL MySQL.
   optional: true
   properties:
   - name: display_name
     type: string
     label: Display Name
-    description: Display name
+    description: Name of the plan to be displayed to users.
     configurable: true
   - name: description
     type: string
     label: Plan description
-    description: Plan description
+    description: The description of the plan shown to users.
     configurable: true
   - name: service
     type: dropdown_select
     default: 4bc59b9a-8520-409f-85da-1c7552315863
     label: Service
-    description: The service this plan is associated with
+    description: The service this plan is associated with.
     options:
     - name: 4bc59b9a-8520-409f-85da-1c7552315863
       label: Google CloudSQL MySQL
@@ -302,13 +362,13 @@ service_plan_forms:
     type: string
     label: Tier
     description: Case-sensitive tier/machine type name (see https://cloud.google.com/sql/pricing
-      for more information)
+      for more information).
     configurable: true
   - name: pricing_plan
     type: dropdown_select
     default: PER_USE
     label: Pricing Plan
-    description: Select a pricing plan (only for 1st generation instances)
+    description: Select a pricing plan (only for 1st generation instances).
     configurable: true
     options:
     - name: PER_USE
@@ -320,28 +380,28 @@ service_plan_forms:
     default: "10"
     label: Max Disk Size
     description: Maximum disk size in GB (applicable only to Second Generation instances,
-      10 minimum/default)
+      10 minimum/default).
     configurable: true
 - name: cloudsql_postgres_custom_plans
   label: Google CloudSQL PostgreSQL Custom Plans
-  description: Generate custom plans for Google CloudSQL PostgreSQL
+  description: Generate custom plans for Google CloudSQL PostgreSQL.
   optional: true
   properties:
   - name: display_name
     type: string
     label: Display Name
-    description: Display name
+    description: Name of the plan to be displayed to users.
     configurable: true
   - name: description
     type: string
     label: Plan description
-    description: Plan description
+    description: The description of the plan shown to users.
     configurable: true
   - name: service
     type: dropdown_select
     default: cbad6d78-a73c-432d-b8ff-b219a17a803a
     label: Service
-    description: The service this plan is associated with
+    description: The service this plan is associated with.
     options:
     - name: cbad6d78-a73c-432d-b8ff-b219a17a803a
       label: Google CloudSQL PostgreSQL
@@ -349,13 +409,13 @@ service_plan_forms:
     type: string
     label: Tier
     description: A string of the form db-custom-[CPUS]-[MEMORY_MBS], where memory
-      is at least 3840
+      is at least 3840.
     configurable: true
   - name: pricing_plan
     type: dropdown_select
     default: PER_USE
     label: Pricing Plan
-    description: The pricing plan
+    description: The pricing plan.
     options:
     - name: PER_USE
       label: Per-Use
@@ -363,28 +423,28 @@ service_plan_forms:
     type: string
     default: "10"
     label: Max Disk Size
-    description: Maximum disk size in GB (10 minimum/default)
+    description: Maximum disk size in GB, 10 is the minimum.
     configurable: true
 - name: spanner_custom_plans
   label: Google Spanner Custom Plans
-  description: Generate custom plans for Google Spanner
+  description: Generate custom plans for Google Spanner.
   optional: true
   properties:
   - name: display_name
     type: string
     label: Display Name
-    description: Display name
+    description: Name of the plan to be displayed to users.
     configurable: true
   - name: description
     type: string
     label: Plan description
-    description: Plan description
+    description: The description of the plan shown to users.
     configurable: true
   - name: service
     type: dropdown_select
     default: 51b3e27e-d323-49ce-8c5f-1211e6409e82
     label: Service
-    description: The service this plan is associated with
+    description: The service this plan is associated with.
     options:
     - name: 51b3e27e-d323-49ce-8c5f-1211e6409e82
       label: Google Spanner
@@ -392,7 +452,7 @@ service_plan_forms:
     type: string
     default: "1"
     label: Num Nodes
-    description: Number of Nodes, A minimum of 3 nodes is recommended for production
-      environments. (see https://cloud.google.com/spanner/pricing for more information)
+    description: 'Number of nodes, a minimum of 3 nodes is recommended for production
+      environments. See: https://cloud.google.com/spanner/pricing for more information.'
     configurable: true
 


### PR DESCRIPTION
Fixes part of #98. Bind overrides are still pending and will be added to the same form once bind moves over to using `varcontext`.

These overrides are explicitly added before the user values so they'll be overwritten by them. I considered overwriting the values on the actual list of plan variables, but decided against it because those are evaluated and I don't think we want to be giving that power to operators yet; especially when the plan variables are executed in a very specific order to ensure they all resolve correctly.

Later on, when user-defined plans become a thing operators can customize to their hearts' content, but KISS for now.