### PR TITLE
Move Example Tests to use JSONSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New `coldline` Cloud Storage plan.
 - Ability to create custom Cloud Storage plans.
 - New tile form for creating custom Cloud Storage plans.
+- Examples of binding variables to the docs.
+- Constraints/validation of the binding variables to the docs.
 
 ### Changed
 - Role whitelists are now validated through JSON Schema checks.
+- The `run-examples` sub-command now evaluates the credentials against the JSON Schema, improving robustness.
 
 ### Fixed
 - Fixed issue where Cloud Datastore service accounts were getting the same name.

--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 	"github.com/spf13/viper"
@@ -253,26 +254,51 @@ func ServiceAccountBindOutputVariables() []broker.BrokerVariable {
 			FieldName: "Email",
 			Type:      broker.JsonTypeString,
 			Details:   "Email address of the service account.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Examples("pcf-binding-ex312029@my-project.iam.gserviceaccount.com").
+				Pattern(`^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`).
+				Build(),
 		},
 		{
 			FieldName: "Name",
 			Type:      broker.JsonTypeString,
 			Details:   "The name of the service account.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Examples("pcf-binding-ex312029").
+				Build(),
 		},
 		{
 			FieldName: "PrivateKeyData",
 			Type:      broker.JsonTypeString,
-			Details:   "Service account private key data. Base-64 encoded JSON.",
+			Details:   "Service account private key data. Base64 encoded JSON.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				MinLength(512).                // absolute lower bound
+				Pattern(`^[A-Za-z0-9+/]*=*$`). // very rough Base64 regex
+				Build(),
 		},
 		{
 			FieldName: "ProjectId",
 			Type:      broker.JsonTypeString,
 			Details:   "ID of the project that owns the service account.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Examples("my-project").
+				Pattern(`^[a-z0-9-]+$`).
+				MinLength(6).
+				MaxLength(30).
+				Build(),
 		},
 		{
 			FieldName: "UniqueId",
 			Type:      broker.JsonTypeString,
-			Details:   "Unique and stable id of the service account.",
+			Details:   "Unique and stable ID of the service account.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Examples("112447814736626230844").
+				Build(),
 		},
 	}
 }

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -90,6 +90,11 @@ func serviceDefinition() *broker.BrokerService {
 				FieldName: "dataset_id",
 				Type:      broker.JsonTypeString,
 				Details:   "The name of the BigQuery dataset.",
+				Required:  true,
+				Constraints: validation.NewConstraintBuilder().
+					Pattern("^[A-Za-z0-9_]+$").
+					MaxLength(1024).
+					Build(),
 			},
 		),
 		Examples: []broker.ServiceExample{

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -124,6 +124,12 @@ func serviceDefinition() *broker.BrokerService {
 				FieldName: "instance_id",
 				Type:      broker.JsonTypeString,
 				Details:   "The name of the BigTable dataset.",
+				Required:  true,
+				Constraints: validation.NewConstraintBuilder().
+					MinLength(6).
+					MaxLength(33).
+					Pattern("^[a-z][-0-9a-z]+$").
+					Build(),
 			},
 		),
 		PlanVariables: []broker.BrokerVariable{

--- a/brokerapi/brokers/cloudsql/common-definition.go
+++ b/brokerapi/brokers/cloudsql/common-definition.go
@@ -196,20 +196,114 @@ func commonProvisionVariables() []broker.BrokerVariable {
 func commonBindOutputVariables() []broker.BrokerVariable {
 	return append(accountmanagers.ServiceAccountBindOutputVariables(), []broker.BrokerVariable{
 		// Certificate
-		{FieldName: "CaCert", Type: broker.JsonTypeString, Details: "The server Certificate Authority's certificate."},
-		{FieldName: "ClientCert", Type: broker.JsonTypeString, Details: "The client certificate. For First Generation instances, the new certificate does not take effect until the instance is restarted."},
-		{FieldName: "ClientKey", Type: broker.JsonTypeString, Details: "The client certificate key."},
-		{FieldName: "Sha1Fingerprint", Type: broker.JsonTypeString, Details: "The SHA1 fingerprint of the client certificate."},
+		{
+			FieldName: "CaCert",
+			Type:      broker.JsonTypeString,
+			Details:   "The server Certificate Authority's certificate.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Examples("-----BEGIN CERTIFICATE-----BASE64 Certificate Text-----END CERTIFICATE-----").
+				Build(),
+		},
+		{
+			FieldName: "ClientCert",
+			Type:      broker.JsonTypeString,
+			Details:   "The client certificate. For First Generation instances, the new certificate does not take effect until the instance is restarted.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Examples("-----BEGIN CERTIFICATE-----BASE64 Certificate Text-----END CERTIFICATE-----").
+				Build(),
+		},
+		{
+			FieldName: "ClientKey",
+			Type:      broker.JsonTypeString,
+			Details:   "The client certificate key.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Examples("-----BEGIN RSA PRIVATE KEY-----BASE64 Key Text-----END RSA PRIVATE KEY-----").
+				Build(),
+		},
+		{
+			FieldName: "Sha1Fingerprint",
+			Type:      broker.JsonTypeString,
+			Details:   "The SHA1 fingerprint of the client certificate.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Examples("e6d0c68f35032c6c2132217d1f1fb06b12ed32e2").
+				Pattern(`^[0-9a-f]{40}$`).
+				Build(),
+		},
 
 		// Connection URI
-		{FieldName: "UriPrefix", Type: broker.JsonTypeString, Details: "The connection prefix e.g. `mysql` or `postgres`."},
-		{FieldName: "Username", Type: broker.JsonTypeString, Details: "The name of the SQL user provisioned."},
-		{FieldName: "database_name", Type: broker.JsonTypeString, Details: "The name of the database on the instance."},
-		{FieldName: "host", Type: broker.JsonTypeString, Details: "The hostname or ip of the database instance."},
-		{FieldName: "instance_name", Type: broker.JsonTypeString, Details: "The name of the database instance."},
-		{FieldName: "uri", Type: broker.JsonTypeString, Details: "A database connection string."},
-
-		{FieldName: "last_master_operation_id", Type: broker.JsonTypeString, Details: "(GCP internals) The id of the last operation on the database."},
-		{FieldName: "region", Type: broker.JsonTypeString, Details: "The region the database is in."},
+		{
+			FieldName:   "UriPrefix",
+			Type:        broker.JsonTypeString,
+			Details:     "The connection prefix.",
+			Required:    false,
+			Constraints: validation.NewConstraintBuilder().Examples("jdbc:", "").Build(),
+		},
+		{
+			FieldName:   "Username",
+			Type:        broker.JsonTypeString,
+			Details:     "The name of the SQL user provisioned.",
+			Required:    true,
+			Constraints: validation.NewConstraintBuilder().Examples("sb15404128767777").Build(),
+		},
+		{
+			FieldName:   "Password",
+			Type:        broker.JsonTypeString,
+			Details:     "The database password for the SQL user.",
+			Required:    true,
+			Constraints: validation.NewConstraintBuilder().Examples("N-JPz7h2RHPZ81jB5gDHdnluddnIFMWG4nd5rKjR_8A=").Build(),
+		},
+		{
+			FieldName:   "database_name",
+			Type:        broker.JsonTypeString,
+			Details:     "The name of the database on the instance.",
+			Required:    true,
+			Constraints: validation.NewConstraintBuilder().Examples("pcf-sb-2-1540412407295372465").Build(),
+		},
+		{
+			FieldName:   "host",
+			Type:        broker.JsonTypeString,
+			Details:     "The hostname or IP address of the database instance.",
+			Required:    true,
+			Constraints: validation.NewConstraintBuilder().Examples("127.0.0.1").Build(),
+		},
+		{
+			FieldName: "instance_name",
+			Type:      broker.JsonTypeString,
+			Details:   "The name of the database instance.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Examples("pcf-sb-1-1540412407295273023").
+				Pattern("^[a-z][a-z0-9-]+$").
+				MaxLength(84).
+				Build(),
+		},
+		{
+			FieldName:   "uri",
+			Type:        broker.JsonTypeString,
+			Details:     "A database connection string.",
+			Required:    true,
+			Constraints: validation.NewConstraintBuilder().Examples("mysql://user:pass@127.0.0.1/pcf-sb-2-1540412407295372465?ssl_mode=required").Build(),
+		},
+		{
+			FieldName:   "last_master_operation_id",
+			Type:        broker.JsonTypeString,
+			Details:     "(deprecated) The id of the last operation on the database.",
+			Required:    false,
+			Constraints: validation.NewConstraintBuilder().Examples("mysql://user:pass@127.0.0.1/pcf-sb-2-1540412407295372465?ssl_mode=required").Build(),
+		},
+		{
+			FieldName: "region",
+			Type:      broker.JsonTypeString,
+			Details:   "The region the database is in.",
+			Required:  true,
+			Constraints: validation.NewConstraintBuilder().
+				Pattern("^[A-Za-z][-a-z0-9A-Z]+$").
+				Examples("northamerica-northeast1", "southamerica-east1", "us-east1").
+				Build(),
+		},
 	}...)
 }

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -123,7 +123,7 @@ again during that time (on a best-effort basis).
 				Constraints: validation.NewConstraintBuilder().
 					MinLength(0). // subscription name could be blank on return
 					MaxLength(255).
-					Pattern(`^[a-zA-Z][a-zA-Z0-9\d\-_~%\.\+]+`). // adapted from the Pub/Sub create subscription page's validator
+					Pattern(`^(|[a-zA-Z][a-zA-Z0-9\d\-_~%\.\+]+)`). // adapted from the Pub/Sub create subscription page's validator
 					Build(),
 			},
 			broker.BrokerVariable{

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -119,11 +119,23 @@ again during that time (on a best-effort basis).
 				FieldName: "subscription_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the subscription.",
+				Required:  false,
+				Constraints: validation.NewConstraintBuilder().
+					MinLength(0). // subscription name could be blank on return
+					MaxLength(255).
+					Pattern(`^[a-zA-Z][a-zA-Z0-9\d\-_~%\.\+]+`). // adapted from the Pub/Sub create subscription page's validator
+					Build(),
 			},
 			broker.BrokerVariable{
 				FieldName: "topic_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the topic.",
+				Required:  true,
+				Constraints: validation.NewConstraintBuilder().
+					MinLength(3).
+					MaxLength(255).
+					Pattern(`^[a-zA-Z][a-zA-Z0-9\d\-_~%\.\+]+$`). // adapted from the Pub/Sub create topic page's validator
+					Build(),
 			},
 		),
 

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -109,7 +109,13 @@ func serviceDefinition() *broker.BrokerService {
 			broker.BrokerVariable{
 				FieldName: "instance_id",
 				Type:      broker.JsonTypeString,
-				Details:   "Name of the spanner instance the account can connect to.",
+				Details:   "Name of the Spanner instance the account can connect to.",
+				Required:  true,
+				Constraints: validation.NewConstraintBuilder().
+					MinLength(6).
+					MaxLength(30).
+					Pattern("^[a-z][-a-z0-9]*[a-z0-9]$").
+					Build(),
 			},
 		),
 		PlanVariables: []broker.BrokerVariable{

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -111,7 +111,13 @@ func serviceDefinition() *broker.BrokerService {
 			broker.BrokerVariable{
 				FieldName: "bucket_name",
 				Type:      broker.JsonTypeString,
-				Details:   "Name of the bucket this binding is for",
+				Details:   "Name of the bucket this binding is for.",
+				Required:  true,
+				Constraints: validation.NewConstraintBuilder(). // https://cloud.google.com/storage/docs/naming
+										Pattern("^[A-Za-z0-9_\\.]+$").
+										MinLength(3).
+										MaxLength(222).
+										Build(),
 			},
 		),
 		PlanVariables: []broker.BrokerVariable{

--- a/docs/use.md
+++ b/docs/use.md
@@ -33,12 +33,24 @@ A fast, economical and fully managed data warehouse for large-scale data analyti
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
- * `dataset_id` _string_ - The name of the BigQuery dataset.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
+ * `dataset_id` _string_ - **Required** The name of the BigQuery dataset.
+    * The string must have at most 1024 characters.
+    * The string must match the regular expression `^[A-Za-z0-9_]+$`.
 
 ## Plans
 
@@ -129,12 +141,25 @@ A high performance NoSQL database service for large analytical and operational w
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
- * `instance_id` _string_ - The name of the BigTable dataset.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
+ * `instance_id` _string_ - **Required** The name of the BigTable dataset.
+    * The string must have at most 33 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z][-0-9a-z]+$`.
 
 ## Plans
 
@@ -253,23 +278,51 @@ Google Cloud SQL is a fully-managed MySQL database service.
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
- * `CaCert` _string_ - The server Certificate Authority's certificate.
- * `ClientCert` _string_ - The client certificate. For First Generation instances, the new certificate does not take effect until the instance is restarted.
- * `ClientKey` _string_ - The client certificate key.
- * `Sha1Fingerprint` _string_ - The SHA1 fingerprint of the client certificate.
- * `UriPrefix` _string_ - The connection prefix e.g. `mysql` or `postgres`.
- * `Username` _string_ - The name of the SQL user provisioned.
- * `database_name` _string_ - The name of the database on the instance.
- * `host` _string_ - The hostname or ip of the database instance.
- * `instance_name` _string_ - The name of the database instance.
- * `uri` _string_ - A database connection string.
- * `last_master_operation_id` _string_ - (GCP internals) The id of the last operation on the database.
- * `region` _string_ - The region the database is in.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
+ * `CaCert` _string_ - **Required** The server Certificate Authority's certificate.
+    * Examples: [-----BEGIN CERTIFICATE-----BASE64 Certificate Text-----END CERTIFICATE-----].
+ * `ClientCert` _string_ - **Required** The client certificate. For First Generation instances, the new certificate does not take effect until the instance is restarted.
+    * Examples: [-----BEGIN CERTIFICATE-----BASE64 Certificate Text-----END CERTIFICATE-----].
+ * `ClientKey` _string_ - **Required** The client certificate key.
+    * Examples: [-----BEGIN RSA PRIVATE KEY-----BASE64 Key Text-----END RSA PRIVATE KEY-----].
+ * `Sha1Fingerprint` _string_ - **Required** The SHA1 fingerprint of the client certificate.
+    * Examples: [e6d0c68f35032c6c2132217d1f1fb06b12ed32e2].
+    * The string must match the regular expression `^[0-9a-f]{40}$`.
+ * `UriPrefix` _string_ - The connection prefix.
+    * Examples: [jdbc: ].
+ * `Username` _string_ - **Required** The name of the SQL user provisioned.
+    * Examples: [sb15404128767777].
+ * `Password` _string_ - **Required** The database password for the SQL user.
+    * Examples: [N-JPz7h2RHPZ81jB5gDHdnluddnIFMWG4nd5rKjR_8A=].
+ * `database_name` _string_ - **Required** The name of the database on the instance.
+    * Examples: [pcf-sb-2-1540412407295372465].
+ * `host` _string_ - **Required** The hostname or IP address of the database instance.
+    * Examples: [127.0.0.1].
+ * `instance_name` _string_ - **Required** The name of the database instance.
+    * Examples: [pcf-sb-1-1540412407295273023].
+    * The string must have at most 84 characters.
+    * The string must match the regular expression `^[a-z][a-z0-9-]+$`.
+ * `uri` _string_ - **Required** A database connection string.
+    * Examples: [mysql://user:pass@127.0.0.1/pcf-sb-2-1540412407295372465?ssl_mode=required].
+ * `last_master_operation_id` _string_ - (deprecated) The id of the last operation on the database.
+    * Examples: [mysql://user:pass@127.0.0.1/pcf-sb-2-1540412407295372465?ssl_mode=required].
+ * `region` _string_ - **Required** The region the database is in.
+    * Examples: [northamerica-northeast1 southamerica-east1 us-east1].
+    * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
 
 ## Plans
 
@@ -403,23 +456,51 @@ Google Cloud SQL is a fully-managed MySQL database service.
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
- * `CaCert` _string_ - The server Certificate Authority's certificate.
- * `ClientCert` _string_ - The client certificate. For First Generation instances, the new certificate does not take effect until the instance is restarted.
- * `ClientKey` _string_ - The client certificate key.
- * `Sha1Fingerprint` _string_ - The SHA1 fingerprint of the client certificate.
- * `UriPrefix` _string_ - The connection prefix e.g. `mysql` or `postgres`.
- * `Username` _string_ - The name of the SQL user provisioned.
- * `database_name` _string_ - The name of the database on the instance.
- * `host` _string_ - The hostname or ip of the database instance.
- * `instance_name` _string_ - The name of the database instance.
- * `uri` _string_ - A database connection string.
- * `last_master_operation_id` _string_ - (GCP internals) The id of the last operation on the database.
- * `region` _string_ - The region the database is in.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
+ * `CaCert` _string_ - **Required** The server Certificate Authority's certificate.
+    * Examples: [-----BEGIN CERTIFICATE-----BASE64 Certificate Text-----END CERTIFICATE-----].
+ * `ClientCert` _string_ - **Required** The client certificate. For First Generation instances, the new certificate does not take effect until the instance is restarted.
+    * Examples: [-----BEGIN CERTIFICATE-----BASE64 Certificate Text-----END CERTIFICATE-----].
+ * `ClientKey` _string_ - **Required** The client certificate key.
+    * Examples: [-----BEGIN RSA PRIVATE KEY-----BASE64 Key Text-----END RSA PRIVATE KEY-----].
+ * `Sha1Fingerprint` _string_ - **Required** The SHA1 fingerprint of the client certificate.
+    * Examples: [e6d0c68f35032c6c2132217d1f1fb06b12ed32e2].
+    * The string must match the regular expression `^[0-9a-f]{40}$`.
+ * `UriPrefix` _string_ - The connection prefix.
+    * Examples: [jdbc: ].
+ * `Username` _string_ - **Required** The name of the SQL user provisioned.
+    * Examples: [sb15404128767777].
+ * `Password` _string_ - **Required** The database password for the SQL user.
+    * Examples: [N-JPz7h2RHPZ81jB5gDHdnluddnIFMWG4nd5rKjR_8A=].
+ * `database_name` _string_ - **Required** The name of the database on the instance.
+    * Examples: [pcf-sb-2-1540412407295372465].
+ * `host` _string_ - **Required** The hostname or IP address of the database instance.
+    * Examples: [127.0.0.1].
+ * `instance_name` _string_ - **Required** The name of the database instance.
+    * Examples: [pcf-sb-1-1540412407295273023].
+    * The string must have at most 84 characters.
+    * The string must match the regular expression `^[a-z][a-z0-9-]+$`.
+ * `uri` _string_ - **Required** A database connection string.
+    * Examples: [mysql://user:pass@127.0.0.1/pcf-sb-2-1540412407295372465?ssl_mode=required].
+ * `last_master_operation_id` _string_ - (deprecated) The id of the last operation on the database.
+    * Examples: [mysql://user:pass@127.0.0.1/pcf-sb-2-1540412407295372465?ssl_mode=required].
+ * `region` _string_ - **Required** The region the database is in.
+    * Examples: [northamerica-northeast1 southamerica-east1 us-east1].
+    * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
 
 ## Plans
 
@@ -510,11 +591,21 @@ _No parameters supported._
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
 
 ## Plans
 
@@ -587,11 +678,21 @@ _No parameters supported._
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
 
 ## Plans
 
@@ -678,13 +779,29 @@ A global service for real-time and reliable messaging and streaming data.
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
  * `subscription_name` _string_ - Name of the subscription.
- * `topic_name` _string_ - Name of the topic.
+    * The string must have at most 255 characters.
+    * The string must have at least 0 characters.
+    * The string must match the regular expression `^[a-zA-Z][a-zA-Z0-9\d\-_~%\.\+]+`.
+ * `topic_name` _string_ - **Required** Name of the topic.
+    * The string must have at most 255 characters.
+    * The string must have at least 3 characters.
+    * The string must match the regular expression `^[a-zA-Z][a-zA-Z0-9\d\-_~%\.\+]+$`.
 
 ## Plans
 
@@ -834,12 +951,25 @@ The first horizontally scalable, globally consistent, relational database servic
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
- * `instance_id` _string_ - Name of the spanner instance the account can connect to.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
+ * `instance_id` _string_ - **Required** Name of the Spanner instance the account can connect to.
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z][-a-z0-9]*[a-z0-9]$`.
 
 ## Plans
 
@@ -946,11 +1076,21 @@ _No parameters supported._
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
 
 ## Plans
 
@@ -1021,11 +1161,21 @@ _No parameters supported._
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
 
 ## Plans
 
@@ -1096,11 +1246,21 @@ _No parameters supported._
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
 
 ## Plans
 
@@ -1180,12 +1340,25 @@ Unified object storage for developers and enterprises. Cloud Storage allows worl
 
 **Response Parameters**
 
- * `Email` _string_ - Email address of the service account.
- * `Name` _string_ - The name of the service account.
- * `PrivateKeyData` _string_ - Service account private key data. Base-64 encoded JSON.
- * `ProjectId` _string_ - ID of the project that owns the service account.
- * `UniqueId` _string_ - Unique and stable id of the service account.
- * `bucket_name` _string_ - Name of the bucket this binding is for
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
+ * `bucket_name` _string_ - **Required** Name of the bucket this binding is for.
+    * The string must have at most 222 characters.
+    * The string must have at least 3 characters.
+    * The string must match the regular expression `^[A-Za-z0-9_\.]+$`.
 
 ## Plans
 

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -99,18 +99,9 @@ func RunExample(client *Client, example broker.ServiceExample, service *broker.B
 	}
 
 	credentialsEntry := binding.Credentials.(map[string]interface{})
-
-	allContained := true
-	for _, v := range service.BindOutputVariables {
-		_, ok := credentialsEntry[v.FieldName]
-		if !ok {
-			allContained = false
-			log.Printf("Error: credentials were missing property: %q", v.FieldName)
-		}
-	}
-
-	if !allContained {
-		return errors.New("Not all properties were found in the bound credentials")
+	if err := broker.ValidateVariables(credentialsEntry, service.BindOutputVariables); err != nil {
+		log.Printf("Error: results don't match JSON Schema: %v", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Move the `run-examples` command over to use JSON Schemas annotated on the output variables for validation.

This means we have improved documentation about expected values, examples in our docs, more robust tests against little mistakes where a type/existence check isn't enough and less custom code for validation.

The constraints listed are meant to be sanity checks rather than being exact. For example, the base64 regex used to validate service accounts matches both valid an invalid base64, but it's an approximation that's easy to explain, document, and works well as a sanity check. We want to validate that fields don't get transposed, deleted, overwritten, and have the general right shape and size.

~~Tests are still running on my machine, but I'm building this PR before going home to get the overall idea out.~~ Tests are now good!

Fixes #322 