### PR TITLE
validate roles using JSONSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ability to create custom Cloud Storage plans.
 - New tile form for creating custom Cloud Storage plans.
 
+### Changed
+- Role whitelists are now validated through JSON Schema checks.
+
 ## [4.0.0] - 2018-10-01
 
 ### Added

--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
+	"github.com/spf13/viper"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/jwt"
@@ -50,15 +51,6 @@ func (sam *ServiceAccountManager) CreateCredentials(ctx context.Context, instanc
 	role, err := extractRole(details)
 	if err != nil {
 		return nil, err
-	}
-
-	bkr, err := broker.GetServiceById(details.ServiceID)
-	if err != nil {
-		return nil, err
-	}
-
-	if bkr.IsRoleWhitelistEnabled() && !whitelistAllows(bkr.RoleWhitelist(), role) {
-		return nil, fmt.Errorf("The role %s is not allowed for this service. You must use one of %v.", role, bkr.RoleWhitelist())
 	}
 
 	return sam.CreateAccountWithRoles(ctx, bindingID, []string{role})
@@ -232,11 +224,16 @@ type ServiceAccountInfo struct {
 	PrivateKeyData string `json:"PrivateKeyData"`
 }
 
-func ServiceAccountBindInputVariables(roleWhitelist []string) []broker.BrokerVariable {
-	defaultRoles := strings.Join(roleWhitelist, "', '")
+func ServiceAccountBindInputVariables(serviceName string, defaultWhitelist []string) []broker.BrokerVariable {
 	details := fmt.Sprintf(`The role for the account without the "roles/" prefix.
 		See: https://cloud.google.com/iam/docs/understanding-roles for more details.
-		The following roles are available by default but may be overridden by your operator: '%s'.`, defaultRoles)
+		Note: The default enumeration may be overridden by your operator.`)
+
+	whitelist := roleWhitelist(serviceName, defaultWhitelist)
+	whitelistEnum := make(map[interface{}]string)
+	for _, val := range whitelist {
+		whitelistEnum[val] = roleResourcePrefix + val
+	}
 
 	return []broker.BrokerVariable{
 		{
@@ -244,6 +241,7 @@ func ServiceAccountBindInputVariables(roleWhitelist []string) []broker.BrokerVar
 			FieldName: "role",
 			Type:      broker.JsonTypeString,
 			Details:   details,
+			Enum:      whitelistEnum,
 		},
 	}
 }
@@ -281,4 +279,22 @@ func ServiceAccountBindOutputVariables() []broker.BrokerVariable {
 
 func whitelistAllows(whitelist []string, role string) bool {
 	return NewStringSet(whitelist...).Contains(role)
+}
+
+// RoleWhitelistProperty computes the Viper property name for the boolean the user
+// can set to enable or disable the role whitelist.
+func RoleWhitelistProperty(serviceName string) string {
+	return fmt.Sprintf("service.%s.whitelist", serviceName)
+}
+
+// roleWhitelist returns the whitelist of roles the operator has allowed or the
+// default if it is blank.
+func roleWhitelist(serviceName string, defaultRoleWhitelist []string) []string {
+	rawWhitelist := viper.GetString(RoleWhitelistProperty(serviceName))
+	wl := strings.Split(rawWhitelist, ",")
+	if strings.TrimSpace(rawWhitelist) != "" {
+		return wl
+	}
+
+	return defaultRoleWhitelist
 }

--- a/brokerapi/brokers/account_managers/service_account_manager_test.go
+++ b/brokerapi/brokers/account_managers/service_account_manager_test.go
@@ -15,9 +15,11 @@
 package account_managers
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pivotal-cf/brokerapi"
+	"github.com/spf13/viper"
 )
 
 func TestWhitelistAllows(t *testing.T) {
@@ -76,4 +78,26 @@ func TestExtractRole(t *testing.T) {
 			t.Errorf("%s) expected error? %v got: %s", name, testcase.ShouldError, err)
 		}
 	}
+}
+
+func ExampleRoleWhitelistProperty() {
+	serviceName := "left-handed-smoke-sifter"
+
+	fmt.Println(RoleWhitelistProperty(serviceName))
+
+	// Output: service.left-handed-smoke-sifter.whitelist
+}
+
+func ExampleroleWhitelist() {
+	serviceName := "my-service"
+	defaultRoleWhitelist := []string{"a", "b", "c"}
+
+	viper.Set(RoleWhitelistProperty(serviceName), "")
+	fmt.Println(roleWhitelist(serviceName, defaultRoleWhitelist))
+
+	viper.Set(RoleWhitelistProperty(serviceName), "x,y,z")
+	fmt.Println(roleWhitelist(serviceName, defaultRoleWhitelist))
+
+	// Output: [a b c]
+	// [x y z]
 }

--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -16,6 +16,7 @@ package api_service
 
 import (
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
@@ -30,7 +31,7 @@ func init() {
 	}
 
 	bs := &broker.BrokerService{
-		Name: "google-ml-apis",
+		Name: models.MlName,
 		DefaultServiceDefinition: `
 		{
       "id": "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4",
@@ -60,7 +61,7 @@ func init() {
 		`,
 		ProvisionInputVariables: []broker.BrokerVariable{},
 		DefaultRoleWhitelist:    roleWhitelist,
-		BindInputVariables:      accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
+		BindInputVariables:      accountmanagers.ServiceAccountBindInputVariables(models.MlName, roleWhitelist),
 		BindOutputVariables:     accountmanagers.ServiceAccountBindOutputVariables(),
 		Examples: []broker.ServiceExample{
 			{

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -16,6 +16,7 @@ package bigquery
 
 import (
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 )
@@ -34,7 +35,7 @@ func serviceDefinition() *broker.BrokerService {
 	}
 
 	return &broker.BrokerService{
-		Name: "google-bigquery",
+		Name: models.BigqueryName,
 		DefaultServiceDefinition: `{
         "id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",
         "description": "A fast, economical and fully managed data warehouse for large-scale data analytics.",
@@ -83,7 +84,7 @@ func serviceDefinition() *broker.BrokerService {
 			},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
-		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
+		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(models.BigqueryName, roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "dataset_id",

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -16,6 +16,7 @@ package bigtable
 
 import (
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 )
@@ -32,7 +33,7 @@ func serviceDefinition() *broker.BrokerService {
 	}
 
 	return &broker.BrokerService{
-		Name: "google-bigtable",
+		Name: models.BigtableName,
 		DefaultServiceDefinition: `{
       "id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe",
       "description": "A high performance NoSQL database service for large analytical and operational workloads.",
@@ -117,7 +118,7 @@ func serviceDefinition() *broker.BrokerService {
 			},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
-		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
+		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(models.BigtableName, roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "instance_id",

--- a/brokerapi/brokers/cloudsql/common-definition.go
+++ b/brokerapi/brokers/cloudsql/common-definition.go
@@ -35,8 +35,8 @@ func roleWhitelist() []string {
 	}
 }
 
-func commonBindVariables() []broker.BrokerVariable {
-	return append(accountmanagers.ServiceAccountBindInputVariables(roleWhitelist()),
+func commonBindVariables(serviceName string) []broker.BrokerVariable {
+	return append(accountmanagers.ServiceAccountBindInputVariables(serviceName, roleWhitelist()),
 		broker.BrokerVariable{
 			FieldName: "jdbc_uri_format",
 			Type:      broker.JsonTypeString,

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -15,6 +15,7 @@
 package cloudsql
 
 import (
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
@@ -26,7 +27,7 @@ func init() {
 
 func mysqlServiceDefinition() *broker.BrokerService {
 	return &broker.BrokerService{
-		Name: "google-cloudsql-mysql",
+		Name: models.CloudsqlMySQLName,
 		DefaultServiceDefinition: `{
 		    "id": "4bc59b9a-8520-409f-85da-1c7552315863",
 		    "description": "Google Cloud SQL is a fully-managed MySQL database service.",
@@ -241,7 +242,7 @@ func mysqlServiceDefinition() *broker.BrokerService {
 			{Name: "_", Default: `${assert(disk_size <= max_disk_size, "disk size (${disk_size}) is greater than max allowed disk size for this plan (${max_disk_size})")}`, Overwrite: true},
 		},
 		DefaultRoleWhitelist:  roleWhitelist(),
-		BindInputVariables:    commonBindVariables(),
+		BindInputVariables:    commonBindVariables(models.CloudsqlMySQLName),
 		BindOutputVariables:   commonBindOutputVariables(),
 		BindComputedVariables: commonBindComputedVariables(),
 		PlanVariables: []broker.BrokerVariable{

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -15,6 +15,7 @@
 package cloudsql
 
 import (
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
@@ -26,7 +27,7 @@ func init() {
 
 func postgresServiceDefinition() *broker.BrokerService {
 	return &broker.BrokerService{
-		Name: "google-cloudsql-postgres",
+		Name: models.CloudsqlPostgresName,
 		DefaultServiceDefinition: `{
         "id": "cbad6d78-a73c-432d-b8ff-b219a17a803a",
         "description": "Google Cloud SQL is a fully-managed PostgreSQL database service.",
@@ -195,7 +196,7 @@ func postgresServiceDefinition() *broker.BrokerService {
 		},
 
 		DefaultRoleWhitelist:  roleWhitelist(),
-		BindInputVariables:    commonBindVariables(),
+		BindInputVariables:    commonBindVariables(models.CloudsqlPostgresName),
 		BindOutputVariables:   commonBindOutputVariables(),
 		BindComputedVariables: commonBindComputedVariables(),
 		PlanVariables: []broker.BrokerVariable{

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -14,9 +14,12 @@
 
 package pubsub
 
-import "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
-import accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
-import "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+import (
+	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+)
 
 func init() {
 	broker.Register(serviceDefinition())
@@ -31,7 +34,7 @@ func serviceDefinition() *broker.BrokerService {
 	}
 
 	return &broker.BrokerService{
-		Name: "google-pubsub",
+		Name: models.PubsubName,
 		DefaultServiceDefinition: `{
       "id": "628629e3-79f5-4255-b981-d14c6c7856be",
       "description": "A global service for real-time and reliable messaging and streaming data.",
@@ -110,7 +113,7 @@ again during that time (on a best-effort basis).
 			},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
-		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
+		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(models.PubsubName, roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "subscription_name",

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -16,6 +16,7 @@ package spanner
 
 import (
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 )
@@ -33,7 +34,7 @@ func serviceDefinition() *broker.BrokerService {
 	}
 
 	return &broker.BrokerService{
-		Name: "google-spanner",
+		Name: models.SpannerName,
 		DefaultServiceDefinition: `
 		{
 			"id": "51b3e27e-d323-49ce-8c5f-1211e6409e82",
@@ -103,7 +104,7 @@ func serviceDefinition() *broker.BrokerService {
 			},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
-		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
+		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(models.SpannerName, roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "instance_id",

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 )
@@ -32,7 +33,7 @@ func serviceDefinition() *broker.BrokerService {
 	}
 
 	return &broker.BrokerService{
-		Name: "google-storage",
+		Name: models.StorageName,
 		DefaultServiceDefinition: `{
 	        "id": "b9e4332e-b42b-4680-bda5-ea1506797474",
 	        "description": "Unified object storage for developers and enterprises. Cloud Storage allows world-wide storage and retrieval of any amount of data at any time.",
@@ -105,7 +106,7 @@ func serviceDefinition() *broker.BrokerService {
 			},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
-		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(roleWhitelist),
+		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(models.StorageName, roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "bucket_name",

--- a/docs/use.md
+++ b/docs/use.md
@@ -28,7 +28,8 @@ A fast, economical and fully managed data warehouse for large-scale data analyti
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'bigquery.dataViewer', 'bigquery.dataEditor', 'bigquery.dataOwner', 'bigquery.user', 'bigquery.jobUser'.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. Note: The default enumeration may be overridden by your operator.
+    * The value must be one of: [bigquery.dataEditor bigquery.dataOwner bigquery.dataViewer bigquery.jobUser bigquery.user].
 
 **Response Parameters**
 
@@ -123,7 +124,8 @@ A high performance NoSQL database service for large analytical and operational w
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'bigtable.user', 'bigtable.reader', 'bigtable.viewer'.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. Note: The default enumeration may be overridden by your operator.
+    * The value must be one of: [bigtable.reader bigtable.user bigtable.viewer].
 
 **Response Parameters**
 
@@ -218,7 +220,7 @@ Google Cloud SQL is a fully-managed MySQL database service.
  * `region` _string_ - The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases. Default: `us-central`.
     * Examples: [northamerica-northeast1 southamerica-east1 us-east1].
     * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
- * `zone` _string_ - (only for 2nd generation instances)
+ * `zone` _string_ - (only for 2nd generation instances) Default: ``.
     * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
  * `disk_type` _string_ - (only for 2nd generation instances) Default: `PD_SSD`.
     * The value must be one of: [PD_HDD PD_SSD].
@@ -242,7 +244,8 @@ Google Cloud SQL is a fully-managed MySQL database service.
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'cloudsql.editor', 'cloudsql.viewer', 'cloudsql.client'.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. Note: The default enumeration may be overridden by your operator.
+    * The value must be one of: [cloudsql.client cloudsql.editor cloudsql.viewer].
  * `jdbc_uri_format` _string_ - If `true`, `uri` field will contain a JDBC formatted URI. Default: `false`.
     * The value must be one of: [false true].
  * `username` _string_ - The SQL username for the account. Default: `sb${str.truncate(14, time.nano())}`.
@@ -251,6 +254,7 @@ Google Cloud SQL is a fully-managed MySQL database service.
 **Response Parameters**
 
  * `Email` _string_ - Email address of the service account.
+ * `Name` _string_ - The name of the service account.
  * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
  * `ProjectId` _string_ - ID of the project that owns the service account.
  * `UniqueId` _string_ - Unique and stable id of the service account.
@@ -366,7 +370,7 @@ Google Cloud SQL is a fully-managed MySQL database service.
  * `region` _string_ - The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases. Default: `us-central`.
     * Examples: [northamerica-northeast1 southamerica-east1 us-east1].
     * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
- * `zone` _string_ - (only for 2nd generation instances)
+ * `zone` _string_ - (only for 2nd generation instances) Default: ``.
     * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
  * `disk_type` _string_ - (only for 2nd generation instances) Default: `PD_SSD`.
     * The value must be one of: [PD_HDD PD_SSD].
@@ -390,7 +394,8 @@ Google Cloud SQL is a fully-managed MySQL database service.
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'cloudsql.editor', 'cloudsql.viewer', 'cloudsql.client'.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. Note: The default enumeration may be overridden by your operator.
+    * The value must be one of: [cloudsql.client cloudsql.editor cloudsql.viewer].
  * `jdbc_uri_format` _string_ - If `true`, `uri` field will contain a JDBC formatted URI. Default: `false`.
     * The value must be one of: [false true].
  * `username` _string_ - The SQL username for the account. Default: `sb${str.truncate(14, time.nano())}`.
@@ -399,6 +404,7 @@ Google Cloud SQL is a fully-managed MySQL database service.
 **Response Parameters**
 
  * `Email` _string_ - Email address of the service account.
+ * `Name` _string_ - The name of the service account.
  * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
  * `ProjectId` _string_ - ID of the project that owns the service account.
  * `UniqueId` _string_ - Unique and stable id of the service account.
@@ -576,7 +582,8 @@ _No parameters supported._
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'ml.developer', 'ml.viewer', 'ml.modelOwner', 'ml.modelUser', 'ml.jobOwner', 'ml.operationOwner'.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. Note: The default enumeration may be overridden by your operator.
+    * The value must be one of: [ml.developer ml.jobOwner ml.modelOwner ml.modelUser ml.operationOwner ml.viewer].
 
 **Response Parameters**
 
@@ -666,7 +673,8 @@ A global service for real-time and reliable messaging and streaming data.
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'pubsub.publisher', 'pubsub.subscriber', 'pubsub.viewer', 'pubsub.editor'.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. Note: The default enumeration may be overridden by your operator.
+    * The value must be one of: [pubsub.editor pubsub.publisher pubsub.subscriber pubsub.viewer].
 
 **Response Parameters**
 
@@ -821,7 +829,8 @@ The first horizontally scalable, globally consistent, relational database servic
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'spanner.databaseAdmin', 'spanner.databaseReader', 'spanner.databaseUser', 'spanner.viewer'.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. Note: The default enumeration may be overridden by your operator.
+    * The value must be one of: [spanner.databaseAdmin spanner.databaseReader spanner.databaseUser spanner.viewer].
 
 **Response Parameters**
 
@@ -1166,7 +1175,8 @@ Unified object storage for developers and enterprises. Cloud Storage allows worl
 **Request Parameters**
 
 
- * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. The following roles are available by default but may be overridden by your operator: 'storage.objectCreator', 'storage.objectViewer', 'storage.objectAdmin'.
+ * `role` _string_ - **Required** The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. Note: The default enumeration may be overridden by your operator.
+    * The value must be one of: [storage.objectAdmin storage.objectCreator storage.objectViewer].
 
 **Response Parameters**
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -56,16 +56,6 @@ func ExampleBrokerService_UserDefinedPlansProperty() {
 	// Output: service.left-handed-smoke-sifter.plans
 }
 
-func ExampleBrokerService_RoleWhitelistProperty() {
-	service := BrokerService{
-		Name: "left-handed-smoke-sifter",
-	}
-
-	fmt.Println(service.RoleWhitelistProperty())
-
-	// Output: service.left-handed-smoke-sifter.whitelist
-}
-
 func ExampleBrokerService_IsEnabled() {
 	service := BrokerService{
 		Name: "left-handed-smoke-sifter",
@@ -93,21 +83,6 @@ func ExampleBrokerService_IsRoleWhitelistEnabled() {
 
 	// Output: true
 	// false
-}
-
-func ExampleBrokerService_RoleWhitelist() {
-	service := BrokerService{
-		Name:                 "my-service",
-		DefaultRoleWhitelist: []string{"a", "b", "c"},
-	}
-	viper.Set(service.RoleWhitelistProperty(), "")
-	fmt.Println(service.RoleWhitelist())
-
-	viper.Set(service.RoleWhitelistProperty(), "x,y,z")
-	fmt.Println(service.RoleWhitelist())
-
-	// Output: [a b c]
-	// [x y z]
 }
 
 func ExampleBrokerService_TileUserDefinedPlansVariable() {

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -162,18 +162,6 @@ func (svc *BrokerService) BindDefaultOverrides() map[string]interface{} {
 	return viper.GetStringMap(svc.BindDefaultOverrideProperty())
 }
 
-// RoleWhitelist returns the whitelist of roles the operator has allowed or the
-// default if it is blank.
-func (svc *BrokerService) RoleWhitelist() []string {
-	rawWhitelist := viper.GetString(svc.RoleWhitelistProperty())
-	wl := strings.Split(rawWhitelist, ",")
-	if strings.TrimSpace(rawWhitelist) != "" {
-		return wl
-	}
-
-	return svc.DefaultRoleWhitelist
-}
-
 // TileUserDefinedPlansVariable returns the name of the user defined plans
 // variable for the broker tile.
 func (svc *BrokerService) TileUserDefinedPlansVariable() string {

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -132,12 +132,6 @@ func (svc *BrokerService) UserDefinedPlansProperty() string {
 	return fmt.Sprintf("service.%s.plans", svc.Name)
 }
 
-// RoleWhitelistProperty computes the Viper property name for the boolean the user
-// can set to enable or disable the role whitelist.
-func (svc *BrokerService) RoleWhitelistProperty() string {
-	return fmt.Sprintf("service.%s.whitelist", svc.Name)
-}
-
 // ProvisionDefaultOverrideProperty returns the Viper property name for the
 // object users can set to override the default values on provision.
 func (svc *BrokerService) ProvisionDefaultOverrideProperty() string {
@@ -150,16 +144,10 @@ func (svc *BrokerService) ProvisionDefaultOverrides() map[string]interface{} {
 	return viper.GetStringMap(svc.ProvisionDefaultOverrideProperty())
 }
 
-// RoleWhitelist returns the whitelist of roles the operator has allowed or the
-// default if it is blank.
-func (svc *BrokerService) RoleWhitelist() []string {
-	rawWhitelist := viper.GetString(svc.RoleWhitelistProperty())
-	wl := strings.Split(rawWhitelist, ",")
-	if strings.TrimSpace(rawWhitelist) != "" {
-		return wl
-	}
-
-	return svc.DefaultRoleWhitelist
+// IsRoleWhitelistEnabled returns false if the service has no default whitelist
+// meaning it does not allow any roles.
+func (svc *BrokerService) IsRoleWhitelistEnabled() bool {
+	return len(svc.DefaultRoleWhitelist) > 0
 }
 
 // TileUserDefinedPlansVariable returns the name of the user defined plans
@@ -179,12 +167,6 @@ func (svc *BrokerService) TileUserDefinedPlansVariable() string {
 // or true otherwise.
 func (svc *BrokerService) IsEnabled() bool {
 	return viper.GetBool(svc.EnabledProperty())
-}
-
-// IsRoleWhitelistEnabled returns false if the service has no default whitelist
-// meaning it does not allow any roles.
-func (svc *BrokerService) IsRoleWhitelistEnabled() bool {
-	return len(svc.DefaultRoleWhitelist) > 0
 }
 
 // CatalogEntry returns the service broker catalog entry for this service, it

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 )
@@ -123,7 +124,7 @@ func generateRoleWhitelistForm() Form {
 		}
 
 		enableForm := FormProperty{
-			Name:         strings.ToLower(utils.PropertyToEnv(svc.RoleWhitelistProperty())),
+			Name:         strings.ToLower(utils.PropertyToEnv(account_managers.RoleWhitelistProperty(svc.Name))),
 			Label:        fmt.Sprintf("Role whitelist for %s instances.", entry.Metadata.DisplayName),
 			Description:  "A comma delimited list of roles (minus the role/ prefix) that can be used when creating bound users for this service.",
 			Type:         "string",
@@ -231,7 +232,7 @@ func generateCompatibilityForm() Form {
 				Label:        "Enables input variable JSON Schema validation checks",
 				Configurable: true,
 				Default:      true,
-				Description: singleLine(`Enables validating user input variables against JSON Schema definitions.`),
+				Description:  singleLine(`Enables validating user input variables against JSON Schema definitions.`),
 			},
 		},
 	}


### PR DESCRIPTION
Move the role whitelist checks to use JSONSchema. This normalizes the way we do validation rather than special one-off checks. #304, #250 