### PR TITLE
simplify other details handling

### DIFF
--- a/brokerapi/brokers/bigquery/broker.go
+++ b/brokerapi/brokers/bigquery/broker.go
@@ -16,7 +16,6 @@ package bigquery
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
@@ -69,19 +68,17 @@ func (b *BigQueryBroker) Provision(ctx context.Context, instanceId string, detai
 		DatasetId: newDataset.DatasetReference.DatasetId,
 	}
 
-	otherDetails, err := json.Marshal(ii)
-	if err != nil {
-		return models.ServiceInstanceDetails{}, fmt.Errorf("Error marshalling other details: %s", err)
+	id := models.ServiceInstanceDetails{
+		Name:     newDataset.DatasetReference.DatasetId,
+		Url:      newDataset.SelfLink,
+		Location: newDataset.Location,
 	}
 
-	i := models.ServiceInstanceDetails{
-		Name:         newDataset.DatasetReference.DatasetId,
-		Url:          newDataset.SelfLink,
-		Location:     newDataset.Location,
-		OtherDetails: string(otherDetails),
+	if err := id.SetOtherDetails(ii); err != nil {
+		return models.ServiceInstanceDetails{}, err
 	}
 
-	return i, nil
+	return id, nil
 }
 
 // Deprovision deletes the dataset associated with the given instance.

--- a/brokerapi/brokers/bigtable/broker.go
+++ b/brokerapi/brokers/bigtable/broker.go
@@ -15,7 +15,6 @@
 package bigtable
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -85,17 +84,15 @@ func (b *BigTableBroker) Provision(ctx context.Context, instanceId string, detai
 		InstanceId: instanceName,
 	}
 
-	otherDetails, err := json.Marshal(ii)
-	if err != nil {
-		return models.ServiceInstanceDetails{}, fmt.Errorf("Error marshalling other details: %s", err)
+	id := models.ServiceInstanceDetails{
+		Name: instanceName,
 	}
 
-	return models.ServiceInstanceDetails{
-		Name:         instanceName,
-		Url:          "",
-		Location:     "",
-		OtherDetails: string(otherDetails),
-	}, nil
+	if err := id.SetOtherDetails(ii); err != nil {
+		return models.ServiceInstanceDetails{}, err
+	}
+
+	return id, nil
 }
 
 // Deprovision deletes the BigTable associated with the given instance.

--- a/brokerapi/brokers/models/db.go
+++ b/brokerapi/brokers/models/db.go
@@ -33,27 +33,29 @@ const (
 // binding to a service.
 type ServiceBindingCredentials ServiceBindingCredentialsV1
 
-// GetOtherDetails returns an unmarshaled version of the OtherDetails field
-// or errors.
-func (sbc ServiceBindingCredentials) GetOtherDetails() (map[string]string, error) {
-	var creds map[string]string
-	err := json.Unmarshal([]byte(sbc.OtherDetails), &creds)
-	return creds, err
-}
-
 // ServiceInstanceDetails holds information about provisioned services.
 type ServiceInstanceDetails ServiceInstanceDetailsV2
 
-// GetOtherDetails returns an unmarshaled version of the OtherDetails field
-// or errors.
-func (si ServiceInstanceDetails) GetOtherDetails() (map[string]string, error) {
-	var instanceDetails map[string]string
-	if si.OtherDetails == "" {
-		return instanceDetails, nil
+// SetOtherDetails marshals the value passed in into a JSON string and sets
+// OtherDetails to it if marshalling was successful.
+func (si *ServiceInstanceDetails) SetOtherDetails(toSet interface{}) error {
+	out, err := json.Marshal(toSet)
+	if err != nil {
+		return err
 	}
 
-	err := json.Unmarshal([]byte(si.OtherDetails), &instanceDetails)
-	return instanceDetails, err
+	si.OtherDetails = string(out)
+	return nil
+}
+
+// GetOtherDetails returns an unmarshalls the OtherDetails field into the given
+// struct. An empty OtherDetails field does not get unmarshalled and does not error.
+func (si ServiceInstanceDetails) GetOtherDetails(v interface{}) error {
+	if si.OtherDetails == "" {
+		return nil
+	}
+
+	return json.Unmarshal([]byte(si.OtherDetails), v)
 }
 
 // ProvisionRequestDetails holds user-defined properties passed to a call

--- a/brokerapi/brokers/pubsub/broker.go
+++ b/brokerapi/brokers/pubsub/broker.go
@@ -15,7 +15,6 @@
 package pubsub
 
 import (
-	"encoding/json"
 	"errors"
 
 	googlepubsub "cloud.google.com/go/pubsub"
@@ -109,17 +108,17 @@ func (b *PubSubBroker) Provision(ctx context.Context, instanceId string, details
 		SubscriptionName: subscriptionName,
 	}
 
-	otherDetails, err := json.Marshal(ii)
-	if err != nil {
-		return models.ServiceInstanceDetails{}, fmt.Errorf("Error marshalling json: %s", err)
+	id := models.ServiceInstanceDetails{
+		Name:     topicName,
+		Url:      "",
+		Location: "",
 	}
 
-	return models.ServiceInstanceDetails{
-		Name:         topicName,
-		Url:          "",
-		Location:     "",
-		OtherDetails: string(otherDetails),
-	}, nil
+	if err := id.SetOtherDetails(ii); err != nil {
+		return models.ServiceInstanceDetails{}, err
+	}
+
+	return id, err
 }
 
 // Deprovision deletes the topic and subscription associated with the given instance.
@@ -133,13 +132,13 @@ func (b *PubSubBroker) Deprovision(ctx context.Context, topic models.ServiceInst
 		return nil, fmt.Errorf("Error deleting pubsub topic: %s", err)
 	}
 
-	otherDetails, err := topic.GetOtherDetails()
-	if err != nil {
+	otherDetails := InstanceInformation{}
+	if err := topic.GetOtherDetails(&otherDetails); err != nil {
 		return nil, err
 	}
 
-	if subscriptionName := otherDetails["subscription_name"]; subscriptionName != "" {
-		if err := service.Subscription(subscriptionName).Delete(ctx); err != nil {
+	if otherDetails.SubscriptionName != "" {
+		if err := service.Subscription(otherDetails.SubscriptionName).Delete(ctx); err != nil {
 			return nil, fmt.Errorf("Error deleting subscription: %s", err)
 		}
 	}

--- a/brokerapi/brokers/spanner/broker.go
+++ b/brokerapi/brokers/spanner/broker.go
@@ -16,7 +16,6 @@ package spanner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	googlespanner "cloud.google.com/go/spanner/admin/instance/apiv1"
@@ -82,19 +81,19 @@ func (s *SpannerBroker) Provision(ctx context.Context, instanceId string, detail
 		InstanceId: instanceName,
 	}
 
-	otherDetails, err := json.Marshal(ii)
-	if err != nil {
-		return models.ServiceInstanceDetails{}, fmt.Errorf("Error marshalling other details: %s", err)
-	}
-
-	return models.ServiceInstanceDetails{
+	id := models.ServiceInstanceDetails{
 		Name:          instanceName,
 		Url:           "",
 		Location:      instanceLocation,
-		OtherDetails:  string(otherDetails),
 		OperationType: models.ProvisionOperationType,
 		OperationId:   op.Name(),
-	}, nil
+	}
+
+	if err := id.SetOtherDetails(ii); err != nil {
+		return models.ServiceInstanceDetails{}, err
+	}
+
+	return id, nil
 }
 
 // PollInstance gets the last operation for this instance and polls its status.

--- a/brokerapi/brokers/storage/broker.go
+++ b/brokerapi/brokers/storage/broker.go
@@ -15,7 +15,6 @@
 package storage
 
 import (
-	"encoding/json"
 	"fmt"
 
 	googlestorage "cloud.google.com/go/storage"
@@ -73,17 +72,16 @@ func (b *StorageBroker) Provision(ctx context.Context, instanceId string, detail
 		BucketName: attrs.Name,
 	}
 
-	otherDetails, err := json.Marshal(ii)
-	if err != nil {
+	id := models.ServiceInstanceDetails{
+		Name:     attrs.Name,
+		Location: attrs.Location,
+	}
+
+	if err := id.SetOtherDetails(ii); err != nil {
 		return models.ServiceInstanceDetails{}, fmt.Errorf("Error marshalling json: %s", err)
 	}
 
-	return models.ServiceInstanceDetails{
-		Name:         attrs.Name,
-		Url:          "",
-		Location:     attrs.Location,
-		OtherDetails: string(otherDetails),
-	}, nil
+	return id, nil
 }
 
 // Deprovision deletes the bucket associated with the given instance.


### PR DESCRIPTION
Changes the way we handle OtherDetails marshaling/unmarshalling so all the BrokerHelpers are consistent and don't need to know the back-end implementation.