### PR TITLE
move handling of async deprovision to GCPServiceBroker

### DIFF
--- a/brokerapi/brokers/api_service/broker.go
+++ b/brokerapi/brokers/api_service/broker.go
@@ -33,6 +33,6 @@ func (b *ApiServiceBroker) Provision(ctx context.Context, instanceId string, det
 }
 
 // Deprovision is a no-op call because only service accounts need to be bound/unbound for Google Machine Learning APIs.
-func (b *ApiServiceBroker) Deprovision(ctx context.Context, dataset models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
-	return nil
+func (b *ApiServiceBroker) Deprovision(ctx context.Context, dataset models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
+	return nil, nil
 }

--- a/brokerapi/brokers/bigquery/broker.go
+++ b/brokerapi/brokers/bigquery/broker.go
@@ -86,17 +86,17 @@ func (b *BigQueryBroker) Provision(ctx context.Context, instanceId string, detai
 
 // Deprovision deletes the dataset associated with the given instance.
 // Note: before deprovisioning you must delete all the tables in the dataset.
-func (b *BigQueryBroker) Deprovision(ctx context.Context, dataset models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
+func (b *BigQueryBroker) Deprovision(ctx context.Context, dataset models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
 	service, err := b.createClient(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err = service.Datasets.Delete(b.ProjectId, dataset.Name).Do(); err != nil {
-		return fmt.Errorf("Error deleting dataset: %s", err)
+		return nil, fmt.Errorf("Error deleting dataset: %s", err)
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (b *BigQueryBroker) createClient(ctx context.Context) (*googlebigquery.Service, error) {

--- a/brokerapi/brokers/bigquery/broker.go
+++ b/brokerapi/brokers/bigquery/broker.go
@@ -92,7 +92,7 @@ func (b *BigQueryBroker) Deprovision(ctx context.Context, dataset models.Service
 		return nil, err
 	}
 
-	if err = service.Datasets.Delete(b.ProjectId, dataset.Name).Do(); err != nil {
+	if err := service.Datasets.Delete(b.ProjectId, dataset.Name).Do(); err != nil {
 		return nil, fmt.Errorf("Error deleting dataset: %s", err)
 	}
 

--- a/brokerapi/brokers/bigtable/broker.go
+++ b/brokerapi/brokers/bigtable/broker.go
@@ -99,17 +99,17 @@ func (b *BigTableBroker) Provision(ctx context.Context, instanceId string, detai
 }
 
 // Deprovision deletes the BigTable associated with the given instance.
-func (b *BigTableBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
+func (b *BigTableBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
 	service, err := b.createClient(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := service.DeleteInstance(ctx, instance.Name); err != nil {
-		return fmt.Errorf("Error deleting Bigtable instance: %s", err)
+		return nil, fmt.Errorf("Error deleting Bigtable instance: %s", err)
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (b *BigTableBroker) createClient(ctx context.Context) (*googlebigtable.InstanceAdminClient, error) {

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -576,26 +576,19 @@ func (b *CloudSQLBroker) pollOperationUntilDone(ctx context.Context, op *googlec
 }
 
 // Deprovision issues a delete call on the database instance.
-func (b *CloudSQLBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
+func (b *CloudSQLBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
 	sqlService, err := b.createClient(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// delete the instance from google
 	op, err := sqlService.Instances.Delete(b.ProjectId, instance.Name).Do()
 	if err != nil {
-		return fmt.Errorf("Error deleting instance: %s", err)
+		return nil, fmt.Errorf("Error deleting instance: %s", err)
 	}
 
-	instance.OperationType = models.DeprovisionOperationType
-	instance.OperationId = op.Name
-
-	if err := db_service.SaveServiceInstanceDetails(ctx, &instance); err != nil {
-		return fmt.Errorf("Error saving delete instance operation: %s", err)
-	}
-
-	return nil
+	return &op.Name, nil
 }
 
 // ProvisionsAsync indicates that CloudSQL uses asynchronous provisioning.

--- a/brokerapi/brokers/datastore/broker.go
+++ b/brokerapi/brokers/datastore/broker.go
@@ -33,8 +33,8 @@ func (b *DatastoreBroker) Provision(ctx context.Context, instanceId string, deta
 }
 
 // Deprovision is a no-op call because only service accounts need to be bound/unbound for Datastore.
-func (b *DatastoreBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
-	return nil
+func (b *DatastoreBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
+	return nil, nil
 }
 
 // Bind creates a service account with access to Datastore.

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -223,7 +223,7 @@ func (gcpBroker *GCPServiceBroker) Provision(ctx context.Context, instanceID str
 
 // Deprovision destroys an existing instance of a service.
 // It is bound to the `DELETE /v2/service_instances/:instance_id` endpoint and can be called using the `cf delete-service` command.
-func (gcpBroker *GCPServiceBroker) Deprovision(ctx context.Context, instanceID string, details brokerapi.DeprovisionDetails, clientSupportsAsync bool) (brokerapi.DeprovisionServiceSpec, error) {
+func (gcpBroker *GCPServiceBroker) Deprovision(ctx context.Context, instanceID string, details brokerapi.DeprovisionDetails, clientSupportsAsync bool) (response brokerapi.DeprovisionServiceSpec, err error) {
 	gcpBroker.Logger.Info("Deprovisioning", lager.Data{
 		"instance_id":        instanceID,
 		"accepts_incomplete": clientSupportsAsync,
@@ -231,8 +231,6 @@ func (gcpBroker *GCPServiceBroker) Deprovision(ctx context.Context, instanceID s
 	})
 
 	service := gcpBroker.ServiceBrokerMap[details.ServiceID]
-	deprovisionIsAsync := service.DeprovisionsAsync()
-	response := brokerapi.DeprovisionServiceSpec{IsAsync: deprovisionIsAsync}
 
 	// make sure that instance actually exists
 	count, err := db_service.CountServiceInstanceDetailsById(ctx, instanceID)
@@ -244,8 +242,8 @@ func (gcpBroker *GCPServiceBroker) Deprovision(ctx context.Context, instanceID s
 	}
 
 	// if async deprovisioning isn't allowed but this service needs it, throw an error
-	if deprovisionIsAsync && !clientSupportsAsync {
-		return brokerapi.DeprovisionServiceSpec{}, brokerapi.ErrAsyncRequired
+	if service.DeprovisionsAsync() && !clientSupportsAsync {
+		return response, brokerapi.ErrAsyncRequired
 	}
 
 	// deprovision
@@ -254,21 +252,27 @@ func (gcpBroker *GCPServiceBroker) Deprovision(ctx context.Context, instanceID s
 		return response, brokerapi.NewFailureResponseBuilder(err, http.StatusInternalServerError, "fetching instance from database").Build()
 	}
 
-	if err := service.Deprovision(ctx, *instance, details); err != nil {
+	operationId, err := service.Deprovision(ctx, *instance, details)
+	if err != nil {
 		return response, err
 	}
 
-	// soft-delete instance details from the db if this is a synchronous operation
-	// if it's an async operation we can't delete from the db until we're sure delete succeeded, so this is
-	// handled internally to LastOperation
-	if !deprovisionIsAsync {
-		err = db_service.DeleteServiceInstanceDetailsById(ctx, instanceID)
-		if err != nil {
+	if operationId == nil {
+		// soft-delete instance details from the db if this is a synchronous operation
+		// if it's an async operation we can't delete from the db until we're sure delete succeeded, so this is
+		// handled internally to LastOperation
+		if err := db_service.DeleteServiceInstanceDetailsById(ctx, instanceID); err != nil {
 			return response, fmt.Errorf("Error deleting instance details from database: %s. WARNING: this instance will remain visible in cf. Contact your operator for cleanup", err)
 		}
-	}
+		return response, nil
+	} else {
+		response.IsAsync = true
+		response.OperationData = *operationId
 
-	return response, nil
+		instance.OperationType = models.DeprovisionOperationType
+		instance.OperationId = *operationId
+		return response, db_service.SaveServiceInstanceDetails(ctx, instance)
+	}
 }
 
 // Bind creates an account with credentials to access an instance of a service.

--- a/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
+++ b/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
@@ -69,7 +69,7 @@ type FakeServiceBrokerHelper struct {
 	unbindReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DeprovisionStub        func(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error
+	DeprovisionStub        func(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (operationId *string, err error)
 	deprovisionMutex       sync.RWMutex
 	deprovisionArgsForCall []struct {
 		ctx      context.Context
@@ -77,10 +77,12 @@ type FakeServiceBrokerHelper struct {
 		details  brokerapi.DeprovisionDetails
 	}
 	deprovisionReturns struct {
-		result1 error
+		result1 *string
+		result2 error
 	}
 	deprovisionReturnsOnCall map[int]struct {
-		result1 error
+		result1 *string
+		result2 error
 	}
 	PollInstanceStub        func(ctx context.Context, instance models.ServiceInstanceDetails) (bool, error)
 	pollInstanceMutex       sync.RWMutex
@@ -328,7 +330,7 @@ func (fake *FakeServiceBrokerHelper) UnbindReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeServiceBrokerHelper) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
+func (fake *FakeServiceBrokerHelper) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (operationId *string, err error) {
 	fake.deprovisionMutex.Lock()
 	ret, specificReturn := fake.deprovisionReturnsOnCall[len(fake.deprovisionArgsForCall)]
 	fake.deprovisionArgsForCall = append(fake.deprovisionArgsForCall, struct {
@@ -342,9 +344,9 @@ func (fake *FakeServiceBrokerHelper) Deprovision(ctx context.Context, instance m
 		return fake.DeprovisionStub(ctx, instance, details)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fake.deprovisionReturns.result1
+	return fake.deprovisionReturns.result1, fake.deprovisionReturns.result2
 }
 
 func (fake *FakeServiceBrokerHelper) DeprovisionCallCount() int {
@@ -359,23 +361,26 @@ func (fake *FakeServiceBrokerHelper) DeprovisionArgsForCall(i int) (context.Cont
 	return fake.deprovisionArgsForCall[i].ctx, fake.deprovisionArgsForCall[i].instance, fake.deprovisionArgsForCall[i].details
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionReturns(result1 error) {
+func (fake *FakeServiceBrokerHelper) DeprovisionReturns(result1 *string, result2 error) {
 	fake.DeprovisionStub = nil
 	fake.deprovisionReturns = struct {
-		result1 error
-	}{result1}
+		result1 *string
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionReturnsOnCall(i int, result1 error) {
+func (fake *FakeServiceBrokerHelper) DeprovisionReturnsOnCall(i int, result1 *string, result2 error) {
 	fake.DeprovisionStub = nil
 	if fake.deprovisionReturnsOnCall == nil {
 		fake.deprovisionReturnsOnCall = make(map[int]struct {
-			result1 error
+			result1 *string
+			result2 error
 		})
 	}
 	fake.deprovisionReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+		result1 *string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeServiceBrokerHelper) PollInstance(ctx context.Context, instance models.ServiceInstanceDetails) (bool, error) {

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -29,7 +29,10 @@ type ServiceBrokerHelper interface {
 	Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (ServiceBindingCredentials, error)
 	BuildInstanceCredentials(ctx context.Context, bindRecord ServiceBindingCredentials, instanceRecord ServiceInstanceDetails) (map[string]string, error)
 	Unbind(ctx context.Context, details ServiceBindingCredentials) error
-	Deprovision(ctx context.Context, instance ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error
+	// Deprovision deprovisions the service.
+	// If the deprovision is asynchronous (results in a long-running job), then operationId is returned.
+	// If no error and no operationId are returned, then the deprovision is expected to have been completed successfully.
+	Deprovision(ctx context.Context, instance ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (operationId *string, err error)
 	PollInstance(ctx context.Context, instance ServiceInstanceDetails) (bool, error)
 	ProvisionsAsync() bool
 	DeprovisionsAsync() bool

--- a/brokerapi/brokers/pubsub/broker.go
+++ b/brokerapi/brokers/pubsub/broker.go
@@ -123,28 +123,28 @@ func (b *PubSubBroker) Provision(ctx context.Context, instanceId string, details
 }
 
 // Deprovision deletes the topic and subscription associated with the given instance.
-func (b *PubSubBroker) Deprovision(ctx context.Context, topic models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
+func (b *PubSubBroker) Deprovision(ctx context.Context, topic models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
 	service, err := b.createClient(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := service.Topic(topic.Name).Delete(ctx); err != nil {
-		return fmt.Errorf("Error deleting pubsub topic: %s", err)
+		return nil, fmt.Errorf("Error deleting pubsub topic: %s", err)
 	}
 
 	otherDetails, err := topic.GetOtherDetails()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if subscriptionName := otherDetails["subscription_name"]; subscriptionName != "" {
 		if err := service.Subscription(subscriptionName).Delete(ctx); err != nil {
-			return fmt.Errorf("Error deleting subscription: %s", err)
+			return nil, fmt.Errorf("Error deleting subscription: %s", err)
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (b *PubSubBroker) createClient(ctx context.Context) (*googlepubsub.Client, error) {

--- a/brokerapi/brokers/spanner/broker.go
+++ b/brokerapi/brokers/spanner/broker.go
@@ -133,10 +133,10 @@ func (s *SpannerBroker) PollInstance(ctx context.Context, instance models.Servic
 }
 
 // Deprovision deletes the Spanner instance associated with the given instance.
-func (s *SpannerBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
+func (s *SpannerBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
 	client, err := s.createAdminClient(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// delete instance
@@ -145,10 +145,10 @@ func (s *SpannerBroker) Deprovision(ctx context.Context, instance models.Service
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error deleting instance: %s", err)
+		return nil, fmt.Errorf("Error deleting instance: %s", err)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // ProvisionsAsync indicates that Spanner uses asynchronous provisioning

--- a/brokerapi/brokers/stackdriver_debugger/broker.go
+++ b/brokerapi/brokers/stackdriver_debugger/broker.go
@@ -33,8 +33,8 @@ func (b *StackdriverDebuggerBroker) Provision(ctx context.Context, instanceId st
 }
 
 // Deprovision is a no-op call because only service accounts need to be bound/unbound for Stackdriver.
-func (b *StackdriverDebuggerBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
-	return nil
+func (b *StackdriverDebuggerBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
+	return nil, nil
 }
 
 // Bind creates a service account with access to Stackdriver Debugger.

--- a/brokerapi/brokers/stackdriver_profiler/broker.go
+++ b/brokerapi/brokers/stackdriver_profiler/broker.go
@@ -33,8 +33,8 @@ func (b *StackdriverProfilerBroker) Provision(ctx context.Context, instanceId st
 }
 
 // Deprovision is a no-op call because only service accounts need to be bound/unbound for Stackdriver.
-func (b *StackdriverProfilerBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
-	return nil
+func (b *StackdriverProfilerBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
+	return nil, nil
 }
 
 // Bind creates a service account with access to Stackdriver Profiler.

--- a/brokerapi/brokers/stackdriver_trace/broker.go
+++ b/brokerapi/brokers/stackdriver_trace/broker.go
@@ -33,8 +33,8 @@ func (b *StackdriverTraceBroker) Provision(ctx context.Context, instanceId strin
 }
 
 // Deprovision is a no-op call because only service accounts need to be bound/unbound for Stackdriver.
-func (b *StackdriverTraceBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
-	return nil
+func (b *StackdriverTraceBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
+	return nil, nil
 }
 
 // Bind creates a service account with access to Stackdriver Trace.

--- a/brokerapi/brokers/storage/broker.go
+++ b/brokerapi/brokers/storage/broker.go
@@ -88,17 +88,17 @@ func (b *StorageBroker) Provision(ctx context.Context, instanceId string, detail
 
 // Deprovision deletes the bucket associated with the given instance.
 // Note that all objects within the bucket must be deleted first.
-func (b *StorageBroker) Deprovision(ctx context.Context, bucket models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) error {
+func (b *StorageBroker) Deprovision(ctx context.Context, bucket models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
 	storageService, err := b.createClient(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err = storageService.Bucket(bucket.Name).Delete(ctx); err != nil {
-		return fmt.Errorf("Error deleting bucket: %s", err)
+		return nil, fmt.Errorf("Error deleting bucket: %s", err)
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (b *StorageBroker) createClient(ctx context.Context) (*googlestorage.Client, error) {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -122,6 +122,8 @@ user-defined plans.
 			if err := client.RunExamplesForService(apiClient, serviceName); err != nil {
 				log.Fatalf("Error executing examples: %v", err)
 			}
+
+			log.Println("Success")
 		},
 	}
 


### PR DESCRIPTION
This moves handling of the operation ID for asynchronous deprovision calls into GCPServiceBroker.

The service broker is responsible for managing the state of the instance, platform, and database, allowing the ServiceBrokerHelper to be responsible for just calling the right APIs and formatting requests.

part of #250 and #305 