### PR TITLE
create a varcontext builder for bind calls

### DIFF
--- a/docs/custom-services.md
+++ b/docs/custom-services.md
@@ -2,7 +2,7 @@
 
 This documentation is for an **UNRELEASED** upcoming feature for the GCP Service Broker and should not be considered complete.
 
-## Provision variable resolution
+## Variable resolution
 
 The variables fed into your Terraform services file are resolved in the following order:
 

--- a/docs/custom-services.md
+++ b/docs/custom-services.md
@@ -2,19 +2,19 @@
 
 This documentation is for an **UNRELEASED** upcoming feature for the GCP Service Broker and should not be considered complete.
 
-## Variable resolution
+## Provision variable resolution
 
 The variables fed into your Terraform services file are resolved in the following order:
 
 * Variables defined in your `computed_variables` JSON list.
-* Variables defined by the selected service plan in its `service_properties` map.
+* (Only for Provision) Variables defined by the selected service plan in its `service_properties` map.
 * User defined variables (in `provision_input_variables` or `bind_input_variables`)
-* **TODO** Operator default variables loaded from the environment.
+* Operator default variables loaded from the environment.
 * Default variables (in `provision_input_variables` or `bind_input_variables`).
 
 Note that the order the variables are combined in code is slightly different.
 
-* **TODO** Operator default variables loaded from the environment.
+* Operator default variables loaded from the environment.
 * User defined variables (in `provision_input_variables` or `bind_input_variables`)
 * **If the variables are not defined yet** default variables (in `provision_input_variables` or `bind_input_variables`).
 * Variables defined by the selected service plan in its `service_properties` map.
@@ -57,11 +57,20 @@ The broker makes additional variables available to be used during provision and 
 
 ### Provision
 
-* `request.service.id` - _string_ The GUID of the requested service.
-* `request.plan.id` - _string_ The ID of the requested plan. Plan IDs are unique within an instance.
-* `request.instance.id` - _string_ The ID of the requested instance. Instance IDs are unique within a service.
+* `request.service_id` - _string_ The GUID of the requested service.
+* `request.plan_id` - _string_ The ID of the requested plan. Plan IDs are unique within an instance.
+* `request.instance_id` - _string_ The ID of the requested instance. Instance IDs are unique within a service.
 * `request.default_labels` - _map[string]string_ A map of labels that should be applied to the created infrastructure for billing/accounting/tracking purposes.
 
+### Bind
+
+* `request.binding_id` - _string_ The ID of the new binding.
+* `request.instance_id` - _string_ The ID of the existing instance to bind to.
+* `request.service_id` - _string_ The GUID of the service this binding is for.
+* `request.plan_id` - _string_ The ID of plan the instance was created with.
+* `request.app_guid` - _string_ The ID of the application this binding is for.
+* `instance.name` - _string_ The name of the instance.
+* `instance.details` - _map[string]any_ Output variables of the instance as specified by ProvisionOutputVariables.
 
 ## Design guidelines
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -395,9 +395,31 @@ A JSON object with key/value pairs. Keys MUST be the name of a user-defined prov
   <li>Default: <code>{}</code></li>
 </ul>
 
+<b><tt>GSB_SERVICE_GOOGLE_BIGQUERY_BIND_DEFAULTS</tt></b> - <i>text</i> - Bind default override Google BigQuery instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined bind property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
 <b><tt>GSB_SERVICE_GOOGLE_BIGTABLE_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google Bigtable instances.
 
 A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_BIGTABLE_BIND_DEFAULTS</tt></b> - <i>text</i> - Bind default override Google Bigtable instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined bind property and values are the alternative default.
 
 
 
@@ -417,9 +439,31 @@ A JSON object with key/value pairs. Keys MUST be the name of a user-defined prov
   <li>Default: <code>{}</code></li>
 </ul>
 
+<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_BIND_DEFAULTS</tt></b> - <i>text</i> - Bind default override Google CloudSQL MySQL instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined bind property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
 <b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google CloudSQL PostgreSQL instances.
 
 A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_BIND_DEFAULTS</tt></b> - <i>text</i> - Bind default override Google CloudSQL PostgreSQL instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined bind property and values are the alternative default.
 
 
 
