### PR TITLE
simplify BuildInstanceCredentials and Bind

### DIFF
--- a/brokerapi/brokers/broker_base/broker_base.go
+++ b/brokerapi/brokers/broker_base/broker_base.go
@@ -16,9 +16,11 @@ package broker_base
 
 import (
 	"context"
+	"encoding/json"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 
 	"github.com/pivotal-cf/brokerapi"
 	"golang.org/x/oauth2/jwt"
@@ -35,14 +37,22 @@ type BrokerBase struct {
 
 // Bind creates a service account with access to the provisioned resource with
 // the given instance.
-func (b *BrokerBase) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *BrokerBase) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (map[string]interface{}, error) {
 	return b.AccountManager.CreateCredentials(ctx, instanceID, bindingID, details, models.ServiceInstanceDetails{})
 }
 
 // BuildInstanceCredentials combines the bind credentials with the connection
 // information in the instance details to get a full set of connection details.
-func (b *BrokerBase) BuildInstanceCredentials(ctx context.Context, bindDetails models.ServiceBindingCredentials, instanceDetails models.ServiceInstanceDetails) (map[string]interface{}, error) {
-	return b.AccountManager.BuildInstanceCredentials(ctx, bindDetails, instanceDetails)
+func (b *BrokerBase) BuildInstanceCredentials(ctx context.Context, bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]interface{}, error) {
+	vc, err := varcontext.Builder().
+		MergeJsonObject(json.RawMessage(bindRecord.OtherDetails)).
+		MergeJsonObject(json.RawMessage(instanceRecord.OtherDetails)).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	return vc.ToMap(), nil
 }
 
 // Unbind deletes the created service account from the GCP Project.

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -236,20 +236,20 @@ func (b *CloudSQLBroker) ensureUsernamePassword(instanceID, bindingID string, de
 // Bind creates a new username, password, and set of ssl certs for the given instance.
 // The function may be slow to return because CloudSQL operations are asynchronous.
 // The default PCF service broker timeout may need to be raised to 90 or 120 seconds to accommodate the long bind time.
-func (b *CloudSQLBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *CloudSQLBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (map[string]interface{}, error) {
 	// get context before trying to create anything to catch errors early
 	cloudDb, err := db_service.GetServiceInstanceDetailsById(ctx, instanceID)
 	if err != nil {
-		return models.ServiceBindingCredentials{}, brokerapi.ErrInstanceDoesNotExist
+		return nil, brokerapi.ErrInstanceDoesNotExist
 	}
 
 	params := make(map[string]interface{})
 	if err := json.Unmarshal(details.RawParameters, &params); err != nil {
-		return models.ServiceBindingCredentials{}, fmt.Errorf("Error unmarshalling parameters: %s", err)
+		return nil, fmt.Errorf("Error unmarshalling parameters: %s", err)
 	}
 
 	if err := b.ensureUsernamePassword(instanceID, bindingID, &details); err != nil {
-		return models.ServiceBindingCredentials{}, err
+		return nil, err
 	}
 
 	combinedCreds := varcontext.Builder()
@@ -259,8 +259,7 @@ func (b *CloudSQLBroker) Bind(ctx context.Context, instanceID, bindingID string,
 	if err != nil {
 		return saCreds, err
 	}
-
-	combinedCreds.MergeJsonObject(json.RawMessage(saCreds.OtherDetails))
+	combinedCreds.MergeMap(saCreds)
 
 	sqlCreds, err := b.createSqlCredentials(ctx, instanceID, bindingID, details, *cloudDb)
 	if err != nil {
@@ -274,18 +273,7 @@ func (b *CloudSQLBroker) Bind(ctx context.Context, instanceID, bindingID string,
 	}
 	combinedCreds.MergeMap(map[string]interface{}{"UriPrefix": uriPrefix})
 
-	builtCreds, err := combinedCreds.Build()
-	if err != nil {
-		return saCreds, err
-	}
-
-	credBytes, err := builtCreds.ToJson()
-	if err != nil {
-		return saCreds, err
-	}
-
-	saCreds.OtherDetails = string(credBytes)
-	return saCreds, nil
+	return combinedCreds.BuildMap()
 }
 
 func (b *CloudSQLBroker) BuildInstanceCredentials(ctx context.Context, bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]interface{}, error) {

--- a/brokerapi/brokers/datastore/broker.go
+++ b/brokerapi/brokers/datastore/broker.go
@@ -38,6 +38,6 @@ func (b *DatastoreBroker) Deprovision(ctx context.Context, instance models.Servi
 }
 
 // Bind creates a service account with access to Datastore.
-func (b *DatastoreBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *DatastoreBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (map[string]interface{}, error) {
 	return b.AccountManager.CreateAccountWithRoles(ctx, instanceID, []string{"datastore.user"})
 }

--- a/brokerapi/brokers/models/modelsfakes/fake_service_account_manager.go
+++ b/brokerapi/brokers/models/modelsfakes/fake_service_account_manager.go
@@ -10,7 +10,7 @@ import (
 )
 
 type FakeServiceAccountManager struct {
-	CreateCredentialsStub        func(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error)
+	CreateCredentialsStub        func(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (map[string]interface{}, error)
 	createCredentialsMutex       sync.RWMutex
 	createCredentialsArgsForCall []struct {
 		ctx        context.Context
@@ -20,11 +20,11 @@ type FakeServiceAccountManager struct {
 		instance   models.ServiceInstanceDetails
 	}
 	createCredentialsReturns struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}
 	createCredentialsReturnsOnCall map[int]struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}
 	DeleteCredentialsStub        func(ctx context.Context, creds models.ServiceBindingCredentials) error
@@ -39,22 +39,7 @@ type FakeServiceAccountManager struct {
 	deleteCredentialsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	BuildInstanceCredentialsStub        func(ctx context.Context, bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]interface{}, error)
-	buildInstanceCredentialsMutex       sync.RWMutex
-	buildInstanceCredentialsArgsForCall []struct {
-		ctx            context.Context
-		bindRecord     models.ServiceBindingCredentials
-		instanceRecord models.ServiceInstanceDetails
-	}
-	buildInstanceCredentialsReturns struct {
-		result1 map[string]interface{}
-		result2 error
-	}
-	buildInstanceCredentialsReturnsOnCall map[int]struct {
-		result1 map[string]interface{}
-		result2 error
-	}
-	CreateAccountWithRolesStub        func(ctx context.Context, bindingID string, roles []string) (models.ServiceBindingCredentials, error)
+	CreateAccountWithRolesStub        func(ctx context.Context, bindingID string, roles []string) (map[string]interface{}, error)
 	createAccountWithRolesMutex       sync.RWMutex
 	createAccountWithRolesArgsForCall []struct {
 		ctx       context.Context
@@ -62,18 +47,18 @@ type FakeServiceAccountManager struct {
 		roles     []string
 	}
 	createAccountWithRolesReturns struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}
 	createAccountWithRolesReturnsOnCall map[int]struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServiceAccountManager) CreateCredentials(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
+func (fake *FakeServiceAccountManager) CreateCredentials(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (map[string]interface{}, error) {
 	fake.createCredentialsMutex.Lock()
 	ret, specificReturn := fake.createCredentialsReturnsOnCall[len(fake.createCredentialsArgsForCall)]
 	fake.createCredentialsArgsForCall = append(fake.createCredentialsArgsForCall, struct {
@@ -106,24 +91,24 @@ func (fake *FakeServiceAccountManager) CreateCredentialsArgsForCall(i int) (cont
 	return fake.createCredentialsArgsForCall[i].ctx, fake.createCredentialsArgsForCall[i].instanceID, fake.createCredentialsArgsForCall[i].bindingID, fake.createCredentialsArgsForCall[i].details, fake.createCredentialsArgsForCall[i].instance
 }
 
-func (fake *FakeServiceAccountManager) CreateCredentialsReturns(result1 models.ServiceBindingCredentials, result2 error) {
+func (fake *FakeServiceAccountManager) CreateCredentialsReturns(result1 map[string]interface{}, result2 error) {
 	fake.CreateCredentialsStub = nil
 	fake.createCredentialsReturns = struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeServiceAccountManager) CreateCredentialsReturnsOnCall(i int, result1 models.ServiceBindingCredentials, result2 error) {
+func (fake *FakeServiceAccountManager) CreateCredentialsReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
 	fake.CreateCredentialsStub = nil
 	if fake.createCredentialsReturnsOnCall == nil {
 		fake.createCredentialsReturnsOnCall = make(map[int]struct {
-			result1 models.ServiceBindingCredentials
+			result1 map[string]interface{}
 			result2 error
 		})
 	}
 	fake.createCredentialsReturnsOnCall[i] = struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}{result1, result2}
 }
@@ -177,60 +162,7 @@ func (fake *FakeServiceAccountManager) DeleteCredentialsReturnsOnCall(i int, res
 	}{result1}
 }
 
-func (fake *FakeServiceAccountManager) BuildInstanceCredentials(ctx context.Context, bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]interface{}, error) {
-	fake.buildInstanceCredentialsMutex.Lock()
-	ret, specificReturn := fake.buildInstanceCredentialsReturnsOnCall[len(fake.buildInstanceCredentialsArgsForCall)]
-	fake.buildInstanceCredentialsArgsForCall = append(fake.buildInstanceCredentialsArgsForCall, struct {
-		ctx            context.Context
-		bindRecord     models.ServiceBindingCredentials
-		instanceRecord models.ServiceInstanceDetails
-	}{ctx, bindRecord, instanceRecord})
-	fake.recordInvocation("BuildInstanceCredentials", []interface{}{ctx, bindRecord, instanceRecord})
-	fake.buildInstanceCredentialsMutex.Unlock()
-	if fake.BuildInstanceCredentialsStub != nil {
-		return fake.BuildInstanceCredentialsStub(ctx, bindRecord, instanceRecord)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.buildInstanceCredentialsReturns.result1, fake.buildInstanceCredentialsReturns.result2
-}
-
-func (fake *FakeServiceAccountManager) BuildInstanceCredentialsCallCount() int {
-	fake.buildInstanceCredentialsMutex.RLock()
-	defer fake.buildInstanceCredentialsMutex.RUnlock()
-	return len(fake.buildInstanceCredentialsArgsForCall)
-}
-
-func (fake *FakeServiceAccountManager) BuildInstanceCredentialsArgsForCall(i int) (context.Context, models.ServiceBindingCredentials, models.ServiceInstanceDetails) {
-	fake.buildInstanceCredentialsMutex.RLock()
-	defer fake.buildInstanceCredentialsMutex.RUnlock()
-	return fake.buildInstanceCredentialsArgsForCall[i].ctx, fake.buildInstanceCredentialsArgsForCall[i].bindRecord, fake.buildInstanceCredentialsArgsForCall[i].instanceRecord
-}
-
-func (fake *FakeServiceAccountManager) BuildInstanceCredentialsReturns(result1 map[string]interface{}, result2 error) {
-	fake.BuildInstanceCredentialsStub = nil
-	fake.buildInstanceCredentialsReturns = struct {
-		result1 map[string]interface{}
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeServiceAccountManager) BuildInstanceCredentialsReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
-	fake.BuildInstanceCredentialsStub = nil
-	if fake.buildInstanceCredentialsReturnsOnCall == nil {
-		fake.buildInstanceCredentialsReturnsOnCall = make(map[int]struct {
-			result1 map[string]interface{}
-			result2 error
-		})
-	}
-	fake.buildInstanceCredentialsReturnsOnCall[i] = struct {
-		result1 map[string]interface{}
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeServiceAccountManager) CreateAccountWithRoles(ctx context.Context, bindingID string, roles []string) (models.ServiceBindingCredentials, error) {
+func (fake *FakeServiceAccountManager) CreateAccountWithRoles(ctx context.Context, bindingID string, roles []string) (map[string]interface{}, error) {
 	var rolesCopy []string
 	if roles != nil {
 		rolesCopy = make([]string, len(roles))
@@ -266,24 +198,24 @@ func (fake *FakeServiceAccountManager) CreateAccountWithRolesArgsForCall(i int) 
 	return fake.createAccountWithRolesArgsForCall[i].ctx, fake.createAccountWithRolesArgsForCall[i].bindingID, fake.createAccountWithRolesArgsForCall[i].roles
 }
 
-func (fake *FakeServiceAccountManager) CreateAccountWithRolesReturns(result1 models.ServiceBindingCredentials, result2 error) {
+func (fake *FakeServiceAccountManager) CreateAccountWithRolesReturns(result1 map[string]interface{}, result2 error) {
 	fake.CreateAccountWithRolesStub = nil
 	fake.createAccountWithRolesReturns = struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeServiceAccountManager) CreateAccountWithRolesReturnsOnCall(i int, result1 models.ServiceBindingCredentials, result2 error) {
+func (fake *FakeServiceAccountManager) CreateAccountWithRolesReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
 	fake.CreateAccountWithRolesStub = nil
 	if fake.createAccountWithRolesReturnsOnCall == nil {
 		fake.createAccountWithRolesReturnsOnCall = make(map[int]struct {
-			result1 models.ServiceBindingCredentials
+			result1 map[string]interface{}
 			result2 error
 		})
 	}
 	fake.createAccountWithRolesReturnsOnCall[i] = struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}{result1, result2}
 }
@@ -295,8 +227,6 @@ func (fake *FakeServiceAccountManager) Invocations() map[string][][]interface{} 
 	defer fake.createCredentialsMutex.RUnlock()
 	fake.deleteCredentialsMutex.RLock()
 	defer fake.deleteCredentialsMutex.RUnlock()
-	fake.buildInstanceCredentialsMutex.RLock()
-	defer fake.buildInstanceCredentialsMutex.RUnlock()
 	fake.createAccountWithRolesMutex.RLock()
 	defer fake.createAccountWithRolesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
+++ b/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
@@ -26,7 +26,7 @@ type FakeServiceBrokerHelper struct {
 		result1 models.ServiceInstanceDetails
 		result2 error
 	}
-	BindStub        func(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error)
+	BindStub        func(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (map[string]interface{}, error)
 	bindMutex       sync.RWMutex
 	bindArgsForCall []struct {
 		ctx        context.Context
@@ -35,11 +35,11 @@ type FakeServiceBrokerHelper struct {
 		details    brokerapi.BindDetails
 	}
 	bindReturns struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}
 	bindReturnsOnCall map[int]struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}
 	BuildInstanceCredentialsStub        func(ctx context.Context, bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]interface{}, error)
@@ -186,7 +186,7 @@ func (fake *FakeServiceBrokerHelper) ProvisionReturnsOnCall(i int, result1 model
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) Bind(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (fake *FakeServiceBrokerHelper) Bind(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails) (map[string]interface{}, error) {
 	fake.bindMutex.Lock()
 	ret, specificReturn := fake.bindReturnsOnCall[len(fake.bindArgsForCall)]
 	fake.bindArgsForCall = append(fake.bindArgsForCall, struct {
@@ -218,24 +218,24 @@ func (fake *FakeServiceBrokerHelper) BindArgsForCall(i int) (context.Context, st
 	return fake.bindArgsForCall[i].ctx, fake.bindArgsForCall[i].instanceID, fake.bindArgsForCall[i].bindingID, fake.bindArgsForCall[i].details
 }
 
-func (fake *FakeServiceBrokerHelper) BindReturns(result1 models.ServiceBindingCredentials, result2 error) {
+func (fake *FakeServiceBrokerHelper) BindReturns(result1 map[string]interface{}, result2 error) {
 	fake.BindStub = nil
 	fake.bindReturns = struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) BindReturnsOnCall(i int, result1 models.ServiceBindingCredentials, result2 error) {
+func (fake *FakeServiceBrokerHelper) BindReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
 	fake.BindStub = nil
 	if fake.bindReturnsOnCall == nil {
 		fake.bindReturnsOnCall = make(map[int]struct {
-			result1 models.ServiceBindingCredentials
+			result1 map[string]interface{}
 			result2 error
 		})
 	}
 	fake.bindReturnsOnCall[i] = struct {
-		result1 models.ServiceBindingCredentials
+		result1 map[string]interface{}
 		result2 error
 	}{result1, result2}
 }

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -25,7 +25,9 @@ import (
 
 type ServiceBrokerHelper interface {
 	Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan ServicePlan) (ServiceInstanceDetails, error)
-	Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (ServiceBindingCredentials, error)
+	// Bind creates credentials for accessing the service and stores information necessary to
+	// access the service _and_ delete the binding in the returned map.
+	Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (map[string]interface{}, error)
 	BuildInstanceCredentials(ctx context.Context, bindRecord ServiceBindingCredentials, instanceRecord ServiceInstanceDetails) (map[string]interface{}, error)
 	Unbind(ctx context.Context, details ServiceBindingCredentials) error
 	// Deprovision deprovisions the service.
@@ -44,10 +46,9 @@ type ServiceBrokerHelper interface {
 }
 
 type ServiceAccountManager interface {
-	CreateCredentials(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance ServiceInstanceDetails) (ServiceBindingCredentials, error)
+	CreateCredentials(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance ServiceInstanceDetails) (map[string]interface{}, error)
 	DeleteCredentials(ctx context.Context, creds ServiceBindingCredentials) error
-	BuildInstanceCredentials(ctx context.Context, bindRecord ServiceBindingCredentials, instanceRecord ServiceInstanceDetails) (map[string]interface{}, error)
-	CreateAccountWithRoles(ctx context.Context, bindingID string, roles []string) (ServiceBindingCredentials, error)
+	CreateAccountWithRoles(ctx context.Context, bindingID string, roles []string) (map[string]interface{}, error)
 }
 
 // This custom user agent string is added to provision calls so that Google can track the aggregated use of this tool

--- a/brokerapi/brokers/stackdriver_debugger/broker.go
+++ b/brokerapi/brokers/stackdriver_debugger/broker.go
@@ -38,6 +38,6 @@ func (b *StackdriverDebuggerBroker) Deprovision(ctx context.Context, instance mo
 }
 
 // Bind creates a service account with access to Stackdriver Debugger.
-func (b *StackdriverDebuggerBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *StackdriverDebuggerBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (map[string]interface{}, error) {
 	return b.AccountManager.CreateAccountWithRoles(ctx, bindingID, []string{"clouddebugger.agent"})
 }

--- a/brokerapi/brokers/stackdriver_profiler/broker.go
+++ b/brokerapi/brokers/stackdriver_profiler/broker.go
@@ -38,6 +38,6 @@ func (b *StackdriverProfilerBroker) Deprovision(ctx context.Context, instance mo
 }
 
 // Bind creates a service account with access to Stackdriver Profiler.
-func (b *StackdriverProfilerBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *StackdriverProfilerBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (map[string]interface{}, error) {
 	return b.AccountManager.CreateAccountWithRoles(ctx, bindingID, []string{"cloudprofiler.agent"})
 }

--- a/brokerapi/brokers/stackdriver_trace/broker.go
+++ b/brokerapi/brokers/stackdriver_trace/broker.go
@@ -38,6 +38,6 @@ func (b *StackdriverTraceBroker) Deprovision(ctx context.Context, instance model
 }
 
 // Bind creates a service account with access to Stackdriver Trace.
-func (b *StackdriverTraceBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *StackdriverTraceBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (map[string]interface{}, error) {
 	return b.AccountManager.CreateAccountWithRoles(ctx, bindingID, []string{"cloudtrace.agent"})
 }


### PR DESCRIPTION
Further #250 by simplifying the IAM account managers by making them return only connection info as a map rather than DB stuff they shouldn't care about.

This reduces a lot of the marshaling/unmarshaling of JSON we were doing internally and possible error cases that could raise.