### PR TITLE
update service state after successful lastoperation

### DIFF
--- a/brokerapi/brokers/broker_base/broker_base.go
+++ b/brokerapi/brokers/broker_base/broker_base.go
@@ -65,3 +65,9 @@ func (b *BrokerBase) ProvisionsAsync() bool {
 func (b *BrokerBase) DeprovisionsAsync() bool {
 	return false
 }
+
+// UpdateInstanceDetails updates the ServiceInstanceDetails with the most recent state from GCP.
+// This instance is a no-op method.
+func (b *BrokerBase) UpdateInstanceDetails(ctx context.Context, instance *models.ServiceInstanceDetails) error {
+	return nil
+}

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -453,12 +453,14 @@ func (b *CloudSQLBroker) PollInstance(ctx context.Context, instance models.Servi
 	}
 
 	if instance.OperationType == models.ProvisionOperationType {
-		instancePtr := &instance
-		if err := b.UpdateInstanceDetails(ctx, instancePtr); err != nil {
+		// Update the instance information from the server side before
+		// creating the database. The modification happens _only_ to 
+		// this instance of the details and is not persisted to the db.
+		if err := b.UpdateInstanceDetails(ctx, &instance); err != nil {
 			return true, err
 		}
 
-		return true, b.createDatabase(ctx, instancePtr)
+		return true, b.createDatabase(ctx, &instance)
 	}
 
 	return true, nil

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -453,19 +453,20 @@ func (b *CloudSQLBroker) PollInstance(ctx context.Context, instance models.Servi
 	}
 
 	if instance.OperationType == models.ProvisionOperationType {
-		if err := b.refreshServiceInstanceDetails(ctx, &instance); err != nil {
+		instancePtr := &instance
+		if err := b.UpdateInstanceDetails(ctx, instancePtr); err != nil {
 			return true, err
 		}
 
-		return true, b.createDatabase(ctx, &instance)
+		return true, b.createDatabase(ctx, instancePtr)
 	}
 
 	return true, nil
 }
 
 // refreshServiceInstanceDetails fetches the settings for the instance from GCP
-// and upates the service with the refreshed info.
-func (b *CloudSQLBroker) refreshServiceInstanceDetails(ctx context.Context, instance *models.ServiceInstanceDetails) error {
+// and upates the provided instance with the refreshed info.
+func (b *CloudSQLBroker) UpdateInstanceDetails(ctx context.Context, instance *models.ServiceInstanceDetails) error {
 	var instanceInfo InstanceInformation
 	if err := json.Unmarshal([]byte(instance.OtherDetails), &instanceInfo); err != nil {
 		return fmt.Errorf("Error unmarshalling instance information.")
@@ -494,7 +495,7 @@ func (b *CloudSQLBroker) refreshServiceInstanceDetails(ctx context.Context, inst
 	}
 	instance.OtherDetails = string(otherDetails)
 
-	return db_service.SaveServiceInstanceDetails(ctx, instance)
+	return nil
 }
 
 // createDatabase creates tha database on the instance referenced by ServiceInstanceDetails.

--- a/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
+++ b/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
@@ -114,6 +114,18 @@ type FakeServiceBrokerHelper struct {
 	deprovisionsAsyncReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	UpdateInstanceDetailsStub        func(ctx context.Context, instance *models.ServiceInstanceDetails) error
+	updateInstanceDetailsMutex       sync.RWMutex
+	updateInstanceDetailsArgsForCall []struct {
+		ctx      context.Context
+		instance *models.ServiceInstanceDetails
+	}
+	updateInstanceDetailsReturns struct {
+		result1 error
+	}
+	updateInstanceDetailsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -510,6 +522,55 @@ func (fake *FakeServiceBrokerHelper) DeprovisionsAsyncReturnsOnCall(i int, resul
 	}{result1}
 }
 
+func (fake *FakeServiceBrokerHelper) UpdateInstanceDetails(ctx context.Context, instance *models.ServiceInstanceDetails) error {
+	fake.updateInstanceDetailsMutex.Lock()
+	ret, specificReturn := fake.updateInstanceDetailsReturnsOnCall[len(fake.updateInstanceDetailsArgsForCall)]
+	fake.updateInstanceDetailsArgsForCall = append(fake.updateInstanceDetailsArgsForCall, struct {
+		ctx      context.Context
+		instance *models.ServiceInstanceDetails
+	}{ctx, instance})
+	fake.recordInvocation("UpdateInstanceDetails", []interface{}{ctx, instance})
+	fake.updateInstanceDetailsMutex.Unlock()
+	if fake.UpdateInstanceDetailsStub != nil {
+		return fake.UpdateInstanceDetailsStub(ctx, instance)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.updateInstanceDetailsReturns.result1
+}
+
+func (fake *FakeServiceBrokerHelper) UpdateInstanceDetailsCallCount() int {
+	fake.updateInstanceDetailsMutex.RLock()
+	defer fake.updateInstanceDetailsMutex.RUnlock()
+	return len(fake.updateInstanceDetailsArgsForCall)
+}
+
+func (fake *FakeServiceBrokerHelper) UpdateInstanceDetailsArgsForCall(i int) (context.Context, *models.ServiceInstanceDetails) {
+	fake.updateInstanceDetailsMutex.RLock()
+	defer fake.updateInstanceDetailsMutex.RUnlock()
+	return fake.updateInstanceDetailsArgsForCall[i].ctx, fake.updateInstanceDetailsArgsForCall[i].instance
+}
+
+func (fake *FakeServiceBrokerHelper) UpdateInstanceDetailsReturns(result1 error) {
+	fake.UpdateInstanceDetailsStub = nil
+	fake.updateInstanceDetailsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeServiceBrokerHelper) UpdateInstanceDetailsReturnsOnCall(i int, result1 error) {
+	fake.UpdateInstanceDetailsStub = nil
+	if fake.updateInstanceDetailsReturnsOnCall == nil {
+		fake.updateInstanceDetailsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateInstanceDetailsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeServiceBrokerHelper) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -529,6 +590,8 @@ func (fake *FakeServiceBrokerHelper) Invocations() map[string][][]interface{} {
 	defer fake.provisionsAsyncMutex.RUnlock()
 	fake.deprovisionsAsyncMutex.RLock()
 	defer fake.deprovisionsAsyncMutex.RUnlock()
+	fake.updateInstanceDetailsMutex.RLock()
+	defer fake.updateInstanceDetailsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -33,6 +33,12 @@ type ServiceBrokerHelper interface {
 	PollInstance(ctx context.Context, instance ServiceInstanceDetails) (bool, error)
 	ProvisionsAsync() bool
 	DeprovisionsAsync() bool
+
+	// UpdateInstanceDetails updates the ServiceInstanceDetails with the most recent state from GCP.
+	// This function is optional, but will be called after async provisions, updates, and possibly
+	// on broker version changes.
+	// Return a nil error if you choose not to implement this function.
+	UpdateInstanceDetails(ctx context.Context, instance *ServiceInstanceDetails) error
 }
 
 type AccountManager interface {


### PR DESCRIPTION
Add state polling to the BrokerHelper explicitly to be called after LastOperation succeeds. This does three things:

* Removes an additional piece of lifecycle management logic from each broker.
* Provides a standardized way we can upgrade state in the future when we need additional info to be gathered/stored. For example, re-fetching CloudSQL's status after an upgrade from v1 to v2.
* Gives us a path towards supporting updates.

Part of #250 and #305 