### PR TITLE
added the concept of constants to varcontext which can't be overridden

### DIFF
--- a/docs/custom-services.md
+++ b/docs/custom-services.md
@@ -51,6 +51,18 @@ The following string interpolation functions are available for use:
   * Generates `count` bytes of cryptographically secure randomness and converts it to [URL Encoded Base64](https://tools.ietf.org/html/rfc4648).
   * The randomness makes it suitable for using as passwords.
 
+## Variable reference
+
+The broker makes additional variables available to be used during provision and bind calls.
+
+### Provision
+
+* `request.service.id` - _string_ The GUID of the requested service.
+* `request.plan.id` - _string_ The ID of the requested plan. Plan IDs are unique within an instance.
+* `request.instance.id` - _string_ The ID of the requested instance. Instance IDs are unique within a service.
+* `request.default_labels` - _map[string]string_ A map of labels that should be applied to the created infrastructure for billing/accounting/tracking purposes.
+
+
 ## Design guidelines
 
 When you're creating a new service for the broker you're designing for three separate sets of people:

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -335,7 +335,15 @@ func (svc *BrokerService) provisionDefaults() []varcontext.DefaultVariable {
 func (svc *BrokerService) ProvisionVariables(instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (*varcontext.VarContext, error) {
 	defaults := svc.provisionDefaults()
 
+	constants := map[string]interface{}{
+		"request.plan.id":        details.PlanID,
+		"request.service.id":     details.ServiceID,
+		"request.instance.id":    details.ServiceID,
+		"request.default_labels": utils.ExtractDefaultLabels(instanceId, details),
+	}
+
 	return varcontext.Builder().
+		SetEvalConstants(constants).
 		MergeMap(svc.ProvisionDefaultOverrides()).
 		MergeJsonObject(details.GetRawParameters()).
 		MergeDefaults(defaults).

--- a/pkg/varcontext/builder_test.go
+++ b/pkg/varcontext/builder_test.go
@@ -109,6 +109,21 @@ func TestContextBuilder(t *testing.T) {
 			}{Name: "Foo"}),
 			Expected: map[string]interface{}{"username": "Foo"},
 		},
+
+		// constants
+		"Basic constants": {
+			Builder: Builder().
+				SetEvalConstants(map[string]interface{}{"PI": 3.14}).
+				MergeEvalResult("out", "${PI}"),
+			Expected: map[string]interface{}{"out": "3.14"},
+		},
+		"User overrides constant": {
+			Builder: Builder().
+				SetEvalConstants(map[string]interface{}{"PI": 3.14}).
+				MergeMap(map[string]interface{}{"PI": 3.2}). // reassign incorrectly, https://en.wikipedia.org/wiki/Indiana_Pi_Bill
+				MergeEvalResult("PI", "${PI}"),              // test which PI gets referenced
+			Expected: map[string]interface{}{"PI": "3.14"},
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
This PR adds a concept of constants which aren't overridable by users or available in the output, they're simply there to be used if required.

These could include, for example, project ID, instance ID, service ID, default labels, instance information and mathematical constants.

This isn't the most elegant solution for a DSL, but a more complicated one would likely be overkill because this is the last major use-case for our internal "language" to make is suitable converting our existing variables over.