### PR TITLE
Add instance data to unbind

### DIFF
--- a/brokerapi/brokers/broker_base/broker_base.go
+++ b/brokerapi/brokers/broker_base/broker_base.go
@@ -56,7 +56,7 @@ func (b *BrokerBase) BuildInstanceCredentials(ctx context.Context, bindRecord mo
 }
 
 // Unbind deletes the created service account from the GCP Project.
-func (b *BrokerBase) Unbind(ctx context.Context, creds models.ServiceBindingCredentials) error {
+func (b *BrokerBase) Unbind(ctx context.Context, instance models.ServiceInstanceDetails, creds models.ServiceBindingCredentials) error {
 	return b.AccountManager.DeleteCredentials(ctx, creds)
 }
 

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -484,7 +484,7 @@ var _ = Describe("AccountManagers", func() {
 	Describe("unbind", func() {
 		Context("when unbind is called on the broker", func() {
 			It("it should call the account manager delete account from google method", func() {
-				err = iamStyleBroker.Unbind(context.Background(), models.ServiceBindingCredentials{})
+				err = iamStyleBroker.Unbind(context.Background(), models.ServiceInstanceDetails{}, models.ServiceBindingCredentials{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(accountManager.DeleteCredentialsCallCount()).To(Equal(1))
 			})

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -392,8 +392,14 @@ func (gcpBroker *GCPServiceBroker) Unbind(ctx context.Context, instanceID, bindi
 		return brokerapi.ErrBindingDoesNotExist
 	}
 
+	// get existing service instance details
+	instance, err := db_service.GetServiceInstanceDetailsById(ctx, instanceID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving service instance details: %s", err)
+	}
+
 	// remove binding from Google
-	if err := service.Unbind(ctx, *existingBinding); err != nil {
+	if err := service.Unbind(ctx, *instance, *existingBinding); err != nil {
 		return err
 	}
 

--- a/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
+++ b/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
@@ -42,12 +42,12 @@ type FakeServiceBrokerHelper struct {
 		result1 map[string]interface{}
 		result2 error
 	}
-	BuildInstanceCredentialsStub        func(ctx context.Context, bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]interface{}, error)
+	BuildInstanceCredentialsStub        func(ctx context.Context, bindRecord models.ServiceBindingCredentials, instance models.ServiceInstanceDetails) (map[string]interface{}, error)
 	buildInstanceCredentialsMutex       sync.RWMutex
 	buildInstanceCredentialsArgsForCall []struct {
-		ctx            context.Context
-		bindRecord     models.ServiceBindingCredentials
-		instanceRecord models.ServiceInstanceDetails
+		ctx        context.Context
+		bindRecord models.ServiceBindingCredentials
+		instance   models.ServiceInstanceDetails
 	}
 	buildInstanceCredentialsReturns struct {
 		result1 map[string]interface{}
@@ -57,11 +57,12 @@ type FakeServiceBrokerHelper struct {
 		result1 map[string]interface{}
 		result2 error
 	}
-	UnbindStub        func(ctx context.Context, details models.ServiceBindingCredentials) error
+	UnbindStub        func(ctx context.Context, instance models.ServiceInstanceDetails, details models.ServiceBindingCredentials) error
 	unbindMutex       sync.RWMutex
 	unbindArgsForCall []struct {
-		ctx     context.Context
-		details models.ServiceBindingCredentials
+		ctx      context.Context
+		instance models.ServiceInstanceDetails
+		details  models.ServiceBindingCredentials
 	}
 	unbindReturns struct {
 		result1 error
@@ -240,18 +241,18 @@ func (fake *FakeServiceBrokerHelper) BindReturnsOnCall(i int, result1 map[string
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) BuildInstanceCredentials(ctx context.Context, bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]interface{}, error) {
+func (fake *FakeServiceBrokerHelper) BuildInstanceCredentials(ctx context.Context, bindRecord models.ServiceBindingCredentials, instance models.ServiceInstanceDetails) (map[string]interface{}, error) {
 	fake.buildInstanceCredentialsMutex.Lock()
 	ret, specificReturn := fake.buildInstanceCredentialsReturnsOnCall[len(fake.buildInstanceCredentialsArgsForCall)]
 	fake.buildInstanceCredentialsArgsForCall = append(fake.buildInstanceCredentialsArgsForCall, struct {
-		ctx            context.Context
-		bindRecord     models.ServiceBindingCredentials
-		instanceRecord models.ServiceInstanceDetails
-	}{ctx, bindRecord, instanceRecord})
-	fake.recordInvocation("BuildInstanceCredentials", []interface{}{ctx, bindRecord, instanceRecord})
+		ctx        context.Context
+		bindRecord models.ServiceBindingCredentials
+		instance   models.ServiceInstanceDetails
+	}{ctx, bindRecord, instance})
+	fake.recordInvocation("BuildInstanceCredentials", []interface{}{ctx, bindRecord, instance})
 	fake.buildInstanceCredentialsMutex.Unlock()
 	if fake.BuildInstanceCredentialsStub != nil {
-		return fake.BuildInstanceCredentialsStub(ctx, bindRecord, instanceRecord)
+		return fake.BuildInstanceCredentialsStub(ctx, bindRecord, instance)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -268,7 +269,7 @@ func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsCallCount() int {
 func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsArgsForCall(i int) (context.Context, models.ServiceBindingCredentials, models.ServiceInstanceDetails) {
 	fake.buildInstanceCredentialsMutex.RLock()
 	defer fake.buildInstanceCredentialsMutex.RUnlock()
-	return fake.buildInstanceCredentialsArgsForCall[i].ctx, fake.buildInstanceCredentialsArgsForCall[i].bindRecord, fake.buildInstanceCredentialsArgsForCall[i].instanceRecord
+	return fake.buildInstanceCredentialsArgsForCall[i].ctx, fake.buildInstanceCredentialsArgsForCall[i].bindRecord, fake.buildInstanceCredentialsArgsForCall[i].instance
 }
 
 func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsReturns(result1 map[string]interface{}, result2 error) {
@@ -293,17 +294,18 @@ func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsReturnsOnCall(i int
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) Unbind(ctx context.Context, details models.ServiceBindingCredentials) error {
+func (fake *FakeServiceBrokerHelper) Unbind(ctx context.Context, instance models.ServiceInstanceDetails, details models.ServiceBindingCredentials) error {
 	fake.unbindMutex.Lock()
 	ret, specificReturn := fake.unbindReturnsOnCall[len(fake.unbindArgsForCall)]
 	fake.unbindArgsForCall = append(fake.unbindArgsForCall, struct {
-		ctx     context.Context
-		details models.ServiceBindingCredentials
-	}{ctx, details})
-	fake.recordInvocation("Unbind", []interface{}{ctx, details})
+		ctx      context.Context
+		instance models.ServiceInstanceDetails
+		details  models.ServiceBindingCredentials
+	}{ctx, instance, details})
+	fake.recordInvocation("Unbind", []interface{}{ctx, instance, details})
 	fake.unbindMutex.Unlock()
 	if fake.UnbindStub != nil {
-		return fake.UnbindStub(ctx, details)
+		return fake.UnbindStub(ctx, instance, details)
 	}
 	if specificReturn {
 		return ret.result1
@@ -317,10 +319,10 @@ func (fake *FakeServiceBrokerHelper) UnbindCallCount() int {
 	return len(fake.unbindArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) UnbindArgsForCall(i int) (context.Context, models.ServiceBindingCredentials) {
+func (fake *FakeServiceBrokerHelper) UnbindArgsForCall(i int) (context.Context, models.ServiceInstanceDetails, models.ServiceBindingCredentials) {
 	fake.unbindMutex.RLock()
 	defer fake.unbindMutex.RUnlock()
-	return fake.unbindArgsForCall[i].ctx, fake.unbindArgsForCall[i].details
+	return fake.unbindArgsForCall[i].ctx, fake.unbindArgsForCall[i].instance, fake.unbindArgsForCall[i].details
 }
 
 func (fake *FakeServiceBrokerHelper) UnbindReturns(result1 error) {


### PR DESCRIPTION
Add instance data to unbind. After this change, the system will do ALL state management (for the serve command) in the `gcp_service_broker`.

This is important to better reason about the state of the system at any one time. We can now define invariants the `gcp_service_broker` must hold to ensure we comply with OSB and avoid getting ourselves into weird failure states that require manual intervention.