@@ -439,9 +483,31 @@ A JSON object with key/value pairs. Keys MUST be the name of a user-defined prov
   <li>Default: <code>{}</code></li>
 </ul>
 
+<b><tt>GSB_SERVICE_GOOGLE_ML_APIS_BIND_DEFAULTS</tt></b> - <i>text</i> - Bind default override Google Machine Learning APIs instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined bind property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
 <b><tt>GSB_SERVICE_GOOGLE_PUBSUB_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google PubSub instances.
 
 A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_PUBSUB_BIND_DEFAULTS</tt></b> - <i>text</i> - Bind default override Google PubSub instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined bind property and values are the alternative default.
 
 
 
@@ -461,9 +527,31 @@ A JSON object with key/value pairs. Keys MUST be the name of a user-defined prov
   <li>Default: <code>{}</code></li>
 </ul>
 
+<b><tt>GSB_SERVICE_GOOGLE_SPANNER_BIND_DEFAULTS</tt></b> - <i>text</i> - Bind default override Google Spanner instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined bind property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
 <b><tt>GSB_SERVICE_GOOGLE_STORAGE_PROVISION_DEFAULTS</tt></b> - <i>text</i> - Provision default override Google Cloud Storage instances.
 
 A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>{}</code></li>
+</ul>
+
+<b><tt>GSB_SERVICE_GOOGLE_STORAGE_BIND_DEFAULTS</tt></b> - <i>text</i> - Bind default override Google Cloud Storage instances.
+
+A JSON object with key/value pairs. Keys MUST be the name of a user-defined bind property and values are the alternative default.
 
 
 

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -150,6 +150,18 @@ func (svc *BrokerService) ProvisionDefaultOverrides() map[string]interface{} {
 	return viper.GetStringMap(svc.ProvisionDefaultOverrideProperty())
 }
 
