### PR TITLE
moved provision to varcontext

### DIFF
--- a/brokerapi/brokers/api_service/broker.go
+++ b/brokerapi/brokers/api_service/broker.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 )
 
@@ -28,7 +29,7 @@ type ApiServiceBroker struct {
 }
 
 // Provision is a no-op call because only service accounts need to be bound/unbound for Google Machine Learning APIs.
-func (b *ApiServiceBroker) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
+func (b *ApiServiceBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
 	return models.ServiceInstanceDetails{}, nil
 }
 

--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -63,6 +63,7 @@ func init() {
 		DefaultRoleWhitelist:    roleWhitelist,
 		BindInputVariables:      accountmanagers.ServiceAccountBindInputVariables(models.MlName, roleWhitelist),
 		BindOutputVariables:     accountmanagers.ServiceAccountBindOutputVariables(),
+		BindComputedVariables:   accountmanagers.ServiceAccountBindComputedVariables(),
 		Examples: []broker.ServiceExample{
 			{
 				Name:            "Basic Configuration",

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -19,6 +19,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 )
 
 func init() {
@@ -83,8 +84,12 @@ func serviceDefinition() *broker.BrokerService {
 					Build(),
 			},
 		},
-		DefaultRoleWhitelist: roleWhitelist,
-		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(models.BigqueryName, roleWhitelist),
+		ProvisionComputedVariables: []varcontext.DefaultVariable{
+			{Name: "labels", Default: "${json.marshal(request.default_labels)}", Overwrite: true},
+		},
+		DefaultRoleWhitelist:  roleWhitelist,
+		BindInputVariables:    accountmanagers.ServiceAccountBindInputVariables(models.BigqueryName, roleWhitelist),
+		BindComputedVariables: accountmanagers.ServiceAccountBindComputedVariables(),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
 			broker.BrokerVariable{
 				FieldName: "dataset_id",

--- a/brokerapi/brokers/bigtable/broker.go
+++ b/brokerapi/brokers/bigtable/broker.go
@@ -22,6 +22,7 @@ import (
 	googlebigtable "cloud.google.com/go/bigtable"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
@@ -46,12 +47,7 @@ var storageTypes = map[string]googlebigtable.StorageType{
 }
 
 // Provision creates a new Bigtable instance from the settings in the user-provided details and service plan.
-func (b *BigTableBroker) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
-	provisionContext, err := serviceDefinition().ProvisionVariables(instanceId, details, plan)
-	if err != nil {
-		return models.ServiceInstanceDetails{}, err
-	}
-
+func (b *BigTableBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
 	instanceName := provisionContext.GetString("name")
 
 	ic := googlebigtable.InstanceConf{

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -132,6 +132,7 @@ func serviceDefinition() *broker.BrokerService {
 					Build(),
 			},
 		),
+		BindComputedVariables: accountmanagers.ServiceAccountBindComputedVariables(),
 		PlanVariables: []broker.BrokerVariable{
 			{
 				FieldName: "storage_type",

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -118,8 +118,8 @@ var _ = Describe("Brokers", func() {
 			gcpBroker.ServiceBrokerMap[k] = &modelsfakes.FakeServiceBrokerHelper{
 				ProvisionsAsyncStub:   func() bool { return async },
 				DeprovisionsAsyncStub: func() bool { return async },
-				ProvisionStub: func(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
-					return models.ServiceInstanceDetails{ID: instanceId, OtherDetails: "{\"mynameis\": \"instancename\"}"}, nil
+				ProvisionStub: func(ctx context.Context, vc *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
+					return models.ServiceInstanceDetails{OtherDetails: "{\"mynameis\": \"instancename\"}"}, nil
 				},
 				BindStub: func(ctx context.Context, vc *varcontext.VarContext) (map[string]interface{}, error) {
 					return map[string]interface{}{"foo": "bar"}, nil

--- a/brokerapi/brokers/cloudsql/broker_test.go
+++ b/brokerapi/brokers/cloudsql/broker_test.go
@@ -256,11 +256,18 @@ func TestCreateProvisionRequest(t *testing.T) {
 			if plan == nil {
 				t.Fatalf("Expected plan with id %s to not be nil", tc.PlanId)
 			}
-			request, instanceInfo, err := createProvisionRequest("instance-id-here", details, *plan)
+
+			vars, err := tc.Service.ProvisionVariables("instance-id-here", details, *plan)
 			if err != nil {
 				if tc.ErrContains != "" && strings.Contains(err.Error(), tc.ErrContains) {
 					return
 				}
+
+				t.Fatalf("got error trying to get provision details %s %v", tc.PlanId, err)
+			}
+
+			request, instanceInfo, err := createProvisionRequest(vars)
+			if err != nil {
 
 				t.Fatalf("got unexpected error while creating provision request: %v", err)
 			}

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -230,6 +230,8 @@ func mysqlServiceDefinition() *broker.BrokerService {
 			},
 		}, commonProvisionVariables()...),
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
+			{Name: "labels", Default: `${json.marshal(request.default_labels)}`, Overwrite: true},
+
 			// legacy behavior dictates that empty values get defaults
 			{Name: "instance_name", Default: `${instance_name == "" ? "` + identifierTemplate + `" : instance_name}`, Overwrite: true},
 			{Name: "database_name", Default: `${database_name == "" ? "` + identifierTemplate + `" : database_name}`, Overwrite: true},

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -183,6 +183,8 @@ func postgresServiceDefinition() *broker.BrokerService {
 			},
 		}, commonProvisionVariables()...),
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
+			{Name: "labels", Default: `${json.marshal(request.default_labels)}`, Overwrite: true},
+
 			// legacy behavior dictates that empty values get defaults
 			{Name: "instance_name", Default: `${instance_name == "" ? "` + identifierTemplate + `" : instance_name}`, Overwrite: true},
 			{Name: "database_name", Default: `${database_name == "" ? "` + identifierTemplate + `" : database_name}`, Overwrite: true},

--- a/brokerapi/brokers/datastore/broker.go
+++ b/brokerapi/brokers/datastore/broker.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 )
 
@@ -28,7 +29,7 @@ type DatastoreBroker struct {
 }
 
 // Provision is a no-op call because only service accounts need to be bound/unbound for Datastore.
-func (b *DatastoreBroker) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
+func (b *DatastoreBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
 	return models.ServiceInstanceDetails{}, nil
 }
 

--- a/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
+++ b/brokerapi/brokers/models/modelsfakes/fake_service_broker_helper.go
@@ -11,13 +11,11 @@ import (
 )
 
 type FakeServiceBrokerHelper struct {
-	ProvisionStub        func(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error)
+	ProvisionStub        func(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error)
 	provisionMutex       sync.RWMutex
 	provisionArgsForCall []struct {
-		ctx        context.Context
-		instanceId string
-		details    brokerapi.ProvisionDetails
-		plan       models.ServicePlan
+		ctx              context.Context
+		provisionContext *varcontext.VarContext
 	}
 	provisionReturns struct {
 		result1 models.ServiceInstanceDetails
@@ -132,19 +130,17 @@ type FakeServiceBrokerHelper struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServiceBrokerHelper) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
+func (fake *FakeServiceBrokerHelper) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
 	fake.provisionMutex.Lock()
 	ret, specificReturn := fake.provisionReturnsOnCall[len(fake.provisionArgsForCall)]
 	fake.provisionArgsForCall = append(fake.provisionArgsForCall, struct {
-		ctx        context.Context
-		instanceId string
-		details    brokerapi.ProvisionDetails
-		plan       models.ServicePlan
-	}{ctx, instanceId, details, plan})
-	fake.recordInvocation("Provision", []interface{}{ctx, instanceId, details, plan})
+		ctx              context.Context
+		provisionContext *varcontext.VarContext
+	}{ctx, provisionContext})
+	fake.recordInvocation("Provision", []interface{}{ctx, provisionContext})
 	fake.provisionMutex.Unlock()
 	if fake.ProvisionStub != nil {
-		return fake.ProvisionStub(ctx, instanceId, details, plan)
+		return fake.ProvisionStub(ctx, provisionContext)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -158,10 +154,10 @@ func (fake *FakeServiceBrokerHelper) ProvisionCallCount() int {
 	return len(fake.provisionArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) ProvisionArgsForCall(i int) (context.Context, string, brokerapi.ProvisionDetails, models.ServicePlan) {
+func (fake *FakeServiceBrokerHelper) ProvisionArgsForCall(i int) (context.Context, *varcontext.VarContext) {
 	fake.provisionMutex.RLock()
 	defer fake.provisionMutex.RUnlock()
-	return fake.provisionArgsForCall[i].ctx, fake.provisionArgsForCall[i].instanceId, fake.provisionArgsForCall[i].details, fake.provisionArgsForCall[i].plan
+	return fake.provisionArgsForCall[i].ctx, fake.provisionArgsForCall[i].provisionContext
 }
 
 func (fake *FakeServiceBrokerHelper) ProvisionReturns(result1 models.ServiceInstanceDetails, result2 error) {

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -29,7 +29,10 @@ import (
 // ServiceBrokerHelpers are expected to interact with the state of the system entirely through their inputs and outputs.
 // Specifically, they MUST NOT modify any general state of the broker in the database.
 type ServiceBrokerHelper interface {
-	Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan ServicePlan) (ServiceInstanceDetails, error)
+	// Provision creates the necessary resources that an instance of this service
+	// needs to operate.
+	Provision(ctx context.Context, provisionContext *varcontext.VarContext) (ServiceInstanceDetails, error)
+
 	// Bind provisions the necessary resources for a user to be able to connect to the provisioned service.
 	// This may include creating service accounts, granting permissions, and adding users to services e.g. a SQL database user.
 	// It stores information necessary to access the service _and_ delete the binding in the returned map.

--- a/brokerapi/brokers/pubsub/broker.go
+++ b/brokerapi/brokers/pubsub/broker.go
@@ -20,7 +20,7 @@ import (
 
 	googlepubsub "cloud.google.com/go/pubsub"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 	"golang.org/x/net/context"
 
@@ -48,30 +48,25 @@ type InstanceInformation struct {
 
 // Provision creates a new Pub/Sub topic from the settings in the user-provided details and service plan.
 // If a subscription name is supplied, the function will also create a subscription for the topic.
-func (b *PubSubBroker) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
-	variableContext, err := serviceDefinition().ProvisionVariables(instanceId, details, plan)
-	if err != nil {
-		return models.ServiceInstanceDetails{}, err
-	}
-
+func (b *PubSubBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
 	// Extract and validate all the params exist and are the right types
-	defaultLabels := utils.ExtractDefaultLabels(instanceId, details)
-	topicName := variableContext.GetString("topic_name")
-	subscriptionName := variableContext.GetString("subscription_name")
+	defaultLabels := provisionContext.GetStringMapString("labels")
+	topicName := provisionContext.GetString("topic_name")
+	subscriptionName := provisionContext.GetString("subscription_name")
 	endpoint := ""
-	if variableContext.GetBool("is_push") {
-		endpoint = variableContext.GetString("endpoint")
+	if provisionContext.GetBool("is_push") {
+		endpoint = provisionContext.GetString("endpoint")
 	}
 
 	subscriptionConfig := googlepubsub.SubscriptionConfig{
 		PushConfig: googlepubsub.PushConfig{
 			Endpoint: endpoint,
 		},
-		AckDeadline: time.Duration(variableContext.GetInt("ack_deadline")) * time.Second,
+		AckDeadline: time.Duration(provisionContext.GetInt("ack_deadline")) * time.Second,
 		Labels:      defaultLabels,
 	}
 
-	if err := variableContext.Error(); err != nil {
+	if err := provisionContext.Error(); err != nil {
 		return models.ServiceInstanceDetails{}, err
 	}
 

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -19,6 +19,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 )
 
 func init() {
@@ -112,6 +113,9 @@ again during that time (on a best-effort basis).
 				Default: "10",
 			},
 		},
+		ProvisionComputedVariables: []varcontext.DefaultVariable{
+			{Name: "labels", Default: "${json.marshal(request.default_labels)}", Overwrite: true},
+		},
 		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(models.PubsubName, roleWhitelist),
 		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
@@ -138,7 +142,7 @@ again during that time (on a best-effort basis).
 					Build(),
 			},
 		),
-
+		BindComputedVariables: accountmanagers.ServiceAccountBindComputedVariables(),
 		Examples: []broker.ServiceExample{
 			{
 				Name:        "Basic Configuration",

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -19,6 +19,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 )
 
 func init() {
@@ -102,6 +103,9 @@ func serviceDefinition() *broker.BrokerService {
 					Pattern("^[a-z][-a-z0-9]*[a-z0-9]$").
 					Build(),
 			},
+		},
+		ProvisionComputedVariables: []varcontext.DefaultVariable{
+			{Name: "labels", Default: "${json.marshal(request.default_labels)}", Overwrite: true},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(models.SpannerName, roleWhitelist),

--- a/brokerapi/brokers/stackdriver_debugger/broker.go
+++ b/brokerapi/brokers/stackdriver_debugger/broker.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 )
 
@@ -28,7 +29,7 @@ type StackdriverDebuggerBroker struct {
 }
 
 // Provision is a no-op call because only service accounts need to be bound/unbound for Stackdriver.
-func (b *StackdriverDebuggerBroker) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
+func (b *StackdriverDebuggerBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
 	return models.ServiceInstanceDetails{}, nil
 }
 

--- a/brokerapi/brokers/stackdriver_profiler/broker.go
+++ b/brokerapi/brokers/stackdriver_profiler/broker.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 )
 
@@ -28,7 +29,7 @@ type StackdriverProfilerBroker struct {
 }
 
 // Provision is a no-op call because only service accounts need to be bound/unbound for Stackdriver.
-func (b *StackdriverProfilerBroker) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
+func (b *StackdriverProfilerBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
 	return models.ServiceInstanceDetails{}, nil
 }
 

--- a/brokerapi/brokers/stackdriver_trace/broker.go
+++ b/brokerapi/brokers/stackdriver_trace/broker.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 )
 
@@ -28,7 +29,7 @@ type StackdriverTraceBroker struct {
 }
 
 // Provision is a no-op call because only service accounts need to be bound/unbound for Stackdriver.
-func (b *StackdriverTraceBroker) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
+func (b *StackdriverTraceBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
 	return models.ServiceInstanceDetails{}, nil
 }
 

--- a/brokerapi/brokers/storage/broker.go
+++ b/brokerapi/brokers/storage/broker.go
@@ -21,7 +21,7 @@ import (
 	googlestorage "cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
@@ -40,21 +40,15 @@ type InstanceInformation struct {
 }
 
 // Provision creates a new GCS bucket from the settings in the user-provided details and service plan.
-func (b *StorageBroker) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
-	// resolve variables
-	variableContext, err := serviceDefinition().ProvisionVariables(instanceId, details, plan)
-	if err != nil {
-		return models.ServiceInstanceDetails{}, err
-	}
-
+func (b *StorageBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
 	attrs := googlestorage.BucketAttrs{
-		Name:         variableContext.GetString("name"),
-		StorageClass: variableContext.GetString("storage_class"),
-		Location:     variableContext.GetString("location"),
-		Labels:       utils.ExtractDefaultLabels(instanceId, details),
+		Name:         provisionContext.GetString("name"),
+		StorageClass: provisionContext.GetString("storage_class"),
+		Location:     provisionContext.GetString("location"),
+		Labels:       provisionContext.GetStringMapString("labels"),
 	}
 
-	if err := variableContext.Error(); err != nil {
+	if err := provisionContext.Error(); err != nil {
 		return models.ServiceInstanceDetails{}, err
 	}
 

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -19,6 +19,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 )
 
 func init() {
@@ -104,6 +105,9 @@ func serviceDefinition() *broker.BrokerService {
 					Examples("US", "EU", "southamerica-east1").
 					Build(),
 			},
+		},
+		ProvisionComputedVariables: []varcontext.DefaultVariable{
+			{Name: "labels", Default: "${json.marshal(request.default_labels)}", Overwrite: true},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:   accountmanagers.ServiceAccountBindInputVariables(models.StorageName, roleWhitelist),

--- a/docs/custom-services.md
+++ b/docs/custom-services.md
@@ -50,6 +50,8 @@ The following string interpolation functions are available for use:
 * `rand.base64(count) -> string`
   * Generates `count` bytes of cryptographically secure randomness and converts it to [URL Encoded Base64](https://tools.ietf.org/html/rfc4648).
   * The randomness makes it suitable for using as passwords.
+* `json.marshal(type) -> string`
+  * Returns a JSON marshaled string of the given type.
 
 ## Variable reference
 

--- a/pkg/varcontext/interpolation/eval_test.go
+++ b/pkg/varcontext/interpolation/eval_test.go
@@ -49,6 +49,8 @@ func TestEval(t *testing.T) {
 		"assert success":        {Template: `${assert(true, "nothing should happen")}`, Expected: "true"},
 		"assert failure":        {Template: `${assert(false, "failure message")}`, ErrorContains: "failure message"},
 		"assert message":        {Template: `${assert(false, "failure message ${1+1}")}`, ErrorContains: "failure message 2"},
+		"json marshal":          {Template: "${json.marshal(mapval)}", Variables: map[string]interface{}{"mapval": map[string]string{"hello": "world"}}, Expected: `{"hello":"world"}`},
+		"json marshal array":    {Template: "${json.marshal(list)}", Variables: map[string]interface{}{"list": []string{"a", "b", "c"}}, Expected: `["a","b","c"]`},
 	}
 
 	for tn, tc := range tests {

--- a/pkg/varcontext/varcontext.go
+++ b/pkg/varcontext/varcontext.go
@@ -17,9 +17,10 @@ package varcontext
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cast"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 )
 
 type VarContext struct {
@@ -68,6 +69,17 @@ func (vc *VarContext) GetInt(key string) (res int) {
 func (vc *VarContext) GetBool(key string) (res bool) {
 	vc.validate(key, "boolean", func(val interface{}) (err error) {
 		res, err = cast.ToBoolE(val)
+		return err
+	})
+
+	return
+}
+
+// GetStringMapString gets map[string]string from the context,
+// storing an error if the key doesn't exist or the variable couldn't be cast.
+func (vc *VarContext) GetStringMapString(key string) (res map[string]string) {
+	vc.validate(key, "map[string]string", func(val interface{}) (err error) {
+		res, err = cast.ToStringMapStringE(val)
 		return err
 	})
 

--- a/pkg/varcontext/varcontext_test.go
+++ b/pkg/varcontext/varcontext_test.go
@@ -148,6 +148,46 @@ func TestVarContext_GetBool(t *testing.T) {
 	}
 }
 
+func TestVarContext_GetStringMapString(t *testing.T) {
+	// The following tests operate on the following example map
+	testContext := map[string]interface{}{
+		"single":  map[string]string{"foo": "bar"},
+		"aString": "value",
+		"json":    `{"foo":"bar"}`,
+	}
+
+	tests := map[string]struct {
+		Key      string
+		Expected map[string]string
+		Error    string
+	}{
+		"single map": {"single", map[string]string{"foo": "bar"}, ""},
+		"json map":   {"json", map[string]string{"foo": "bar"}, ""},
+		"string":     {"aString", map[string]string{}, `value for "aString" must be a map[string]string`},
+	}
+
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			vc := &VarContext{context: testContext}
+
+			result := vc.GetStringMapString(tc.Key)
+			if !reflect.DeepEqual(result, tc.Expected) {
+				t.Errorf("Expected to get: %v actual: %v", tc.Expected, result)
+			}
+
+			expectedErrors := tc.Error != ""
+			hasError := vc.Error() != nil
+			if hasError != expectedErrors {
+				t.Fatalf("Got error when not expecting or missing error that was expected: %v", vc.Error())
+			}
+
+			if tc.Error != "" && !strings.Contains(vc.Error().Error(), tc.Error) {
+				t.Errorf("Expected error to contain %q, but got: %v", tc.Error, vc.Error())
+			}
+		})
+	}
+}
+
 func TestVarContext_ToJson(t *testing.T) {
 	vc := &VarContext{context: map[string]interface{}{
 		"t": true,


### PR DESCRIPTION
Pulled the varcontext creation for provisions up from each individual broker into the `gcp_service_broker`.

This meant labels could no longer be computed in the providers so I had to add computed variables to the services that need labels so they explicitly rely on them now. It should be "easy" to add a couple extra HIL functions that merge this default labels map with an optionally provided user one now, once the time comes.