### PR TITLE
Bind instance passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ability to create custom Cloud Storage plans.
 - New tile form for creating custom Cloud Storage plans.
 
+### Fixed
+- Fixed issue where Cloud Datastore service accounts were getting the same name.
+
 ## [4.0.0] - 2018-10-01
 
 ### Added

--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -46,7 +46,7 @@ type ServiceAccountManager struct {
 
 // If roleWhitelist is specified, then the extracted role is validated against it and an error is returned if
 // the role is not contained within the whitelist
-func (sam *ServiceAccountManager) CreateCredentials(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
+func (sam *ServiceAccountManager) CreateCredentials(ctx context.Context, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
 	role, err := extractRole(details)
 	if err != nil {
 		return models.ServiceBindingCredentials{}, err

--- a/brokerapi/brokers/broker_base/broker_base.go
+++ b/brokerapi/brokers/broker_base/broker_base.go
@@ -35,8 +35,8 @@ type BrokerBase struct {
 
 // Bind creates a service account with access to the provisioned resource with
 // the given instance.
-func (b *BrokerBase) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
-	return b.AccountManager.CreateCredentials(ctx, instanceID, bindingID, details, models.ServiceInstanceDetails{})
+func (b *BrokerBase) Bind(ctx context.Context, instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+	return b.AccountManager.CreateCredentials(ctx, bindingID, details, instance)
 }
 
 // BuildInstanceCredentials combines the bind credentials with the connection

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -236,33 +236,28 @@ func (b *CloudSQLBroker) ensureUsernamePassword(instanceID, bindingID string, de
 // Bind creates a new username, password, and set of ssl certs for the given instance.
 // The function may be slow to return because CloudSQL operations are asynchronous.
 // The default PCF service broker timeout may need to be raised to 90 or 120 seconds to accommodate the long bind time.
-func (b *CloudSQLBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *CloudSQLBroker) Bind(ctx context.Context, instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
 	// get context before trying to create anything to catch errors early
-	cloudDb, err := db_service.GetServiceInstanceDetailsById(ctx, instanceID)
-	if err != nil {
-		return models.ServiceBindingCredentials{}, brokerapi.ErrInstanceDoesNotExist
-	}
-
 	params := make(map[string]interface{})
 	if err := json.Unmarshal(details.RawParameters, &params); err != nil {
 		return models.ServiceBindingCredentials{}, fmt.Errorf("Error unmarshalling parameters: %s", err)
 	}
 
-	if err := b.ensureUsernamePassword(instanceID, bindingID, &details); err != nil {
+	if err := b.ensureUsernamePassword(instance.ID, bindingID, &details); err != nil {
 		return models.ServiceBindingCredentials{}, err
 	}
 
 	combinedCreds := varcontext.Builder()
 
 	// Create the service account
-	saCreds, err := b.BrokerBase.Bind(ctx, instanceID, bindingID, details)
+	saCreds, err := b.BrokerBase.Bind(ctx, instance, bindingID, details)
 	if err != nil {
 		return saCreds, err
 	}
 
 	combinedCreds.MergeJsonObject(json.RawMessage(saCreds.OtherDetails))
 
-	sqlCreds, err := b.createSqlCredentials(ctx, instanceID, bindingID, details, *cloudDb)
+	sqlCreds, err := b.createSqlCredentials(ctx, bindingID, details, instance)
 	if err != nil {
 		return saCreds, err
 	}

--- a/brokerapi/brokers/cloudsql/sql_account_manager.go
+++ b/brokerapi/brokers/cloudsql/sql_account_manager.go
@@ -26,7 +26,7 @@ import (
 )
 
 // inserts a new user into the database and creates new ssl certs
-func (broker *CloudSQLBroker) createSqlCredentials(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (map[string]interface{}, error) {
+func (broker *CloudSQLBroker) createSqlCredentials(ctx context.Context, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (map[string]interface{}, error) {
 	vars, err := varcontext.Builder().
 		MergeJsonObject(details.GetRawParameters()).
 		MergeMap(map[string]interface{}{"bindingid": bindingID}).

--- a/brokerapi/brokers/datastore/broker.go
+++ b/brokerapi/brokers/datastore/broker.go
@@ -38,6 +38,6 @@ func (b *DatastoreBroker) Deprovision(ctx context.Context, instance models.Servi
 }
 
 // Bind creates a service account with access to Datastore.
-func (b *DatastoreBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
-	return b.AccountManager.CreateAccountWithRoles(ctx, instanceID, []string{"datastore.user"})
+func (b *DatastoreBroker) Bind(ctx context.Context, instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+	return b.AccountManager.CreateAccountWithRoles(ctx, bindingID, []string{"datastore.user"})
 }

--- a/brokerapi/brokers/models/modelsfakes/fake_service_account_manager.go
+++ b/brokerapi/brokers/models/modelsfakes/fake_service_account_manager.go
@@ -10,14 +10,13 @@ import (
 )
 
 type FakeServiceAccountManager struct {
-	CreateCredentialsStub        func(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error)
+	CreateCredentialsStub        func(ctx context.Context, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error)
 	createCredentialsMutex       sync.RWMutex
 	createCredentialsArgsForCall []struct {
-		ctx        context.Context
-		instanceID string
-		bindingID  string
-		details    brokerapi.BindDetails
-		instance   models.ServiceInstanceDetails
+		ctx       context.Context
+		bindingID string
+		details   brokerapi.BindDetails
+		instance  models.ServiceInstanceDetails
 	}
 	createCredentialsReturns struct {
 		result1 models.ServiceBindingCredentials
@@ -73,20 +72,19 @@ type FakeServiceAccountManager struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServiceAccountManager) CreateCredentials(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
+func (fake *FakeServiceAccountManager) CreateCredentials(ctx context.Context, bindingID string, details brokerapi.BindDetails, instance models.ServiceInstanceDetails) (models.ServiceBindingCredentials, error) {
 	fake.createCredentialsMutex.Lock()
 	ret, specificReturn := fake.createCredentialsReturnsOnCall[len(fake.createCredentialsArgsForCall)]
 	fake.createCredentialsArgsForCall = append(fake.createCredentialsArgsForCall, struct {
-		ctx        context.Context
-		instanceID string
-		bindingID  string
-		details    brokerapi.BindDetails
-		instance   models.ServiceInstanceDetails
-	}{ctx, instanceID, bindingID, details, instance})
-	fake.recordInvocation("CreateCredentials", []interface{}{ctx, instanceID, bindingID, details, instance})
+		ctx       context.Context
+		bindingID string
+		details   brokerapi.BindDetails
+		instance  models.ServiceInstanceDetails
+	}{ctx, bindingID, details, instance})
+	fake.recordInvocation("CreateCredentials", []interface{}{ctx, bindingID, details, instance})
 	fake.createCredentialsMutex.Unlock()
 	if fake.CreateCredentialsStub != nil {
-		return fake.CreateCredentialsStub(ctx, instanceID, bindingID, details, instance)
+		return fake.CreateCredentialsStub(ctx, bindingID, details, instance)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -100,10 +98,10 @@ func (fake *FakeServiceAccountManager) CreateCredentialsCallCount() int {
 	return len(fake.createCredentialsArgsForCall)
 }
 
-func (fake *FakeServiceAccountManager) CreateCredentialsArgsForCall(i int) (context.Context, string, string, brokerapi.BindDetails, models.ServiceInstanceDetails) {
+func (fake *FakeServiceAccountManager) CreateCredentialsArgsForCall(i int) (context.Context, string, brokerapi.BindDetails, models.ServiceInstanceDetails) {
 	fake.createCredentialsMutex.RLock()
 	defer fake.createCredentialsMutex.RUnlock()
-	return fake.createCredentialsArgsForCall[i].ctx, fake.createCredentialsArgsForCall[i].instanceID, fake.createCredentialsArgsForCall[i].bindingID, fake.createCredentialsArgsForCall[i].details, fake.createCredentialsArgsForCall[i].instance
+	return fake.createCredentialsArgsForCall[i].ctx, fake.createCredentialsArgsForCall[i].bindingID, fake.createCredentialsArgsForCall[i].details, fake.createCredentialsArgsForCall[i].instance
 }
 
 func (fake *FakeServiceAccountManager) CreateCredentialsReturns(result1 models.ServiceBindingCredentials, result2 error) {

--- a/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
+++ b/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
@@ -26,13 +26,13 @@ type FakeServiceBrokerHelper struct {
 		result1 models.ServiceInstanceDetails
 		result2 error
 	}
-	BindStub        func(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error)
+	BindStub        func(ctx context.Context, instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error)
 	bindMutex       sync.RWMutex
 	bindArgsForCall []struct {
-		ctx        context.Context
-		instanceID string
-		bindingID  string
-		details    brokerapi.BindDetails
+		ctx       context.Context
+		instance  models.ServiceInstanceDetails
+		bindingID string
+		details   brokerapi.BindDetails
 	}
 	bindReturns struct {
 		result1 models.ServiceBindingCredentials
@@ -186,19 +186,19 @@ func (fake *FakeServiceBrokerHelper) ProvisionReturnsOnCall(i int, result1 model
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) Bind(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (fake *FakeServiceBrokerHelper) Bind(ctx context.Context, instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
 	fake.bindMutex.Lock()
 	ret, specificReturn := fake.bindReturnsOnCall[len(fake.bindArgsForCall)]
 	fake.bindArgsForCall = append(fake.bindArgsForCall, struct {
-		ctx        context.Context
-		instanceID string
-		bindingID  string
-		details    brokerapi.BindDetails
-	}{ctx, instanceID, bindingID, details})
-	fake.recordInvocation("Bind", []interface{}{ctx, instanceID, bindingID, details})
+		ctx       context.Context
+		instance  models.ServiceInstanceDetails
+		bindingID string
+		details   brokerapi.BindDetails
+	}{ctx, instance, bindingID, details})
+	fake.recordInvocation("Bind", []interface{}{ctx, instance, bindingID, details})
 	fake.bindMutex.Unlock()
 	if fake.BindStub != nil {
-		return fake.BindStub(ctx, instanceID, bindingID, details)
+		return fake.BindStub(ctx, instance, bindingID, details)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -212,10 +212,10 @@ func (fake *FakeServiceBrokerHelper) BindCallCount() int {
 	return len(fake.bindArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) BindArgsForCall(i int) (context.Context, string, string, brokerapi.BindDetails) {
+func (fake *FakeServiceBrokerHelper) BindArgsForCall(i int) (context.Context, models.ServiceInstanceDetails, string, brokerapi.BindDetails) {
 	fake.bindMutex.RLock()
 	defer fake.bindMutex.RUnlock()
-	return fake.bindArgsForCall[i].ctx, fake.bindArgsForCall[i].instanceID, fake.bindArgsForCall[i].bindingID, fake.bindArgsForCall[i].details
+	return fake.bindArgsForCall[i].ctx, fake.bindArgsForCall[i].instance, fake.bindArgsForCall[i].bindingID, fake.bindArgsForCall[i].details
 }
 
 func (fake *FakeServiceBrokerHelper) BindReturns(result1 models.ServiceBindingCredentials, result2 error) {

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -25,7 +25,9 @@ import (
 
 type ServiceBrokerHelper interface {
 	Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan ServicePlan) (ServiceInstanceDetails, error)
-	Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (ServiceBindingCredentials, error)
+	// Bind provisions the necessary resources for a user to be able to connect to the provisioned service.
+	// This may include creating service accounts, granting permissions, and adding users to services e.g. a SQL database user.
+	Bind(ctx context.Context, instance ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (ServiceBindingCredentials, error)
 	BuildInstanceCredentials(ctx context.Context, bindRecord ServiceBindingCredentials, instanceRecord ServiceInstanceDetails) (map[string]interface{}, error)
 	Unbind(ctx context.Context, details ServiceBindingCredentials) error
 	// Deprovision deprovisions the service.
@@ -44,7 +46,7 @@ type ServiceBrokerHelper interface {
 }
 
 type ServiceAccountManager interface {
-	CreateCredentials(ctx context.Context, instanceID string, bindingID string, details brokerapi.BindDetails, instance ServiceInstanceDetails) (ServiceBindingCredentials, error)
+	CreateCredentials(ctx context.Context, bindingID string, details brokerapi.BindDetails, instance ServiceInstanceDetails) (ServiceBindingCredentials, error)
 	DeleteCredentials(ctx context.Context, creds ServiceBindingCredentials) error
 	BuildInstanceCredentials(ctx context.Context, bindRecord ServiceBindingCredentials, instanceRecord ServiceInstanceDetails) (map[string]interface{}, error)
 	CreateAccountWithRoles(ctx context.Context, bindingID string, roles []string) (ServiceBindingCredentials, error)

--- a/brokerapi/brokers/stackdriver_debugger/broker.go
+++ b/brokerapi/brokers/stackdriver_debugger/broker.go
@@ -38,6 +38,6 @@ func (b *StackdriverDebuggerBroker) Deprovision(ctx context.Context, instance mo
 }
 
 // Bind creates a service account with access to Stackdriver Debugger.
-func (b *StackdriverDebuggerBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *StackdriverDebuggerBroker) Bind(ctx context.Context, instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
 	return b.AccountManager.CreateAccountWithRoles(ctx, bindingID, []string{"clouddebugger.agent"})
 }

--- a/brokerapi/brokers/stackdriver_profiler/broker.go
+++ b/brokerapi/brokers/stackdriver_profiler/broker.go
@@ -38,6 +38,6 @@ func (b *StackdriverProfilerBroker) Deprovision(ctx context.Context, instance mo
 }
 
 // Bind creates a service account with access to Stackdriver Profiler.
-func (b *StackdriverProfilerBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *StackdriverProfilerBroker) Bind(ctx context.Context, instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
 	return b.AccountManager.CreateAccountWithRoles(ctx, bindingID, []string{"cloudprofiler.agent"})
 }

--- a/brokerapi/brokers/stackdriver_trace/broker.go
+++ b/brokerapi/brokers/stackdriver_trace/broker.go
@@ -38,6 +38,6 @@ func (b *StackdriverTraceBroker) Deprovision(ctx context.Context, instance model
 }
 
 // Bind creates a service account with access to Stackdriver Trace.
-func (b *StackdriverTraceBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
+func (b *StackdriverTraceBroker) Bind(ctx context.Context, instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (models.ServiceBindingCredentials, error) {
 	return b.AccountManager.CreateAccountWithRoles(ctx, bindingID, []string{"cloudtrace.agent"})
 }


### PR DESCRIPTION
Passes though provision instance details on the bind call. #250
With this done we'll be able to refactor to construct `varcontext`s on bind calls #304.

Also fixes a bug where datastore service accounts were getting the same name because the wrong variable was being passed for the default name.