### PR TITLE
Rename Structs

### DIFF
--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -30,7 +30,7 @@ func init() {
 		"ml.operationOwner",
 	}
 
-	bs := &broker.BrokerService{
+	bs := &broker.ServiceDefinition{
 		Name: models.MlName,
 		DefaultServiceDefinition: `
 		{

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -25,7 +25,7 @@ func init() {
 	broker.Register(serviceDefinition())
 }
 
-func serviceDefinition() *broker.BrokerService {
+func serviceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"bigquery.dataViewer",
 		"bigquery.dataEditor",
@@ -34,7 +34,7 @@ func serviceDefinition() *broker.BrokerService {
 		"bigquery.jobUser",
 	}
 
-	return &broker.BrokerService{
+	return &broker.ServiceDefinition{
 		Name: models.BigqueryName,
 		DefaultServiceDefinition: `{
         "id": "f80c0a3e-bd4d-4809-a900-b4e33a6450f1",

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -25,14 +25,14 @@ func init() {
 	broker.Register(serviceDefinition())
 }
 
-func serviceDefinition() *broker.BrokerService {
+func serviceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"bigtable.user",
 		"bigtable.reader",
 		"bigtable.viewer",
 	}
 
-	return &broker.BrokerService{
+	return &broker.ServiceDefinition{
 		Name: models.BigtableName,
 		DefaultServiceDefinition: `{
       "id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe",

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Brokers", func() {
 			if k == serviceNameToId[models.CloudsqlMySQLName] {
 				async = true
 			}
-			gcpBroker.ServiceBrokerMap[k] = &modelsfakes.FakeServiceBrokerHelper{
+			gcpBroker.ServiceBrokerMap[k] = &modelsfakes.FakeServiceProvider{
 				ProvisionsAsyncStub:   func() bool { return async },
 				DeprovisionsAsyncStub: func() bool { return async },
 				ProvisionStub: func(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
@@ -248,7 +248,7 @@ var _ = Describe("Brokers", func() {
 				bqId := serviceNameToId[models.BigqueryName]
 				_, err := gcpBroker.Provision(context.Background(), instanceId, bqProvisionDetails, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[bqId].(*modelsfakes.FakeServiceBrokerHelper).ProvisionCallCount()).To(Equal(1))
+				Expect(gcpBroker.ServiceBrokerMap[bqId].(*modelsfakes.FakeServiceProvider).ProvisionCallCount()).To(Equal(1))
 			})
 
 		})
@@ -301,7 +301,7 @@ var _ = Describe("Brokers", func() {
 					ServiceID: bqId,
 				}, true)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[bqId].(*modelsfakes.FakeServiceBrokerHelper).DeprovisionCallCount()).To(Equal(1))
+				Expect(gcpBroker.ServiceBrokerMap[bqId].(*modelsfakes.FakeServiceProvider).DeprovisionCallCount()).To(Equal(1))
 			})
 		})
 
@@ -331,7 +331,7 @@ var _ = Describe("Brokers", func() {
 				Expect(err).NotTo(HaveOccurred())
 				_, err = gcpBroker.Bind(context.Background(), instanceId, bindingId, storageBindDetails)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.StorageName]].(*modelsfakes.FakeServiceBrokerHelper).BindCallCount()).To(Equal(1))
+				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.StorageName]].(*modelsfakes.FakeServiceProvider).BindCallCount()).To(Equal(1))
 			})
 
 			It("it should reject bad roles", func() {
@@ -359,7 +359,7 @@ var _ = Describe("Brokers", func() {
 				Expect(err).NotTo(HaveOccurred())
 				_, err := gcpBroker.Bind(context.Background(), instanceId, bindingId, storageBindDetails)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.StorageName]].(*modelsfakes.FakeServiceBrokerHelper).BuildInstanceCredentialsCallCount()).To(Equal(1))
+				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.StorageName]].(*modelsfakes.FakeServiceProvider).BuildInstanceCredentialsCallCount()).To(Equal(1))
 			})
 		})
 
@@ -374,7 +374,7 @@ var _ = Describe("Brokers", func() {
 				Expect(err).NotTo(HaveOccurred())
 				err = gcpBroker.Unbind(context.Background(), instanceId, bindingId, storageUnbindDetails)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.StorageName]].(*modelsfakes.FakeServiceBrokerHelper).UnbindCallCount()).To(Equal(1))
+				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.StorageName]].(*modelsfakes.FakeServiceProvider).UnbindCallCount()).To(Equal(1))
 			})
 		})
 
@@ -415,7 +415,7 @@ var _ = Describe("Brokers", func() {
 				Expect(err).NotTo(HaveOccurred())
 				_, err = gcpBroker.LastOperation(context.Background(), instanceId, "operationtoken")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.CloudsqlMySQLName]].(*modelsfakes.FakeServiceBrokerHelper).PollInstanceCallCount()).To(Equal(1))
+				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.CloudsqlMySQLName]].(*modelsfakes.FakeServiceProvider).PollInstanceCallCount()).To(Equal(1))
 			})
 		})
 
@@ -430,8 +430,8 @@ var _ = Describe("AccountManagers", func() {
 
 	var (
 		logger         lager.Logger
-		iamStyleBroker models.ServiceBrokerHelper
-		spannerBroker  models.ServiceBrokerHelper
+		iamStyleBroker models.ServiceProvider
+		spannerBroker  models.ServiceProvider
 		accountManager modelsfakes.FakeServiceAccountManager
 		err            error
 		testCtx        context.Context

--- a/brokerapi/brokers/cloudsql/broker_test.go
+++ b/brokerapi/brokers/cloudsql/broker_test.go
@@ -54,7 +54,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 	postgresPlan := "c4e68ab5-34ca-4d02-857d-3e6b3ab079a7"
 
 	cases := map[string]struct {
-		Service     *broker.BrokerService
+		Service     *broker.ServiceDefinition
 		PlanId      string
 		UserParams  string
 		Validate    func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation)

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -25,8 +25,8 @@ func init() {
 	broker.Register(mysqlServiceDefinition())
 }
 
-func mysqlServiceDefinition() *broker.BrokerService {
-	return &broker.BrokerService{
+func mysqlServiceDefinition() *broker.ServiceDefinition {
+	return &broker.ServiceDefinition{
 		Name: models.CloudsqlMySQLName,
 		DefaultServiceDefinition: `{
 		    "id": "4bc59b9a-8520-409f-85da-1c7552315863",

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -25,8 +25,8 @@ func init() {
 	broker.Register(postgresServiceDefinition())
 }
 
-func postgresServiceDefinition() *broker.BrokerService {
-	return &broker.BrokerService{
+func postgresServiceDefinition() *broker.ServiceDefinition {
+	return &broker.ServiceDefinition{
 		Name: models.CloudsqlPostgresName,
 		DefaultServiceDefinition: `{
         "id": "cbad6d78-a73c-432d-b8ff-b219a17a803a",

--- a/brokerapi/brokers/datastore/definition.go
+++ b/brokerapi/brokers/datastore/definition.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	bs := &broker.BrokerService{
+	bs := &broker.ServiceDefinition{
 		Name: "google-datastore",
 		DefaultServiceDefinition: `{
       "id": "76d4abb2-fee7-4c8f-aee1-bcea2837f02b",

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -47,7 +47,7 @@ import (
 // GCPServiceBroker is a brokerapi.ServiceBroker that can be used to generate an OSB compatible service broker.
 type GCPServiceBroker struct {
 	Catalog               map[string]models.Service
-	ServiceBrokerMap      map[string]models.ServiceBrokerHelper
+	ServiceBrokerMap      map[string]models.ServiceProvider
 	enableInputValidation bool
 
 	Logger lager.Logger
@@ -76,7 +76,7 @@ func New(cfg *config.BrokerConfig, logger lager.Logger) (*GCPServiceBroker, erro
 	}
 
 	// map service specific brokers to general broker
-	self.ServiceBrokerMap = map[string]models.ServiceBrokerHelper{
+	self.ServiceBrokerMap = map[string]models.ServiceProvider{
 		models.StorageName: &storage.StorageBroker{
 			BrokerBase: bb,
 		},
@@ -222,7 +222,7 @@ func (gcpBroker *GCPServiceBroker) Provision(ctx context.Context, instanceID str
 }
 
 func validateProvisionVariables(details brokerapi.ProvisionDetails) error {
-	brokerService, err := broker.GetServiceById(details.ServiceID)
+	ServiceDefinition, err := broker.GetServiceById(details.ServiceID)
 	if err != nil {
 		return err
 	}
@@ -234,11 +234,11 @@ func validateProvisionVariables(details brokerapi.ProvisionDetails) error {
 		}
 	}
 
-	return broker.ValidateVariables(params, brokerService.ProvisionInputVariables)
+	return broker.ValidateVariables(params, ServiceDefinition.ProvisionInputVariables)
 }
 
 func validateBindVariables(details brokerapi.BindDetails) error {
-	brokerService, err := broker.GetServiceById(details.ServiceID)
+	ServiceDefinition, err := broker.GetServiceById(details.ServiceID)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func validateBindVariables(details brokerapi.BindDetails) error {
 		}
 	}
 
-	return broker.ValidateVariables(params, brokerService.BindInputVariables)
+	return broker.ValidateVariables(params, ServiceDefinition.BindInputVariables)
 }
 
 // Deprovision destroys an existing instance of a service.
@@ -320,7 +320,7 @@ func (gcpBroker *GCPServiceBroker) Bind(ctx context.Context, instanceID, binding
 		"details":     details,
 	})
 
-	brokerService, err := broker.GetServiceById(details.ServiceID)
+	ServiceDefinition, err := broker.GetServiceById(details.ServiceID)
 	if err != nil {
 		return brokerapi.Binding{}, err
 	}
@@ -349,7 +349,7 @@ func (gcpBroker *GCPServiceBroker) Bind(ctx context.Context, instanceID, binding
 		}
 	}
 
-	vars, err := brokerService.BindVariables(*instanceRecord, bindingID, details)
+	vars, err := ServiceDefinition.BindVariables(*instanceRecord, bindingID, details)
 	if err != nil {
 		return brokerapi.Binding{}, err
 	}
@@ -469,7 +469,7 @@ func (gcpBroker *GCPServiceBroker) LastOperation(ctx context.Context, instanceID
 
 // updateStateOnOperationCompletion handles updating/cleaning-up resources that need to be changed
 // once lastOperation finishes successfully.
-func (gcpBroker *GCPServiceBroker) updateStateOnOperationCompletion(ctx context.Context, service models.ServiceBrokerHelper, lastOperationType, instanceID string) error {
+func (gcpBroker *GCPServiceBroker) updateStateOnOperationCompletion(ctx context.Context, service models.ServiceProvider, lastOperationType, instanceID string) error {
 	if lastOperationType == models.DeprovisionOperationType {
 		if err := db_service.DeleteServiceInstanceDetailsById(ctx, instanceID); err != nil {
 			return fmt.Errorf("Error deleting instance details from database: %s. WARNING: this instance will remain visible in cf. Contact your operator for cleanup", err)

--- a/brokerapi/brokers/models/modelsfakes/fake_service_provider.go
+++ b/brokerapi/brokers/models/modelsfakes/fake_service_provider.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pivotal-cf/brokerapi"
 )
 
-type FakeServiceBrokerHelper struct {
+type FakeServiceProvider struct {
 	ProvisionStub        func(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error)
 	provisionMutex       sync.RWMutex
 	provisionArgsForCall []struct {
@@ -132,7 +132,7 @@ type FakeServiceBrokerHelper struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServiceBrokerHelper) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
+func (fake *FakeServiceProvider) Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan models.ServicePlan) (models.ServiceInstanceDetails, error) {
 	fake.provisionMutex.Lock()
 	ret, specificReturn := fake.provisionReturnsOnCall[len(fake.provisionArgsForCall)]
 	fake.provisionArgsForCall = append(fake.provisionArgsForCall, struct {
@@ -152,19 +152,19 @@ func (fake *FakeServiceBrokerHelper) Provision(ctx context.Context, instanceId s
 	return fake.provisionReturns.result1, fake.provisionReturns.result2
 }
 
-func (fake *FakeServiceBrokerHelper) ProvisionCallCount() int {
+func (fake *FakeServiceProvider) ProvisionCallCount() int {
 	fake.provisionMutex.RLock()
 	defer fake.provisionMutex.RUnlock()
 	return len(fake.provisionArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) ProvisionArgsForCall(i int) (context.Context, string, brokerapi.ProvisionDetails, models.ServicePlan) {
+func (fake *FakeServiceProvider) ProvisionArgsForCall(i int) (context.Context, string, brokerapi.ProvisionDetails, models.ServicePlan) {
 	fake.provisionMutex.RLock()
 	defer fake.provisionMutex.RUnlock()
 	return fake.provisionArgsForCall[i].ctx, fake.provisionArgsForCall[i].instanceId, fake.provisionArgsForCall[i].details, fake.provisionArgsForCall[i].plan
 }
 
-func (fake *FakeServiceBrokerHelper) ProvisionReturns(result1 models.ServiceInstanceDetails, result2 error) {
+func (fake *FakeServiceProvider) ProvisionReturns(result1 models.ServiceInstanceDetails, result2 error) {
 	fake.ProvisionStub = nil
 	fake.provisionReturns = struct {
 		result1 models.ServiceInstanceDetails
@@ -172,7 +172,7 @@ func (fake *FakeServiceBrokerHelper) ProvisionReturns(result1 models.ServiceInst
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) ProvisionReturnsOnCall(i int, result1 models.ServiceInstanceDetails, result2 error) {
+func (fake *FakeServiceProvider) ProvisionReturnsOnCall(i int, result1 models.ServiceInstanceDetails, result2 error) {
 	fake.ProvisionStub = nil
 	if fake.provisionReturnsOnCall == nil {
 		fake.provisionReturnsOnCall = make(map[int]struct {
@@ -186,7 +186,7 @@ func (fake *FakeServiceBrokerHelper) ProvisionReturnsOnCall(i int, result1 model
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) Bind(ctx context.Context, vc *varcontext.VarContext) (map[string]interface{}, error) {
+func (fake *FakeServiceProvider) Bind(ctx context.Context, vc *varcontext.VarContext) (map[string]interface{}, error) {
 	fake.bindMutex.Lock()
 	ret, specificReturn := fake.bindReturnsOnCall[len(fake.bindArgsForCall)]
 	fake.bindArgsForCall = append(fake.bindArgsForCall, struct {
@@ -204,19 +204,19 @@ func (fake *FakeServiceBrokerHelper) Bind(ctx context.Context, vc *varcontext.Va
 	return fake.bindReturns.result1, fake.bindReturns.result2
 }
 
-func (fake *FakeServiceBrokerHelper) BindCallCount() int {
+func (fake *FakeServiceProvider) BindCallCount() int {
 	fake.bindMutex.RLock()
 	defer fake.bindMutex.RUnlock()
 	return len(fake.bindArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) BindArgsForCall(i int) (context.Context, *varcontext.VarContext) {
+func (fake *FakeServiceProvider) BindArgsForCall(i int) (context.Context, *varcontext.VarContext) {
 	fake.bindMutex.RLock()
 	defer fake.bindMutex.RUnlock()
 	return fake.bindArgsForCall[i].ctx, fake.bindArgsForCall[i].vc
 }
 
-func (fake *FakeServiceBrokerHelper) BindReturns(result1 map[string]interface{}, result2 error) {
+func (fake *FakeServiceProvider) BindReturns(result1 map[string]interface{}, result2 error) {
 	fake.BindStub = nil
 	fake.bindReturns = struct {
 		result1 map[string]interface{}
@@ -224,7 +224,7 @@ func (fake *FakeServiceBrokerHelper) BindReturns(result1 map[string]interface{},
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) BindReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
+func (fake *FakeServiceProvider) BindReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
 	fake.BindStub = nil
 	if fake.bindReturnsOnCall == nil {
 		fake.bindReturnsOnCall = make(map[int]struct {
@@ -238,7 +238,7 @@ func (fake *FakeServiceBrokerHelper) BindReturnsOnCall(i int, result1 map[string
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) BuildInstanceCredentials(ctx context.Context, bindRecord models.ServiceBindingCredentials, instance models.ServiceInstanceDetails) (map[string]interface{}, error) {
+func (fake *FakeServiceProvider) BuildInstanceCredentials(ctx context.Context, bindRecord models.ServiceBindingCredentials, instance models.ServiceInstanceDetails) (map[string]interface{}, error) {
 	fake.buildInstanceCredentialsMutex.Lock()
 	ret, specificReturn := fake.buildInstanceCredentialsReturnsOnCall[len(fake.buildInstanceCredentialsArgsForCall)]
 	fake.buildInstanceCredentialsArgsForCall = append(fake.buildInstanceCredentialsArgsForCall, struct {
@@ -257,19 +257,19 @@ func (fake *FakeServiceBrokerHelper) BuildInstanceCredentials(ctx context.Contex
 	return fake.buildInstanceCredentialsReturns.result1, fake.buildInstanceCredentialsReturns.result2
 }
 
-func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsCallCount() int {
+func (fake *FakeServiceProvider) BuildInstanceCredentialsCallCount() int {
 	fake.buildInstanceCredentialsMutex.RLock()
 	defer fake.buildInstanceCredentialsMutex.RUnlock()
 	return len(fake.buildInstanceCredentialsArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsArgsForCall(i int) (context.Context, models.ServiceBindingCredentials, models.ServiceInstanceDetails) {
+func (fake *FakeServiceProvider) BuildInstanceCredentialsArgsForCall(i int) (context.Context, models.ServiceBindingCredentials, models.ServiceInstanceDetails) {
 	fake.buildInstanceCredentialsMutex.RLock()
 	defer fake.buildInstanceCredentialsMutex.RUnlock()
 	return fake.buildInstanceCredentialsArgsForCall[i].ctx, fake.buildInstanceCredentialsArgsForCall[i].bindRecord, fake.buildInstanceCredentialsArgsForCall[i].instance
 }
 
-func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsReturns(result1 map[string]interface{}, result2 error) {
+func (fake *FakeServiceProvider) BuildInstanceCredentialsReturns(result1 map[string]interface{}, result2 error) {
 	fake.BuildInstanceCredentialsStub = nil
 	fake.buildInstanceCredentialsReturns = struct {
 		result1 map[string]interface{}
@@ -277,7 +277,7 @@ func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsReturns(result1 map
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
+func (fake *FakeServiceProvider) BuildInstanceCredentialsReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
 	fake.BuildInstanceCredentialsStub = nil
 	if fake.buildInstanceCredentialsReturnsOnCall == nil {
 		fake.buildInstanceCredentialsReturnsOnCall = make(map[int]struct {
@@ -291,7 +291,7 @@ func (fake *FakeServiceBrokerHelper) BuildInstanceCredentialsReturnsOnCall(i int
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) Unbind(ctx context.Context, instance models.ServiceInstanceDetails, details models.ServiceBindingCredentials) error {
+func (fake *FakeServiceProvider) Unbind(ctx context.Context, instance models.ServiceInstanceDetails, details models.ServiceBindingCredentials) error {
 	fake.unbindMutex.Lock()
 	ret, specificReturn := fake.unbindReturnsOnCall[len(fake.unbindArgsForCall)]
 	fake.unbindArgsForCall = append(fake.unbindArgsForCall, struct {
@@ -310,26 +310,26 @@ func (fake *FakeServiceBrokerHelper) Unbind(ctx context.Context, instance models
 	return fake.unbindReturns.result1
 }
 
-func (fake *FakeServiceBrokerHelper) UnbindCallCount() int {
+func (fake *FakeServiceProvider) UnbindCallCount() int {
 	fake.unbindMutex.RLock()
 	defer fake.unbindMutex.RUnlock()
 	return len(fake.unbindArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) UnbindArgsForCall(i int) (context.Context, models.ServiceInstanceDetails, models.ServiceBindingCredentials) {
+func (fake *FakeServiceProvider) UnbindArgsForCall(i int) (context.Context, models.ServiceInstanceDetails, models.ServiceBindingCredentials) {
 	fake.unbindMutex.RLock()
 	defer fake.unbindMutex.RUnlock()
 	return fake.unbindArgsForCall[i].ctx, fake.unbindArgsForCall[i].instance, fake.unbindArgsForCall[i].details
 }
 
-func (fake *FakeServiceBrokerHelper) UnbindReturns(result1 error) {
+func (fake *FakeServiceProvider) UnbindReturns(result1 error) {
 	fake.UnbindStub = nil
 	fake.unbindReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeServiceBrokerHelper) UnbindReturnsOnCall(i int, result1 error) {
+func (fake *FakeServiceProvider) UnbindReturnsOnCall(i int, result1 error) {
 	fake.UnbindStub = nil
 	if fake.unbindReturnsOnCall == nil {
 		fake.unbindReturnsOnCall = make(map[int]struct {
@@ -341,7 +341,7 @@ func (fake *FakeServiceBrokerHelper) UnbindReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeServiceBrokerHelper) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (operationId *string, err error) {
+func (fake *FakeServiceProvider) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (operationId *string, err error) {
 	fake.deprovisionMutex.Lock()
 	ret, specificReturn := fake.deprovisionReturnsOnCall[len(fake.deprovisionArgsForCall)]
 	fake.deprovisionArgsForCall = append(fake.deprovisionArgsForCall, struct {
@@ -360,19 +360,19 @@ func (fake *FakeServiceBrokerHelper) Deprovision(ctx context.Context, instance m
 	return fake.deprovisionReturns.result1, fake.deprovisionReturns.result2
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionCallCount() int {
+func (fake *FakeServiceProvider) DeprovisionCallCount() int {
 	fake.deprovisionMutex.RLock()
 	defer fake.deprovisionMutex.RUnlock()
 	return len(fake.deprovisionArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionArgsForCall(i int) (context.Context, models.ServiceInstanceDetails, brokerapi.DeprovisionDetails) {
+func (fake *FakeServiceProvider) DeprovisionArgsForCall(i int) (context.Context, models.ServiceInstanceDetails, brokerapi.DeprovisionDetails) {
 	fake.deprovisionMutex.RLock()
 	defer fake.deprovisionMutex.RUnlock()
 	return fake.deprovisionArgsForCall[i].ctx, fake.deprovisionArgsForCall[i].instance, fake.deprovisionArgsForCall[i].details
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionReturns(result1 *string, result2 error) {
+func (fake *FakeServiceProvider) DeprovisionReturns(result1 *string, result2 error) {
 	fake.DeprovisionStub = nil
 	fake.deprovisionReturns = struct {
 		result1 *string
@@ -380,7 +380,7 @@ func (fake *FakeServiceBrokerHelper) DeprovisionReturns(result1 *string, result2
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionReturnsOnCall(i int, result1 *string, result2 error) {
+func (fake *FakeServiceProvider) DeprovisionReturnsOnCall(i int, result1 *string, result2 error) {
 	fake.DeprovisionStub = nil
 	if fake.deprovisionReturnsOnCall == nil {
 		fake.deprovisionReturnsOnCall = make(map[int]struct {
@@ -394,7 +394,7 @@ func (fake *FakeServiceBrokerHelper) DeprovisionReturnsOnCall(i int, result1 *st
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) PollInstance(ctx context.Context, instance models.ServiceInstanceDetails) (bool, error) {
+func (fake *FakeServiceProvider) PollInstance(ctx context.Context, instance models.ServiceInstanceDetails) (bool, error) {
 	fake.pollInstanceMutex.Lock()
 	ret, specificReturn := fake.pollInstanceReturnsOnCall[len(fake.pollInstanceArgsForCall)]
 	fake.pollInstanceArgsForCall = append(fake.pollInstanceArgsForCall, struct {
@@ -412,19 +412,19 @@ func (fake *FakeServiceBrokerHelper) PollInstance(ctx context.Context, instance 
 	return fake.pollInstanceReturns.result1, fake.pollInstanceReturns.result2
 }
 
-func (fake *FakeServiceBrokerHelper) PollInstanceCallCount() int {
+func (fake *FakeServiceProvider) PollInstanceCallCount() int {
 	fake.pollInstanceMutex.RLock()
 	defer fake.pollInstanceMutex.RUnlock()
 	return len(fake.pollInstanceArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) PollInstanceArgsForCall(i int) (context.Context, models.ServiceInstanceDetails) {
+func (fake *FakeServiceProvider) PollInstanceArgsForCall(i int) (context.Context, models.ServiceInstanceDetails) {
 	fake.pollInstanceMutex.RLock()
 	defer fake.pollInstanceMutex.RUnlock()
 	return fake.pollInstanceArgsForCall[i].ctx, fake.pollInstanceArgsForCall[i].instance
 }
 
-func (fake *FakeServiceBrokerHelper) PollInstanceReturns(result1 bool, result2 error) {
+func (fake *FakeServiceProvider) PollInstanceReturns(result1 bool, result2 error) {
 	fake.PollInstanceStub = nil
 	fake.pollInstanceReturns = struct {
 		result1 bool
@@ -432,7 +432,7 @@ func (fake *FakeServiceBrokerHelper) PollInstanceReturns(result1 bool, result2 e
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) PollInstanceReturnsOnCall(i int, result1 bool, result2 error) {
+func (fake *FakeServiceProvider) PollInstanceReturnsOnCall(i int, result1 bool, result2 error) {
 	fake.PollInstanceStub = nil
 	if fake.pollInstanceReturnsOnCall == nil {
 		fake.pollInstanceReturnsOnCall = make(map[int]struct {
@@ -446,7 +446,7 @@ func (fake *FakeServiceBrokerHelper) PollInstanceReturnsOnCall(i int, result1 bo
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBrokerHelper) ProvisionsAsync() bool {
+func (fake *FakeServiceProvider) ProvisionsAsync() bool {
 	fake.provisionsAsyncMutex.Lock()
 	ret, specificReturn := fake.provisionsAsyncReturnsOnCall[len(fake.provisionsAsyncArgsForCall)]
 	fake.provisionsAsyncArgsForCall = append(fake.provisionsAsyncArgsForCall, struct{}{})
@@ -461,20 +461,20 @@ func (fake *FakeServiceBrokerHelper) ProvisionsAsync() bool {
 	return fake.provisionsAsyncReturns.result1
 }
 
-func (fake *FakeServiceBrokerHelper) ProvisionsAsyncCallCount() int {
+func (fake *FakeServiceProvider) ProvisionsAsyncCallCount() int {
 	fake.provisionsAsyncMutex.RLock()
 	defer fake.provisionsAsyncMutex.RUnlock()
 	return len(fake.provisionsAsyncArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) ProvisionsAsyncReturns(result1 bool) {
+func (fake *FakeServiceProvider) ProvisionsAsyncReturns(result1 bool) {
 	fake.ProvisionsAsyncStub = nil
 	fake.provisionsAsyncReturns = struct {
 		result1 bool
 	}{result1}
 }
 
-func (fake *FakeServiceBrokerHelper) ProvisionsAsyncReturnsOnCall(i int, result1 bool) {
+func (fake *FakeServiceProvider) ProvisionsAsyncReturnsOnCall(i int, result1 bool) {
 	fake.ProvisionsAsyncStub = nil
 	if fake.provisionsAsyncReturnsOnCall == nil {
 		fake.provisionsAsyncReturnsOnCall = make(map[int]struct {
@@ -486,7 +486,7 @@ func (fake *FakeServiceBrokerHelper) ProvisionsAsyncReturnsOnCall(i int, result1
 	}{result1}
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionsAsync() bool {
+func (fake *FakeServiceProvider) DeprovisionsAsync() bool {
 	fake.deprovisionsAsyncMutex.Lock()
 	ret, specificReturn := fake.deprovisionsAsyncReturnsOnCall[len(fake.deprovisionsAsyncArgsForCall)]
 	fake.deprovisionsAsyncArgsForCall = append(fake.deprovisionsAsyncArgsForCall, struct{}{})
@@ -501,20 +501,20 @@ func (fake *FakeServiceBrokerHelper) DeprovisionsAsync() bool {
 	return fake.deprovisionsAsyncReturns.result1
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionsAsyncCallCount() int {
+func (fake *FakeServiceProvider) DeprovisionsAsyncCallCount() int {
 	fake.deprovisionsAsyncMutex.RLock()
 	defer fake.deprovisionsAsyncMutex.RUnlock()
 	return len(fake.deprovisionsAsyncArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionsAsyncReturns(result1 bool) {
+func (fake *FakeServiceProvider) DeprovisionsAsyncReturns(result1 bool) {
 	fake.DeprovisionsAsyncStub = nil
 	fake.deprovisionsAsyncReturns = struct {
 		result1 bool
 	}{result1}
 }
 
-func (fake *FakeServiceBrokerHelper) DeprovisionsAsyncReturnsOnCall(i int, result1 bool) {
+func (fake *FakeServiceProvider) DeprovisionsAsyncReturnsOnCall(i int, result1 bool) {
 	fake.DeprovisionsAsyncStub = nil
 	if fake.deprovisionsAsyncReturnsOnCall == nil {
 		fake.deprovisionsAsyncReturnsOnCall = make(map[int]struct {
@@ -526,7 +526,7 @@ func (fake *FakeServiceBrokerHelper) DeprovisionsAsyncReturnsOnCall(i int, resul
 	}{result1}
 }
 
-func (fake *FakeServiceBrokerHelper) UpdateInstanceDetails(ctx context.Context, instance *models.ServiceInstanceDetails) error {
+func (fake *FakeServiceProvider) UpdateInstanceDetails(ctx context.Context, instance *models.ServiceInstanceDetails) error {
 	fake.updateInstanceDetailsMutex.Lock()
 	ret, specificReturn := fake.updateInstanceDetailsReturnsOnCall[len(fake.updateInstanceDetailsArgsForCall)]
 	fake.updateInstanceDetailsArgsForCall = append(fake.updateInstanceDetailsArgsForCall, struct {
@@ -544,26 +544,26 @@ func (fake *FakeServiceBrokerHelper) UpdateInstanceDetails(ctx context.Context, 
 	return fake.updateInstanceDetailsReturns.result1
 }
 
-func (fake *FakeServiceBrokerHelper) UpdateInstanceDetailsCallCount() int {
+func (fake *FakeServiceProvider) UpdateInstanceDetailsCallCount() int {
 	fake.updateInstanceDetailsMutex.RLock()
 	defer fake.updateInstanceDetailsMutex.RUnlock()
 	return len(fake.updateInstanceDetailsArgsForCall)
 }
 
-func (fake *FakeServiceBrokerHelper) UpdateInstanceDetailsArgsForCall(i int) (context.Context, *models.ServiceInstanceDetails) {
+func (fake *FakeServiceProvider) UpdateInstanceDetailsArgsForCall(i int) (context.Context, *models.ServiceInstanceDetails) {
 	fake.updateInstanceDetailsMutex.RLock()
 	defer fake.updateInstanceDetailsMutex.RUnlock()
 	return fake.updateInstanceDetailsArgsForCall[i].ctx, fake.updateInstanceDetailsArgsForCall[i].instance
 }
 
-func (fake *FakeServiceBrokerHelper) UpdateInstanceDetailsReturns(result1 error) {
+func (fake *FakeServiceProvider) UpdateInstanceDetailsReturns(result1 error) {
 	fake.UpdateInstanceDetailsStub = nil
 	fake.updateInstanceDetailsReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeServiceBrokerHelper) UpdateInstanceDetailsReturnsOnCall(i int, result1 error) {
+func (fake *FakeServiceProvider) UpdateInstanceDetailsReturnsOnCall(i int, result1 error) {
 	fake.UpdateInstanceDetailsStub = nil
 	if fake.updateInstanceDetailsReturnsOnCall == nil {
 		fake.updateInstanceDetailsReturnsOnCall = make(map[int]struct {
@@ -575,7 +575,7 @@ func (fake *FakeServiceBrokerHelper) UpdateInstanceDetailsReturnsOnCall(i int, r
 	}{result1}
 }
 
-func (fake *FakeServiceBrokerHelper) Invocations() map[string][][]interface{} {
+func (fake *FakeServiceProvider) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.provisionMutex.RLock()
@@ -603,7 +603,7 @@ func (fake *FakeServiceBrokerHelper) Invocations() map[string][][]interface{} {
 	return copiedInvocations
 }
 
-func (fake *FakeServiceBrokerHelper) recordInvocation(key string, args []interface{}) {
+func (fake *FakeServiceProvider) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
@@ -615,4 +615,4 @@ func (fake *FakeServiceBrokerHelper) recordInvocation(key string, args []interfa
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ models.ServiceBrokerHelper = new(FakeServiceBrokerHelper)
+var _ models.ServiceProvider = new(FakeServiceProvider)

--- a/brokerapi/brokers/models/service_broker.go
+++ b/brokerapi/brokers/models/service_broker.go
@@ -21,14 +21,14 @@ import (
 	"github.com/pivotal-cf/brokerapi"
 )
 
-//go:generate counterfeiter . ServiceBrokerHelper
+//go:generate counterfeiter . ServiceProvider
 //go:generate counterfeiter . ServiceAccountManager
 
-// ServiceBrokerHelper performs the actual provisoning/deprovisioning part of a service broker request.
-// The broker will handle storing state and validating inputs while a ServiceBrokerHelper changes GCP to match the desired state.
-// ServiceBrokerHelpers are expected to interact with the state of the system entirely through their inputs and outputs.
+// ServiceProvider performs the actual provisoning/deprovisioning part of a service broker request.
+// The broker will handle storing state and validating inputs while a ServiceProvider changes GCP to match the desired state.
+// ServiceProviders are expected to interact with the state of the system entirely through their inputs and outputs.
 // Specifically, they MUST NOT modify any general state of the broker in the database.
-type ServiceBrokerHelper interface {
+type ServiceProvider interface {
 	Provision(ctx context.Context, instanceId string, details brokerapi.ProvisionDetails, plan ServicePlan) (ServiceInstanceDetails, error)
 	// Bind provisions the necessary resources for a user to be able to connect to the provisioned service.
 	// This may include creating service accounts, granting permissions, and adding users to services e.g. a SQL database user.

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -25,7 +25,7 @@ func init() {
 	broker.Register(serviceDefinition())
 }
 
-func serviceDefinition() *broker.BrokerService {
+func serviceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"pubsub.publisher",
 		"pubsub.subscriber",
@@ -33,7 +33,7 @@ func serviceDefinition() *broker.BrokerService {
 		"pubsub.editor",
 	}
 
-	return &broker.BrokerService{
+	return &broker.ServiceDefinition{
 		Name: models.PubsubName,
 		DefaultServiceDefinition: `{
       "id": "628629e3-79f5-4255-b981-d14c6c7856be",

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -25,7 +25,7 @@ func init() {
 	broker.Register(serviceDefinition())
 }
 
-func serviceDefinition() *broker.BrokerService {
+func serviceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"spanner.databaseAdmin",
 		"spanner.databaseReader",
@@ -33,7 +33,7 @@ func serviceDefinition() *broker.BrokerService {
 		"spanner.viewer",
 	}
 
-	return &broker.BrokerService{
+	return &broker.ServiceDefinition{
 		Name: models.SpannerName,
 		DefaultServiceDefinition: `
 		{

--- a/brokerapi/brokers/stackdriver_debugger/definition.go
+++ b/brokerapi/brokers/stackdriver_debugger/definition.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	bs := &broker.BrokerService{
+	bs := &broker.ServiceDefinition{
 		Name: "google-stackdriver-debugger",
 		DefaultServiceDefinition: `{
 		      "id": "83837945-1547-41e0-b661-ea31d76eed11",

--- a/brokerapi/brokers/stackdriver_profiler/definition.go
+++ b/brokerapi/brokers/stackdriver_profiler/definition.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	bs := &broker.BrokerService{
+	bs := &broker.ServiceDefinition{
 		Name: "google-stackdriver-profiler",
 		DefaultServiceDefinition: `{
 		      "id": "00b9ca4a-7cd6-406a-a5b7-2f43f41ade75",

--- a/brokerapi/brokers/stackdriver_trace/definition.go
+++ b/brokerapi/brokers/stackdriver_trace/definition.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	bs := &broker.BrokerService{
+	bs := &broker.ServiceDefinition{
 		Name: "google-stackdriver-trace",
 		DefaultServiceDefinition: `{
       "id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -25,14 +25,14 @@ func init() {
 	broker.Register(serviceDefinition())
 }
 
-func serviceDefinition() *broker.BrokerService {
+func serviceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"storage.objectCreator",
 		"storage.objectViewer",
 		"storage.objectAdmin",
 	}
 
-	return &broker.BrokerService{
+	return &broker.ServiceDefinition{
 		Name: models.StorageName,
 		DefaultServiceDefinition: `{
 	        "id": "b9e4332e-b42b-4680-bda5-ea1506797474",

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-func ExampleBrokerService_EnabledProperty() {
-	service := BrokerService{
+func ExampleServiceDefinition_EnabledProperty() {
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 	}
 
@@ -36,8 +36,8 @@ func ExampleBrokerService_EnabledProperty() {
 	// Output: service.left-handed-smoke-sifter.enabled
 }
 
-func ExampleBrokerService_DefinitionProperty() {
-	service := BrokerService{
+func ExampleServiceDefinition_DefinitionProperty() {
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 	}
 
@@ -46,8 +46,8 @@ func ExampleBrokerService_DefinitionProperty() {
 	// Output: service.left-handed-smoke-sifter.definition
 }
 
-func ExampleBrokerService_UserDefinedPlansProperty() {
-	service := BrokerService{
+func ExampleServiceDefinition_UserDefinedPlansProperty() {
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 	}
 
@@ -56,8 +56,8 @@ func ExampleBrokerService_UserDefinedPlansProperty() {
 	// Output: service.left-handed-smoke-sifter.plans
 }
 
-func ExampleBrokerService_IsEnabled() {
-	service := BrokerService{
+func ExampleServiceDefinition_IsEnabled() {
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 	}
 
@@ -71,8 +71,8 @@ func ExampleBrokerService_IsEnabled() {
 	// false
 }
 
-func ExampleBrokerService_IsRoleWhitelistEnabled() {
-	service := BrokerService{
+func ExampleServiceDefinition_IsRoleWhitelistEnabled() {
+	service := ServiceDefinition{
 		Name:                 "left-handed-smoke-sifter",
 		DefaultRoleWhitelist: []string{"a", "b", "c"},
 	}
@@ -85,8 +85,8 @@ func ExampleBrokerService_IsRoleWhitelistEnabled() {
 	// false
 }
 
-func ExampleBrokerService_TileUserDefinedPlansVariable() {
-	service := BrokerService{
+func ExampleServiceDefinition_TileUserDefinedPlansVariable() {
+	service := ServiceDefinition{
 		Name: "google-spanner",
 	}
 
@@ -95,8 +95,8 @@ func ExampleBrokerService_TileUserDefinedPlansVariable() {
 	// Output: SPANNER_CUSTOM_PLANS
 }
 
-func ExampleBrokerService_ServiceDefinition() {
-	service := BrokerService{
+func ExampleServiceDefinition_ServiceDefinition() {
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl"}`,
 	}
@@ -123,8 +123,8 @@ func ExampleBrokerService_ServiceDefinition() {
 	// Error parsing service definition for "left-handed-smoke-sifter": invalid character 'i' in literal null (expecting 'u')
 }
 
-func ExampleBrokerService_GetPlanById() {
-	service := BrokerService{
+func ExampleServiceDefinition_GetPlanById() {
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl", "plans": [{"id": "builtin-plan", "name": "Builtin!"}]}`,
 	}
@@ -146,7 +146,7 @@ func ExampleBrokerService_GetPlanById() {
 	// missing-plan: Plan ID "missing-plan" could not be found
 }
 
-func TestBrokerService_UserDefinedPlans(t *testing.T) {
+func TestServiceDefinition_UserDefinedPlans(t *testing.T) {
 	cases := map[string]struct {
 		Value       interface{}
 		PlanIds     map[string]bool
@@ -189,7 +189,7 @@ func TestBrokerService_UserDefinedPlans(t *testing.T) {
 		},
 	}
 
-	service := BrokerService{
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl", "name":"lhss"}`,
 		PlanVariables: []BrokerVariable{
@@ -228,7 +228,7 @@ func TestBrokerService_UserDefinedPlans(t *testing.T) {
 	}
 }
 
-func TestBrokerService_CatalogEntry(t *testing.T) {
+func TestServiceDefinition_CatalogEntry(t *testing.T) {
 	cases := map[string]struct {
 		UserDefinition interface{}
 		UserPlans      interface{}
@@ -273,7 +273,7 @@ func TestBrokerService_CatalogEntry(t *testing.T) {
 		},
 	}
 
-	service := BrokerService{
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl"}`,
 	}
@@ -303,8 +303,8 @@ func TestBrokerService_CatalogEntry(t *testing.T) {
 	viper.Set(service.UserDefinedPlansProperty(), nil)
 }
 
-func TestBrokerService_ProvisionVariables(t *testing.T) {
-	service := BrokerService{
+func TestServiceDefinition_ProvisionVariables(t *testing.T) {
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl", "plans": [{"id": "builtin-plan", "name": "Builtin!"}]}`,
 		ProvisionInputVariables: []BrokerVariable{
@@ -435,8 +435,8 @@ func TestBrokerService_ProvisionVariables(t *testing.T) {
 	}
 }
 
-func TestBrokerService_BindVariables(t *testing.T) {
-	service := BrokerService{
+func TestServiceDefinition_BindVariables(t *testing.T) {
+	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
 		DefaultServiceDefinition: `{"id":"abcd-efgh-ijkl", "plans": [{"id": "builtin-plan", "name": "Builtin!"}]}`,
 		BindInputVariables: []BrokerVariable{

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -59,7 +59,7 @@ func RunExamplesForService(client *Client, serviceName string) error {
 
 // RunExample runs a single example against the given service on the broker
 // pointed to by client.
-func RunExample(client *Client, example broker.ServiceExample, service *broker.BrokerService) error {
+func RunExample(client *Client, example broker.ServiceExample, service *broker.ServiceDefinition) error {
 	executor, err := newExampleExecutor(client, example, service)
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func pollUntilFinished(client *Client, instanceId string) error {
 	})
 }
 
-func newExampleExecutor(client *Client, example broker.ServiceExample, service *broker.BrokerService) (*exampleExecutor, error) {
+func newExampleExecutor(client *Client, example broker.ServiceExample, service *broker.ServiceDefinition) (*exampleExecutor, error) {
 	provisionParams, err := json.Marshal(example.ProvisionParams)
 	if err != nil {
 		return nil, err

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -272,7 +272,7 @@ func generateServicePlanForms() []Form {
 
 // generateServicePlanForm creates a form for adding additional service plans
 // to the broker for an existing service.
-func generateServicePlanForm(svc *broker.BrokerService) (Form, error) {
+func generateServicePlanForm(svc *broker.ServiceDefinition) (Form, error) {
 	entry, err := svc.CatalogEntry()
 	if err != nil {
 		return Form{}, err

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -41,7 +41,7 @@ func CatalogDocumentation() string {
 }
 
 // generateServiceDocumentation creates documentation for a single catalog entry
-func generateServiceDocumentation(svc *broker.BrokerService) string {
+func generateServiceDocumentation(svc *broker.ServiceDefinition) string {
 	catalog, err := svc.CatalogEntry()
 	if err != nil {
 		log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)


### PR DESCRIPTION
Rename some of our structs for better clarity into what they do so we don't have GCPServiceBroker, ServiceBrokerHelper, and BrokerService.

* BrokerService -> ServiceDefinition
* ServiceBrokerHelper -> ServiceProvider

#250 