+// BindDefaultOverrideProperty returns the Viper property name for the
+// object users can set to override the default values on bind.
+func (svc *BrokerService) BindDefaultOverrideProperty() string {
+	return fmt.Sprintf("service.%s.bind.defaults", svc.Name)
+}
+
+// BindDefaultOverrides returns the deserialized JSON object for the
+// operator-provided property overrides.
+func (svc *BrokerService) BindDefaultOverrides() map[string]interface{} {
+	return viper.GetStringMap(svc.BindDefaultOverrideProperty())
+}
+
 // RoleWhitelist returns the whitelist of roles the operator has allowed or the
 // default if it is blank.
 func (svc *BrokerService) RoleWhitelist() []string {
@@ -315,6 +327,14 @@ func (svc *BrokerService) provisionDefaults() []varcontext.DefaultVariable {
 	return out
 }
 
+func (svc *BrokerService) bindDefaults() []varcontext.DefaultVariable {
+	var out []varcontext.DefaultVariable
+	for _, v := range svc.BindInputVariables {
+		out = append(out, varcontext.DefaultVariable{Name: v.FieldName, Default: v.Default, Overwrite: false})
+	}
+	return out
+}
+
 // ProvisionVariables gets the variable resolution context for a provision request.
 // Variables have a very specific resolution order, and this function populates the context to preserve that.
 // The variable resolution order is the following:
@@ -322,7 +342,7 @@ func (svc *BrokerService) provisionDefaults() []varcontext.DefaultVariable {
 // 1. Variables defined in your `computed_variables` JSON list.
 // 2. Variables defined by the selected service plan in its `service_properties` map.
 // 3. User defined variables (in `provision_input_variables` or `bind_input_variables`)
-// 4. (eventually) Operator default variables loaded from the environment.
+// 4. Operator default variables loaded from the environment.
 // 5. Default variables (in `provision_input_variables` or `bind_input_variables`).
 //
 // Loading into the map occurs slightly differently.
@@ -335,10 +355,11 @@ func (svc *BrokerService) provisionDefaults() []varcontext.DefaultVariable {
 func (svc *BrokerService) ProvisionVariables(instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (*varcontext.VarContext, error) {
 	defaults := svc.provisionDefaults()
 
+	// The namespaces of these values roughly align with the OSB spec.
 	constants := map[string]interface{}{
-		"request.plan.id":        details.PlanID,
-		"request.service.id":     details.ServiceID,
-		"request.instance.id":    details.ServiceID,
+		"request.plan_id":        details.PlanID,
+		"request.service_id":     details.ServiceID,
+		"request.instance_id":    instanceId,
 		"request.default_labels": utils.ExtractDefaultLabels(instanceId, details),
 	}
 
@@ -349,5 +370,57 @@ func (svc *BrokerService) ProvisionVariables(instanceId string, details brokerap
 		MergeDefaults(defaults).
 		MergeMap(plan.GetServiceProperties()).
 		MergeDefaults(svc.ProvisionComputedVariables).
+		Build()
+}
+
+// BindVariables gets the variable resolution context for a bind request.
+// Variables have a very specific resolution order, and this function populates the context to preserve that.
+// The variable resolution order is the following:
+//
+// 1. Variables defined in your `computed_variables` JSON list.
+// 3. User defined variables (in `bind_input_variables`)
+// 4. Operator default variables loaded from the environment.
+// 5. Default variables (in `bind_input_variables`).
+//
+func (svc *BrokerService) BindVariables(instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (*varcontext.VarContext, error) {
+	defaults := svc.bindDefaults()
+
+	otherDetails := make(map[string]interface{})
+	if instance.OtherDetails != "" {
+		if err := json.Unmarshal(json.RawMessage(instance.OtherDetails), &otherDetails); err != nil {
+			return nil, err
+		}
+	}
+
+	appGuid := ""
+	if details.BindResource != nil {
+		appGuid = details.BindResource.AppGuid
+	}
+
+	// The namespaces of these values roughly align with the OSB spec.
+	constants := map[string]interface{}{
+		// specified in the URL
+		"request.binding_id":  bindingID,
+		"request.instance_id": instance.ID,
+
+		// specified in the request body
+		// Note: the value in instance is considered the official record so values
+		// are pulled from there rather than the request. In a future version of OSB
+		// the duplicate sending of fields is likely to be removed.
+		"request.plan_id":    instance.PlanId,
+		"request.service_id": instance.ServiceId,
+		"request.app_guid":   appGuid,
+
+		// specified by the existing instance
+		"instance.name":    instance.Name,
+		"instance.details": otherDetails,
+	}
+
+	return varcontext.Builder().
+		SetEvalConstants(constants).
+		MergeMap(svc.BindDefaultOverrides()).
+		MergeJsonObject(details.GetRawParameters()).
+		MergeDefaults(defaults).
+		MergeDefaults(svc.BindComputedVariables).
 		Build()
 }

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -156,7 +156,7 @@ func generateDefaultOverrideForm() Form {
 			continue
 		}
 
-		formElement := FormProperty{
+		provisionForm := FormProperty{
 			Name:         strings.ToLower(utils.PropertyToEnv(svc.ProvisionDefaultOverrideProperty())),
 			Label:        fmt.Sprintf("Provision default override %s instances.", entry.Metadata.DisplayName),
 			Description:  "A JSON object with key/value pairs. Keys MUST be the name of a user-defined provision property and values are the alternative default.",
@@ -164,8 +164,17 @@ func generateDefaultOverrideForm() Form {
 			Default:      "{}",
 			Configurable: true,
 		}
+		formElements = append(formElements, provisionForm)
 
-		formElements = append(formElements, formElement)
+		bindForm := FormProperty{
+			Name:         strings.ToLower(utils.PropertyToEnv(svc.BindDefaultOverrideProperty())),
+			Label:        fmt.Sprintf("Bind default override %s instances.", entry.Metadata.DisplayName),
+			Description:  "A JSON object with key/value pairs. Keys MUST be the name of a user-defined bind property and values are the alternative default.",
+			Type:         "text",
+			Default:      "{}",
+			Configurable: true,
+		}
+		formElements = append(formElements, bindForm)
 	}
 
 	return Form{
@@ -231,7 +240,7 @@ func generateCompatibilityForm() Form {
 				Label:        "Enables input variable JSON Schema validation checks",
 				Configurable: true,
 				Default:      true,
-				Description: singleLine(`Enables validating user input variables against JSON Schema definitions.`),
+				Description:  singleLine(`Enables validating user input variables against JSON Schema definitions.`),
 			},
 		},
 	}

--- a/tile.yml
+++ b/tile.yml
@@ -249,12 +249,26 @@ forms:
     description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
       provision property and values are the alternative default.
     configurable: true
+  - name: gsb_service_google_bigquery_bind_defaults
+    type: text
+    default: '{}'
+    label: Bind default override Google BigQuery instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      bind property and values are the alternative default.
+    configurable: true
   - name: gsb_service_google_bigtable_provision_defaults
     type: text
     default: '{}'
     label: Provision default override Google Bigtable instances.
     description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
       provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_bigtable_bind_defaults
+    type: text
+    default: '{}'
+    label: Bind default override Google Bigtable instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      bind property and values are the alternative default.
     configurable: true
   - name: gsb_service_google_cloudsql_mysql_provision_defaults
     type: text
@@ -263,12 +277,26 @@ forms:
     description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
       provision property and values are the alternative default.
     configurable: true
+  - name: gsb_service_google_cloudsql_mysql_bind_defaults
+    type: text
+    default: '{}'
+    label: Bind default override Google CloudSQL MySQL instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      bind property and values are the alternative default.
+    configurable: true
   - name: gsb_service_google_cloudsql_postgres_provision_defaults
     type: text
     default: '{}'
     label: Provision default override Google CloudSQL PostgreSQL instances.
     description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
       provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_cloudsql_postgres_bind_defaults
+    type: text
+    default: '{}'
+    label: Bind default override Google CloudSQL PostgreSQL instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      bind property and values are the alternative default.
     configurable: true
   - name: gsb_service_google_ml_apis_provision_defaults
     type: text
@@ -277,12 +305,26 @@ forms:
     description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
       provision property and values are the alternative default.
     configurable: true
+  - name: gsb_service_google_ml_apis_bind_defaults
+    type: text
+    default: '{}'
+    label: Bind default override Google Machine Learning APIs instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      bind property and values are the alternative default.
+    configurable: true
   - name: gsb_service_google_pubsub_provision_defaults
     type: text
     default: '{}'
     label: Provision default override Google PubSub instances.
     description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
       provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_pubsub_bind_defaults
+    type: text
+    default: '{}'
+    label: Bind default override Google PubSub instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      bind property and values are the alternative default.
     configurable: true
   - name: gsb_service_google_spanner_provision_defaults
     type: text
@@ -291,12 +333,26 @@ forms:
     description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
       provision property and values are the alternative default.
     configurable: true
+  - name: gsb_service_google_spanner_bind_defaults
+    type: text
+    default: '{}'
+    label: Bind default override Google Spanner instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      bind property and values are the alternative default.
+    configurable: true
   - name: gsb_service_google_storage_provision_defaults
     type: text
     default: '{}'
     label: Provision default override Google Cloud Storage instances.
     description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
       provision property and values are the alternative default.
+    configurable: true
+  - name: gsb_service_google_storage_bind_defaults
+    type: text
+    default: '{}'
+    label: Bind default override Google Cloud Storage instances.
+    description: A JSON object with key/value pairs. Keys MUST be the name of a user-defined
+      bind property and values are the alternative default.
     configurable: true
 service_plan_forms:
 - name: bigtable_custom_plans
@@ -377,10 +433,10 @@ service_plan_forms:
     description: Select a pricing plan (only for 1st generation instances).
     configurable: true
     options:
-    - name: PACKAGE
-      label: Package
     - name: PER_USE
       label: Per-Use
+    - name: PACKAGE
+      label: Package
   - name: max_disk_size
     type: string
     default: "10"


### PR DESCRIPTION
Fixes #243, #98 allow operators to define defaults for bind calls that use varcontexts.

This PR adds a varcontext builder for binds similar to the way provision works. It also adds new environment variables and a form for configuring default overrides.