### PR TITLE
CloudSQL schemas

### DIFF
--- a/brokerapi/brokers/cloudsql/common-definition.go
+++ b/brokerapi/brokers/cloudsql/common-definition.go
@@ -21,6 +21,12 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 )
 
+const (
+	passwordTemplate   = "${rand.base64(32)}"
+	usernameTemplate   = `sb${str.truncate(14, time.nano())}`
+	identifierTemplate = `pcf-sb-${counter.next()}-${time.nano()}`
+)
+
 func roleWhitelist() []string {
 	return []string{
 		"cloudsql.editor",
@@ -59,8 +65,8 @@ func commonBindVariables() []broker.BrokerVariable {
 func commonBindComputedVariables() []varcontext.DefaultVariable {
 	return []varcontext.DefaultVariable{
 		// legacy behavior dictates that empty values get defaults
-		{Name: "password", Default: `${password == "" ? rand.base64(32) : password}`, Overwrite: true},
-		{Name: "username", Default: `${username == "" ? "sb${str.truncate(14, time.nano())}" : username}`, Overwrite: true},
+		{Name: "password", Default: `${password == "" ? "` + passwordTemplate + `" : password}`, Overwrite: true},
+		{Name: "username", Default: `${username == "" ? "` + usernameTemplate + `" : username}`, Overwrite: true},
 	}
 }
 
@@ -117,7 +123,7 @@ func commonProvisionVariables() []broker.BrokerVariable {
 		{
 			FieldName: "maintenance_window_day",
 			Type:      broker.JsonTypeString,
-			Details:   "(only for 2nd generation instances) This specifies when a v2 CloudSQL instance should preferably be restarted for system maintenance puruposes. Day of week (1-7), starting on Monday.",
+			Details:   "(only for 2nd generation instances) This specifies when a v2 CloudSQL instance should preferably be restarted for system maintenance purposes. Day of week (1-7), starting on Monday.",
 			Default:   "1",
 			Enum: map[interface{}]string{
 				"1": "Monday",
@@ -189,10 +195,10 @@ func commonProvisionVariables() []broker.BrokerVariable {
 func commonBindOutputVariables() []broker.BrokerVariable {
 	return []broker.BrokerVariable{
 		// Service account credentials (Note: they're a subset of the service account fields returned in a normal request)
-		{FieldName: "Email", Type: broker.JsonTypeString, Details: "Email address of the service account"},
+		{FieldName: "Email", Type: broker.JsonTypeString, Details: "Email address of the service account."},
 		{FieldName: "PrivateKeyData", Type: broker.JsonTypeString, Details: "Service account private key data. Base-64 encoded JSON."},
-		{FieldName: "ProjectId", Type: broker.JsonTypeString, Details: "ID of the project that owns the service account"},
-		{FieldName: "UniqueId", Type: broker.JsonTypeString, Details: "Unique and stable id of the service account"},
+		{FieldName: "ProjectId", Type: broker.JsonTypeString, Details: "ID of the project that owns the service account."},
+		{FieldName: "UniqueId", Type: broker.JsonTypeString, Details: "Unique and stable id of the service account."},
 
 		// Certificate
 		{FieldName: "CaCert", Type: broker.JsonTypeString, Details: "The server Certificate Authority's certificate."},
@@ -201,12 +207,12 @@ func commonBindOutputVariables() []broker.BrokerVariable {
 		{FieldName: "Sha1Fingerprint", Type: broker.JsonTypeString, Details: "The SHA1 fingerprint of the client certificate."},
 
 		// Connection URI
-		{FieldName: "UriPrefix", Type: broker.JsonTypeString, Details: "The connection prefix e.g. `mysql` or `postgres`"},
-		{FieldName: "Username", Type: broker.JsonTypeString, Details: "The name of the SQL user provisioned"},
-		{FieldName: "database_name", Type: broker.JsonTypeString, Details: "The name of the database on the instance"},
-		{FieldName: "host", Type: broker.JsonTypeString, Details: "The hostname or ip of the database instance"},
-		{FieldName: "instance_name", Type: broker.JsonTypeString, Details: "The name of the database instance"},
-		{FieldName: "uri", Type: broker.JsonTypeString, Details: "A database connection string"},
+		{FieldName: "UriPrefix", Type: broker.JsonTypeString, Details: "The connection prefix e.g. `mysql` or `postgres`."},
+		{FieldName: "Username", Type: broker.JsonTypeString, Details: "The name of the SQL user provisioned."},
+		{FieldName: "database_name", Type: broker.JsonTypeString, Details: "The name of the database on the instance."},
+		{FieldName: "host", Type: broker.JsonTypeString, Details: "The hostname or ip of the database instance."},
+		{FieldName: "instance_name", Type: broker.JsonTypeString, Details: "The name of the database instance."},
+		{FieldName: "uri", Type: broker.JsonTypeString, Details: "A database connection string."},
 
 		{FieldName: "last_master_operation_id", Type: broker.JsonTypeString, Details: "(GCP internals) The id of the last operation on the database."},
 		{FieldName: "region", Type: broker.JsonTypeString, Details: "The region the database is in."},

--- a/brokerapi/brokers/cloudsql/common-definition.go
+++ b/brokerapi/brokers/cloudsql/common-definition.go
@@ -18,6 +18,7 @@ import (
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 )
 
 func roleWhitelist() []string {
@@ -53,6 +54,14 @@ func commonBindVariables() []broker.BrokerVariable {
 			Default:   "${rand.base64(32)}",
 		},
 	)
+}
+
+func commonBindComputedVariables() []varcontext.DefaultVariable {
+	return []varcontext.DefaultVariable{
+		// legacy behavior dictates that empty values get defaults
+		{Name: "password", Default: `${password == "" ? rand.base64(32) : password}`, Overwrite: true},
+		{Name: "username", Default: `${username == "" ? "sb${str.truncate(14, time.nano())}" : username}`, Overwrite: true},
+	}
 }
 
 func commonProvisionVariables() []broker.BrokerVariable {

--- a/brokerapi/brokers/cloudsql/common-definition.go
+++ b/brokerapi/brokers/cloudsql/common-definition.go
@@ -17,167 +17,189 @@ package cloudsql
 import (
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 )
 
-var roleWhitelist = []string{
-	"cloudsql.editor",
-	"cloudsql.viewer",
-	"cloudsql.client",
+func roleWhitelist() []string {
+	return []string{
+		"cloudsql.editor",
+		"cloudsql.viewer",
+		"cloudsql.client",
+	}
 }
 
-var commonBindVariables = append(accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
-	broker.BrokerVariable{
-		FieldName: "jdbc_uri_format",
-		Type:      broker.JsonTypeString,
-		Details:   "If `true`, `uri` field will contain a JDBC formatted URI.",
-		Default:   "false",
-	},
-	broker.BrokerVariable{
-		FieldName: "username",
-		Type:      broker.JsonTypeString,
-		Details:   "The SQL username for the account.",
-		Default:   "a generated value",
-	},
-	broker.BrokerVariable{
-		FieldName: "password",
-		Type:      broker.JsonTypeString,
-		Details:   "The SQL password for the account.",
-		Default:   "a generated value",
-	},
-)
-
-var commonProvisionVariables = []broker.BrokerVariable{
-	{
-		FieldName: "instance_name",
-		Type:      broker.JsonTypeString,
-		Details:   "Name of the Cloud SQL instance.",
-		Default:   "a generated value",
-	},
-	{
-		FieldName: "database_name",
-		Type:      broker.JsonTypeString,
-		Details:   "Name of the database inside of the instance.",
-		Default:   "a generated value",
-	},
-	{
-		FieldName: "version",
-		Type:      broker.JsonTypeString,
-		Details:   "The database engine type and version. Defaults to `MYSQL_5_6` for 1st gen MySQL instances, `MYSQL_5_7` for 2nd gen MySQL instances, or `POSTGRES_9_6` for PostgreSQL instances.",
-	},
-	{
-		FieldName: "disk_size",
-		Type:      broker.JsonTypeString,
-		Details:   "In GB (only for 2nd generation instances).",
-		Default:   "10",
-	},
-	{
-		FieldName: "region",
-		Type:      broker.JsonTypeString,
-		Details:   "The geographical region.",
-		Default:   "us-central",
-	},
-	{
-		FieldName: "zone",
-		Type:      broker.JsonTypeString,
-		Details:   "(only for 2nd generation instances)",
-	},
-	{
-		FieldName: "disk_type",
-		Type:      broker.JsonTypeString,
-		Details:   "(only for 2nd generation instances)",
-		Default:   "ssd",
-	},
-	{
-		FieldName: "failover_replica_name",
-		Type:      broker.JsonTypeString,
-		Details:   "(only for 2nd generation instances) If specified, creates a failover replica with the given name.",
-		Default:   "",
-	},
-	{
-		FieldName: "maintenance_window_day",
-		Type:      broker.JsonTypeString,
-		Details:   "(only for 2nd generation instances) The day when disruptive updates (updates that require an instance restart) to this CloudSQL instance can be made. Day of week (1-7), starting on Monday.",
-		Default:   "1",
-	},
-	{
-		FieldName: "maintenance_window_hour",
-		Type:      broker.JsonTypeString,
-		Details:   "(only for 2nd generation instances) The hour of the day when disruptive updates (updates that require an instance restart) to this CloudSQL instance can be made. Hour of day 0-23.",
-		Default:   "0",
-	},
-	{
-		FieldName: "backups_enabled",
-		Type:      broker.JsonTypeString,
-		Details:   "Should daily backups be enabled for the service?",
-		Default:   "true",
-	},
-	{
-		FieldName: "backup_start_time",
-		Type:      broker.JsonTypeString,
-		Details:   "Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM.",
-		Default:   "06:00",
-	},
-	{
-		FieldName: "binlog",
-		Type:      broker.JsonTypeString,
-		Details:   "Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.",
-	},
-	{
-		FieldName: "activation_policy",
-		Type:      broker.JsonTypeString,
-		Details:   "The activation policy specifies when the instance is activated; it is applicable only when the instance state is RUNNABLE.",
-		Default:   "ON_DEMAND",
-		Enum: map[interface{}]string{
-			"ALWAYS":    "Always, instance is always on.",
-			"NEVER":     "Never, instance does not turn on if a request arrives.",
-			"ON_DEMAND": "On Demand, instance responses to incoming requests and turns off when not in use.",
+func commonBindVariables() []broker.BrokerVariable {
+	return append(accountmanagers.ServiceAccountBindInputVariables(roleWhitelist()),
+		broker.BrokerVariable{
+			FieldName: "jdbc_uri_format",
+			Type:      broker.JsonTypeString,
+			Details:   "If `true`, `uri` field will contain a JDBC formatted URI.",
+			Default:   "false",
+			Enum: map[interface{}]string{
+				"true":  "return a JDBC formatted URI",
+				"false": "return a SQL formatted URI",
+			},
 		},
-	},
-	{
-		FieldName: "authorized_networks",
-		Type:      broker.JsonTypeString,
-		Details:   "A comma separated list without spaces.",
-		Default:   "none",
-	},
-	{
-		FieldName: "replication_type",
-		Type:      broker.JsonTypeString,
-		Details:   "The type of replication this instance uses. This can be either ASYNCHRONOUS or SYNCHRONOUS.",
-		Default:   "SYNCHRONOUS",
-		Enum: map[interface{}]string{
-			"ASYNCHRONOUS": "Asynchronous Replication",
-			"SYNCHRONOUS":  "Synchronous Replication",
+		broker.BrokerVariable{
+			FieldName: "username",
+			Type:      broker.JsonTypeString,
+			Details:   "The SQL username for the account.",
+			Default:   `sb${str.truncate(14, time.nano())}`,
 		},
-	},
-	{
-		FieldName: "auto_resize",
-		Type:      broker.JsonTypeString,
-		Details:   "(only for 2nd generation instances) Configuration to increase storage size automatically.",
-		Default:   "false",
-	},
+		broker.BrokerVariable{
+			FieldName: "password",
+			Type:      broker.JsonTypeString,
+			Details:   "The SQL password for the account.",
+			Default:   "${rand.base64(32)}",
+		},
+	)
 }
 
-var commonBindOutputVariables = []broker.BrokerVariable{
-	// Service account credentials (Note: they're a subset of the service account fields returned in a normal request)
-	{FieldName: "Email", Type: broker.JsonTypeString, Details: "Email address of the service account"},
-	{FieldName: "PrivateKeyData", Type: broker.JsonTypeString, Details: "Service account private key data. Base-64 encoded JSON."},
-	{FieldName: "ProjectId", Type: broker.JsonTypeString, Details: "ID of the project that owns the service account"},
-	{FieldName: "UniqueId", Type: broker.JsonTypeString, Details: "Unique and stable id of the service account"},
+func commonProvisionVariables() []broker.BrokerVariable {
+	return []broker.BrokerVariable{
+		{
+			FieldName: "binlog",
+			Type:      broker.JsonTypeString,
+			Details:   "Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.",
+			Enum: map[interface{}]string{
+				"true":  "use binary log",
+				"false": "do not use binary log",
+			},
+		},
+		{
+			FieldName: "disk_size",
+			Type:      broker.JsonTypeString,
+			Details:   "In GB (only for 2nd generation instances).",
+			Default:   "10",
+			Constraints: validation.NewConstraintBuilder().
+				Pattern("^[1-9][0-9]+$").
+				MaxLength(5).
+				Examples("10", "500", "10230").
+				Build(),
+		},
+		{
+			FieldName: "region",
+			Type:      broker.JsonTypeString,
+			Details:   "The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases.",
+			Default:   "us-central",
+			Constraints: validation.NewConstraintBuilder().
+				Pattern("^[A-Za-z][-a-z0-9A-Z]+$").
+				Examples("northamerica-northeast1", "southamerica-east1", "us-east1").
+				Build(),
+		},
+		{
+			FieldName: "zone",
+			Type:      broker.JsonTypeString,
+			Details:   "(only for 2nd generation instances)",
+			Constraints: validation.NewConstraintBuilder().
+				Pattern("^[A-Za-z][-a-z0-9A-Z]+$").
+				Build(),
+		},
+		{
+			FieldName: "disk_type",
+			Type:      broker.JsonTypeString,
+			Details:   "(only for 2nd generation instances)",
+			Default:   "PD_SSD",
+			Enum: map[interface{}]string{
+				"PD_SSD": "flash storage drive",
+				"PD_HDD": "magnetic hard drive",
+			},
+		},
+		{
+			FieldName: "maintenance_window_day",
+			Type:      broker.JsonTypeString,
+			Details:   "(only for 2nd generation instances) This specifies when a v2 CloudSQL instance should preferably be restarted for system maintenance puruposes. Day of week (1-7), starting on Monday.",
+			Default:   "1",
+			Enum: map[interface{}]string{
+				"1": "Monday",
+				"2": "Tuesday",
+				"3": "Wednesday",
+				"4": "Thursday",
+				"5": "Friday",
+				"6": "Saturday",
+				"7": "Sunday",
+			},
+		},
+		{
+			FieldName: "maintenance_window_hour",
+			Type:      broker.JsonTypeString,
+			Details:   "(only for 2nd generation instances) The hour of the day when disruptive updates (updates that require an instance restart) to this CloudSQL instance can be made. Hour of day 0-23.",
+			Default:   "0",
+			Constraints: validation.NewConstraintBuilder().
+				Pattern("^([0-9]|1[0-9]|2[0-3])$").
+				Build(),
+		},
+		{
+			FieldName: "backups_enabled",
+			Type:      broker.JsonTypeString,
+			Details:   "Should daily backups be enabled for the service?",
+			Default:   "true",
+			Enum: map[interface{}]string{
+				"true":  "enable daily backups",
+				"false": "do not enable daily backups",
+			},
+		},
+		{
+			FieldName: "backup_start_time",
+			Type:      broker.JsonTypeString,
+			Details:   "Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM.",
+			Default:   "06:00",
+			Constraints: validation.NewConstraintBuilder().
+				Pattern("^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$").
+				Build(),
+		},
+		{
+			FieldName: "authorized_networks",
+			Type:      broker.JsonTypeString,
+			Details:   "A comma separated list without spaces.",
+			Default:   "",
+		},
+		{
+			FieldName: "replication_type",
+			Type:      broker.JsonTypeString,
+			Details:   "The type of replication this instance uses. This can be either ASYNCHRONOUS or SYNCHRONOUS.",
+			Default:   "SYNCHRONOUS",
+			Enum: map[interface{}]string{
+				"ASYNCHRONOUS": "Asynchronous Replication",
+				"SYNCHRONOUS":  "Synchronous Replication",
+			},
+		},
+		{
+			FieldName: "auto_resize",
+			Type:      broker.JsonTypeString,
+			Details:   "(only for 2nd generation instances) Configuration to increase storage size automatically.",
+			Default:   "false",
+			Enum: map[interface{}]string{
+				"true":  "increase storage size automatically",
+				"false": "do not increase storage size automatically",
+			},
+		},
+	}
+}
 
-	// Certificate
-	{FieldName: "CaCert", Type: broker.JsonTypeString, Details: "The server Certificate Authority's certificate."},
-	{FieldName: "ClientCert", Type: broker.JsonTypeString, Details: "The client certificate. For First Generation instances, the new certificate does not take effect until the instance is restarted."},
-	{FieldName: "ClientKey", Type: broker.JsonTypeString, Details: "The client certificate key."},
-	{FieldName: "Sha1Fingerprint", Type: broker.JsonTypeString, Details: "The SHA1 fingerprint of the client certificate."},
+func commonBindOutputVariables() []broker.BrokerVariable {
+	return []broker.BrokerVariable{
+		// Service account credentials (Note: they're a subset of the service account fields returned in a normal request)
+		{FieldName: "Email", Type: broker.JsonTypeString, Details: "Email address of the service account"},
+		{FieldName: "PrivateKeyData", Type: broker.JsonTypeString, Details: "Service account private key data. Base-64 encoded JSON."},
+		{FieldName: "ProjectId", Type: broker.JsonTypeString, Details: "ID of the project that owns the service account"},
+		{FieldName: "UniqueId", Type: broker.JsonTypeString, Details: "Unique and stable id of the service account"},
 
-	// Connection URI
-	{FieldName: "UriPrefix", Type: broker.JsonTypeString, Details: "The connection prefix e.g. `mysql` or `postgres`"},
-	{FieldName: "Username", Type: broker.JsonTypeString, Details: "The name of the SQL user provisioned"},
-	{FieldName: "database_name", Type: broker.JsonTypeString, Details: "The name of the database on the instance"},
-	{FieldName: "host", Type: broker.JsonTypeString, Details: "The hostname or ip of the database instance"},
-	{FieldName: "instance_name", Type: broker.JsonTypeString, Details: "The name of the database instance"},
-	{FieldName: "uri", Type: broker.JsonTypeString, Details: "A database connection string"},
+		// Certificate
+		{FieldName: "CaCert", Type: broker.JsonTypeString, Details: "The server Certificate Authority's certificate."},
+		{FieldName: "ClientCert", Type: broker.JsonTypeString, Details: "The client certificate. For First Generation instances, the new certificate does not take effect until the instance is restarted."},
+		{FieldName: "ClientKey", Type: broker.JsonTypeString, Details: "The client certificate key."},
+		{FieldName: "Sha1Fingerprint", Type: broker.JsonTypeString, Details: "The SHA1 fingerprint of the client certificate."},
 
-	{FieldName: "last_master_operation_id", Type: broker.JsonTypeString, Details: "(GCP internals) The id of the last operation on the database."},
-	{FieldName: "region", Type: broker.JsonTypeString, Details: "The region the database is in."},
+		// Connection URI
+		{FieldName: "UriPrefix", Type: broker.JsonTypeString, Details: "The connection prefix e.g. `mysql` or `postgres`"},
+		{FieldName: "Username", Type: broker.JsonTypeString, Details: "The name of the SQL user provisioned"},
+		{FieldName: "database_name", Type: broker.JsonTypeString, Details: "The name of the database on the instance"},
+		{FieldName: "host", Type: broker.JsonTypeString, Details: "The hostname or ip of the database instance"},
+		{FieldName: "instance_name", Type: broker.JsonTypeString, Details: "The name of the database instance"},
+		{FieldName: "uri", Type: broker.JsonTypeString, Details: "A database connection string"},
+
+		{FieldName: "last_master_operation_id", Type: broker.JsonTypeString, Details: "(GCP internals) The id of the last operation on the database."},
+		{FieldName: "region", Type: broker.JsonTypeString, Details: "The region the database is in."},
+	}
 }

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -239,13 +239,10 @@ func mysqlServiceDefinition() *broker.BrokerService {
 			// validation
 			{Name: "_", Default: `${assert(disk_size <= max_disk_size, "disk size (${disk_size}) is greater than max allowed disk size for this plan (${max_disk_size})")}`, Overwrite: true},
 		},
-		DefaultRoleWhitelist: roleWhitelist(),
-		BindInputVariables:   commonBindVariables(),
-		BindOutputVariables:  commonBindOutputVariables(),
-		BindComputedVariables: []varcontext.DefaultVariable{
-			{Name: "password", Default: `${password == "" ? rand.base64(32) : password}`, Overwrite: true},
-			{Name: "username", Default: `${username == "" ? "sb${str.truncate(14, time.nano())}" : username}`, Overwrite: true},
-		},
+		DefaultRoleWhitelist:  roleWhitelist(),
+		BindInputVariables:    commonBindVariables(),
+		BindOutputVariables:   commonBindOutputVariables(),
+		BindComputedVariables: commonBindComputedVariables(),
 		PlanVariables: []broker.BrokerVariable{
 			{
 				FieldName: "tier",

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -184,7 +184,7 @@ func mysqlServiceDefinition() *broker.BrokerService {
 				FieldName: "instance_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the Cloud SQL instance.",
-				Default:   "pcf-sb-${counter.next()}-${time.nano()}",
+				Default:   identifierTemplate,
 				Constraints: validation.NewConstraintBuilder().
 					Pattern("^[a-z][a-z0-9-]+$").
 					MaxLength(84).
@@ -194,7 +194,7 @@ func mysqlServiceDefinition() *broker.BrokerService {
 				FieldName: "database_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the database inside of the instance. Must be a valid identifier for your chosen database type.",
-				Default:   "pcf-sb-${counter.next()}-${time.nano()}",
+				Default:   identifierTemplate,
 			},
 			{
 				FieldName: "version",
@@ -230,8 +230,8 @@ func mysqlServiceDefinition() *broker.BrokerService {
 		}, commonProvisionVariables()...),
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
 			// legacy behavior dictates that empty values get defaults
-			{Name: "instance_name", Default: `${instance_name == "" ? "pcf-sb-${counter.next()}-${time.nano()}" : instance_name}`, Overwrite: true},
-			{Name: "database_name", Default: `${database_name == "" ? "pcf-sb-${counter.next()}-${time.nano()}" : database_name}`, Overwrite: true},
+			{Name: "instance_name", Default: `${instance_name == "" ? "` + identifierTemplate + `" : instance_name}`, Overwrite: true},
+			{Name: "database_name", Default: `${database_name == "" ? "` + identifierTemplate + `" : database_name}`, Overwrite: true},
 
 			{Name: "is_first_gen", Default: `${str.matches(tier, "^(d|D)[0-9]+$")}`, Overwrite: true},
 			{Name: "version", Default: `${is_first_gen ? "MYSQL_5_6" : "MYSQL_5_7"}`, Overwrite: false},

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -16,10 +16,16 @@ package cloudsql
 
 import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 )
 
 func init() {
-	bs := &broker.BrokerService{
+	broker.Register(mysqlServiceDefinition())
+}
+
+func mysqlServiceDefinition() *broker.BrokerService {
+	return &broker.BrokerService{
 		Name: "google-cloudsql-mysql",
 		DefaultServiceDefinition: `{
 		    "id": "4bc59b9a-8520-409f-85da-1c7552315863",
@@ -173,10 +179,73 @@ func init() {
 				    }
 				]
 		}`,
-		ProvisionInputVariables: commonProvisionVariables,
-		DefaultRoleWhitelist:    roleWhitelist,
-		BindInputVariables:      commonBindVariables,
-		BindOutputVariables:     commonBindOutputVariables,
+		ProvisionInputVariables: append([]broker.BrokerVariable{
+			{
+				FieldName: "instance_name",
+				Type:      broker.JsonTypeString,
+				Details:   "Name of the Cloud SQL instance.",
+				Default:   "pcf-sb-${counter.next()}-${time.nano()}",
+				Constraints: validation.NewConstraintBuilder().
+					Pattern("^[a-z][a-z0-9-]+$").
+					MaxLength(84).
+					Build(),
+			},
+			{
+				FieldName: "database_name",
+				Type:      broker.JsonTypeString,
+				Details:   "Name of the database inside of the instance. Must be a valid identifier for your chosen database type.",
+				Default:   "pcf-sb-${counter.next()}-${time.nano()}",
+			},
+			{
+				FieldName: "version",
+				Type:      broker.JsonTypeString,
+				Details:   "The database engine type and version. Defaults to `MYSQL_5_6` for 1st gen MySQL instances or `MYSQL_5_7` for 2nd gen MySQL instances.",
+				Enum: map[interface{}]string{
+					"MYSQL_5_5": "MySQL 5.5.X",
+					"MYSQL_5_6": "MySQL 5.6.X",
+					"MYSQL_5_7": "MySQL 5.7.X",
+				},
+			},
+			{
+				FieldName: "failover_replica_name",
+				Type:      broker.JsonTypeString,
+				Details:   "(only for 2nd generation instances) If specified, creates a failover replica with the given name.",
+				Default:   "",
+				Constraints: validation.NewConstraintBuilder().
+					Pattern("^[a-z][a-z0-9-]+$").
+					MaxLength(84).
+					Build(),
+			},
+			{
+				FieldName: "activation_policy",
+				Type:      broker.JsonTypeString,
+				Details:   "The activation policy specifies when the instance is activated; it is applicable only when the instance state is RUNNABLE.",
+				Default:   "ALWAYS",
+				Enum: map[interface{}]string{
+					"ALWAYS":    "Always, instance is always on.",
+					"NEVER":     "Never, instance does not turn on if a request arrives.",
+					"ON_DEMAND": "On Demand, instance responds to incoming requests and turns off when not in use.",
+				},
+			},
+		}, commonProvisionVariables()...),
+		ProvisionComputedVariables: []varcontext.DefaultVariable{
+			// legacy behavior dictates that empty values get defaults
+			{Name: "instance_name", Default: `${instance_name == "" ? "pcf-sb-${counter.next()}-${time.nano()}" : instance_name}`, Overwrite: true},
+			{Name: "database_name", Default: `${database_name == "" ? "pcf-sb-${counter.next()}-${time.nano()}" : database_name}`, Overwrite: true},
+
+			{Name: "is_first_gen", Default: `${str.matches(tier, "^(d|D)[0-9]+$")}`, Overwrite: true},
+			{Name: "version", Default: `${is_first_gen ? "MYSQL_5_6" : "MYSQL_5_7"}`, Overwrite: false},
+
+			// validation
+			{Name: "_", Default: `${assert(disk_size <= max_disk_size, "disk size (${disk_size}) is greater than max allowed disk size for this plan (${max_disk_size})")}`, Overwrite: true},
+		},
+		DefaultRoleWhitelist: roleWhitelist(),
+		BindInputVariables:   commonBindVariables(),
+		BindOutputVariables:  commonBindOutputVariables(),
+		BindComputedVariables: []varcontext.DefaultVariable{
+			{Name: "password", Default: `${password == "" ? rand.base64(32) : password}`, Overwrite: true},
+			{Name: "username", Default: `${username == "" ? "sb${str.truncate(14, time.nano())}" : username}`, Overwrite: true},
+		},
 		PlanVariables: []broker.BrokerVariable{
 			{
 				FieldName: "tier",
@@ -219,6 +288,4 @@ func init() {
 			},
 		},
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -139,7 +139,7 @@ func postgresServiceDefinition() *broker.BrokerService {
 				FieldName: "instance_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the CloudSQL instance.",
-				Default:   "pcf-sb-${counter.next()}-${time.nano()}",
+				Default:   identifierTemplate,
 				Constraints: validation.NewConstraintBuilder().
 					Pattern("^[a-z][a-z0-9-]+$").
 					MaxLength(75).
@@ -149,7 +149,7 @@ func postgresServiceDefinition() *broker.BrokerService {
 				FieldName: "database_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the database inside of the instance. Must be a valid identifier for your chosen database type.",
-				Default:   "pcf-sb-${counter.next()}-${time.nano()}",
+				Default:   identifierTemplate,
 			},
 			{
 				FieldName: "version",
@@ -183,8 +183,8 @@ func postgresServiceDefinition() *broker.BrokerService {
 		}, commonProvisionVariables()...),
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
 			// legacy behavior dictates that empty values get defaults
-			{Name: "instance_name", Default: `${instance_name == "" ? "pcf-sb-${counter.next()}-${time.nano()}" : instance_name}`, Overwrite: true},
-			{Name: "database_name", Default: `${database_name == "" ? "pcf-sb-${counter.next()}-${time.nano()}" : database_name}`, Overwrite: true},
+			{Name: "instance_name", Default: `${instance_name == "" ? "` + identifierTemplate + `" : instance_name}`, Overwrite: true},
+			{Name: "database_name", Default: `${database_name == "" ? "` + identifierTemplate + `" : database_name}`, Overwrite: true},
 
 			{Name: "is_first_gen", Default: `false`, Overwrite: true},
 

--- a/docs/custom-services.md
+++ b/docs/custom-services.md
@@ -59,7 +59,6 @@ When you're creating a new service for the broker you're designing for three sep
 * The operators, the people who are responsible for approving services and plans for developers to use.
 * Yourself, the person who has to maintain the service, strike the right balance of power between the operators and users, and make sure and make sure the new plans/services work as intended.
 
-
 The following sections contain guidelines to help you out.
 
 ### Deciding what to include
@@ -89,7 +88,6 @@ In general, properties which have monetary cost or affect the security of the pl
 
 In our static site bucket example the operator would create plans for different domain names (security) and bucket locations/durabilities (pricing) and the developer would get to set the parameters for the default index/error pages and maybe hostname. A full CNAME would be calculated from the hostname and domain name combination. It isn't clear who would get control over the Pub/Sub endpoint. On one hand, the developers might need it to update a search engine index but on the other the operator might to conduct ongoing security audits.
 
-
 ### Deciding on sensible defaults
 
 The GCP Service Broker operates under the model that the users are benign but fallible.
@@ -97,7 +95,6 @@ Sensible defaults are secure and work well in the average use-case.
 This highly depends on your target audience.
 
 For example, a Pub/Sub instance with one-to-many semantics might default to a read-only role, assuming the default consumer is just going to be a worker node whereas a Pub/Sub instance with many-to-many semantics might default to a read/write role even if some consumers want to be read-only.
-
 
 ### Deciding on what your default plans will look like
 

--- a/docs/custom-services.md
+++ b/docs/custom-services.md
@@ -64,17 +64,25 @@ The following sections contain guidelines to help you out.
 ### Deciding what to include
 
 Services don't need to map one-to-one with cloud products, and probably shouldn't.
-Ideally a service will allow you to get a single, useful, task done and use plans to decide what kind of scale you want it done at.
+Instead, services should be focused around particular workflows, allowing you to get a single, useful, task done.
+Service plans allow you to scale that up or down.
+
+For example, Google CloudSQL contains options for high availability, PostgreSQL and MySQL servers, managing on-prem servers, and read-only replication architectures.
+These features all exist for different audiences, and a generic service trying to fit all the use-cases won't give a good experience to the users, operators, or maintainers.
 
 If you find yourself wishing you could selectively enable or disable variables based on flags, it's a sign you should break down your code into another service.
 For example, a Cloud Storage bucket can be configured to have a retention policy, a public-facing URL, and/or push file-change updates to a Pub/Sub queue.
-It would be a good idea to break those features into two separate services.
-One for hosting a static website with settings for URL, index/error pages, and CNAME.
-And the other for general storage that has retention policies.
-Both could make use of a single variable for a queue.
-This helps while creating plans for them too.
-The static site plans could be simple, maybe containing different domain names and regions.
-The archive bucket plans could be for different retention policies and object durability.
+It would be a good idea to break those features into multiple distinct services:
+
+* One for hosting a static website with settings for URL, index/error pages, and CNAME.
+* Another the other for general storage that has retention policies.
+* A third that also provisions a Pub/Sub queue and acts as a staging area for data.
+
+Breaking things down like this makes it easier to figure out what variables you need to expose, what risks they entail and what kind of plans you'll want:
+
+* The static site plans could be simple, maybe containing different domain names and regions.
+* The archive bucket plans could be for different retention policies and object durability.
+* The staging bucket plans could include options for setting up alerting and the queue at the same time as the bucket is created.
 
 Each cloud service you expose will have a plethora of tunable parameters to choose from.
 Ideally, you should expose enough to be useful to developers and secure, but few enough that your service has a well defined use-case.
@@ -96,7 +104,7 @@ This highly depends on your target audience.
 
 For example, a Pub/Sub instance with one-to-many semantics might default to a read-only role, assuming the default consumer is just going to be a worker node whereas a Pub/Sub instance with many-to-many semantics might default to a read/write role even if some consumers want to be read-only.
 
-### Deciding on what your default plans will look like
+### Deciding on what your default plans will be
 
 If you've gotten to this point, you should have a clear understanding of what your service is trying to accomplish, who the users are, and what variables are configurable in your plans.
 It can be tempting to include every permutation of the variables for plans.

--- a/pkg/varcontext/interpolation/eval_test.go
+++ b/pkg/varcontext/interpolation/eval_test.go
@@ -39,6 +39,14 @@ func TestEval(t *testing.T) {
 		"Truncate Required":     {Template: `${str.truncate(2, "expression")}`, Expected: "ex"},
 		"Truncate Not Required": {Template: `${str.truncate(200, "expression")}`, Expected: "expression"},
 		"Counter":               {Template: "${counter.next()},${counter.next()},${counter.next()}", Expected: "1,2,3"},
+		"Regex":                 {Template: `${regexp.matches("^(D|d)[0-9]+$", "d12345")}`, Expected: "true"},
+		"Bad Regex":             {Template: `${regexp.matches("^($", "d12345")}`, ErrorContains: "error parsing regexp"},
+		"Conditionals True":     {Template: `${true ? "foo" : "bar"}`, Expected: "foo"},
+		"Conditionals False":    {Template: `${false ? "foo" : "bar"}`, Expected: "bar"},
+		"No Short Circuit":      {Template: `${false ? counter.next() : counter.next()}`, Expected: "2"},
+		"assert success":        {Template: `${assert(true, "nothing should happen")}`, Expected: "true"},
+		"assert failure":        {Template: `${assert(false, "failure message")}`, ErrorContains: "failure message"},
+		"assert message":        {Template: `${assert(false, "failure message ${1+1}")}`, ErrorContains: "failure message 2"},
 	}
 
 	for tn, tc := range tests {


### PR DESCRIPTION
I'd like your opinion(s) on this. I've gone and defined the schemas before changing the code for `broker.go` so you can compare the two.

I added the ability to do assertions in the broker variables. The set variables won't affect anything when run, but we do need them in order to maintain the same functionality we had before.

If the CloudSQL API behaves correctly, then we shouldn't need the assertion at all.

Based on all the transformation I've been doing, I wrote down guidelines for future services we (and others) build out.

There is a "breaking" change in this code when combined with the JSONSchema code. The hard drive constants we were provisioning with before weren't in any way valid, I suspect the CloudSQL API was seeing an invalid value and defaulting back to SSD, but if that's the case then users that entered "hdd" thinking it was the other option would instead be getting the more expensive SSD as well. Therefore I'm considering it a bug fix instead.

I also have some hesitations that we're not doing PostgreSQL HA correctly, but that's another story.