### PR TITLE
Service constructors

### DIFF
--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -15,9 +15,12 @@
 package api_service
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -74,6 +77,10 @@ func init() {
 					"role": "ml.developer",
 				},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &ApiServiceBroker{BrokerBase: bb}
 		},
 	}
 

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -15,11 +15,14 @@
 package bigquery
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -114,6 +117,10 @@ func serviceDefinition() *broker.ServiceDefinition {
 					"role": "bigquery.user",
 				},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &BigQueryBroker{BrokerBase: bb}
 		},
 	}
 }

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -15,10 +15,13 @@
 package bigtable
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -165,6 +168,10 @@ func serviceDefinition() *broker.ServiceDefinition {
 					"role": "bigtable.user",
 				},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &BigTableBroker{BrokerBase: bb}
 		},
 	}
 }

--- a/brokerapi/brokers/broker_base/broker_base.go
+++ b/brokerapi/brokers/broker_base/broker_base.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 
@@ -31,6 +32,23 @@ import (
 type ServiceAccountManager interface {
 	CreateCredentials(ctx context.Context, vc *varcontext.VarContext) (map[string]interface{}, error)
 	DeleteCredentials(ctx context.Context, creds models.ServiceBindingCredentials) error
+}
+
+// NewBrokerBase creates a new broker base and account manager it uses from the
+// given settings.
+func NewBrokerBase(projectId string, auth *jwt.Config, logger lager.Logger) BrokerBase {
+	saManager := &account_managers.ServiceAccountManager{
+		HttpConfig: auth,
+		ProjectId:  projectId,
+		Logger:     logger,
+	}
+
+	return BrokerBase{
+		AccountManager: saManager,
+		HttpConfig:     auth,
+		ProjectId:      projectId,
+		Logger:         logger,
+	}
 }
 
 // BrokerBase is the reference bind and unbind implementation for brokers that

--- a/brokerapi/brokers/broker_config.go
+++ b/brokerapi/brokers/broker_config.go
@@ -30,7 +30,6 @@ func init() {
 }
 
 type BrokerConfig struct {
-	Catalog               map[string]broker.Service
 	HttpConfig            *jwt.Config
 	ProjectId             string
 	EnableInputValidation bool
@@ -48,31 +47,10 @@ func NewBrokerConfigFromEnv() (*BrokerConfig, error) {
 		return nil, err
 	}
 
-	catalog, err := initCatalogFromEnv()
-	if err != nil {
-		return nil, err
-	}
-
 	return &BrokerConfig{
-		Catalog:               catalog,
 		ProjectId:             projectId,
 		HttpConfig:            conf,
 		EnableInputValidation: viper.GetBool(inputValidationProp),
 		Registry:              broker.DefaultRegistry,
 	}, nil
-}
-
-// pulls SERVICES, PLANS, and environment variables to construct catalog
-func initCatalogFromEnv() (map[string]broker.Service, error) {
-	serviceMap := make(map[string]broker.Service)
-
-	for _, service := range broker.GetEnabledServices() {
-		entry, err := service.CatalogEntry()
-		if err != nil {
-			return serviceMap, err
-		}
-		serviceMap[entry.ID] = *entry
-	}
-
-	return serviceMap, nil
 }

--- a/brokerapi/brokers/broker_config.go
+++ b/brokerapi/brokers/broker_config.go
@@ -34,6 +34,7 @@ type BrokerConfig struct {
 	HttpConfig            *jwt.Config
 	ProjectId             string
 	EnableInputValidation bool
+	Registry              broker.BrokerRegistry
 }
 
 func NewBrokerConfigFromEnv() (*BrokerConfig, error) {
@@ -57,6 +58,7 @@ func NewBrokerConfigFromEnv() (*BrokerConfig, error) {
 		ProjectId:             projectId,
 		HttpConfig:            conf,
 		EnableInputValidation: viper.GetBool(inputValidationProp),
+		Registry:              broker.DefaultRegistry,
 	}, nil
 }
 

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -48,11 +48,13 @@ var _ = Describe("Brokers", func() {
 		serviceNameToId          map[string]string = make(map[string]string)
 		bqProvisionDetails       brokerapi.ProvisionDetails
 		cloudSqlProvisionDetails brokerapi.ProvisionDetails
+		storageProvisionDetails  brokerapi.ProvisionDetails
 		storageBindDetails       brokerapi.BindDetails
 		storageBadBindDetails    brokerapi.BindDetails
 		storageUnbindDetails     brokerapi.UnbindDetails
 		instanceId               string
 		bindingId                string
+		serviceBrokerMap         map[string]*brokerfakes.FakeServiceProvider = make(map[string]*brokerfakes.FakeServiceProvider)
 	)
 
 	BeforeEach(func() {
@@ -79,10 +81,14 @@ var _ = Describe("Brokers", func() {
 		os.Setenv("SECURITY_USER_NAME", "username")
 		os.Setenv("SECURITY_USER_PASSWORD", "password")
 
-		brokerConfig, err = NewBrokerConfigFromEnv()
-		if err != nil {
-			logger.Error("error", err)
+		registry := broker.BrokerRegistry{}
+		for name, defn := range broker.DefaultRegistry {
+			copy := *defn
+			registry[name] = &copy
 		}
+		brokerConfig, err = NewBrokerConfigFromEnv()
+		Expect(err).To(BeNil())
+		brokerConfig.Registry = registry
 
 		instanceId = "newid"
 		bindingId = "newbinding"
@@ -95,26 +101,28 @@ var _ = Describe("Brokers", func() {
 		var someBigQueryPlanId string
 		var someCloudSQLPlanId string
 		var someStoragePlanId string
-		for _, service := range gcpBroker.Catalog {
-			serviceNameToId[service.Name] = service.ID
+		for _, service := range registry {
+			catalog, err := service.CatalogEntry()
+			Expect(err).To(BeNil())
+			serviceNameToId[service.Name] = catalog.ID
 			if service.Name == models.BigqueryName {
-				someBigQueryPlanId = service.Plans[0].ID
+				someBigQueryPlanId = catalog.Plans[0].ID
 			}
 			if service.Name == models.CloudsqlMySQLName {
 
-				someCloudSQLPlanId = service.Plans[0].ID
+				someCloudSQLPlanId = catalog.Plans[0].ID
 			}
 			if service.Name == models.StorageName {
-				someStoragePlanId = service.Plans[0].ID
+				someStoragePlanId = catalog.Plans[0].ID
 			}
 		}
 
-		for k := range gcpBroker.ServiceBrokerMap {
+		for _, service := range registry {
 			async := false
-			if k == serviceNameToId[models.CloudsqlMySQLName] {
+			if service.Name == models.CloudsqlMySQLName {
 				async = true
 			}
-			gcpBroker.ServiceBrokerMap[k] = &brokerfakes.FakeServiceProvider{
+			fakeProvider := &brokerfakes.FakeServiceProvider{
 				ProvisionsAsyncStub:   func() bool { return async },
 				DeprovisionsAsyncStub: func() bool { return async },
 				ProvisionStub: func(ctx context.Context, vc *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
@@ -123,6 +131,11 @@ var _ = Describe("Brokers", func() {
 				BindStub: func(ctx context.Context, vc *varcontext.VarContext) (map[string]interface{}, error) {
 					return map[string]interface{}{"foo": "bar"}, nil
 				},
+			}
+
+			serviceBrokerMap[serviceNameToId[service.Name]] = fakeProvider
+			service.ProviderBuilder = func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+				return fakeProvider
 			}
 		}
 
@@ -134,6 +147,11 @@ var _ = Describe("Brokers", func() {
 		cloudSqlProvisionDetails = brokerapi.ProvisionDetails{
 			ServiceID: serviceNameToId[models.CloudsqlMySQLName],
 			PlanID:    someCloudSQLPlanId,
+		}
+
+		storageProvisionDetails = brokerapi.ProvisionDetails{
+			ServiceID: serviceNameToId[models.StorageName],
+			PlanID:    someStoragePlanId,
 		}
 
 		storageBindDetails = brokerapi.BindDetails{
@@ -156,9 +174,6 @@ var _ = Describe("Brokers", func() {
 	})
 
 	Describe("Broker init", func() {
-		It("should have enabled services in sevices map", func() {
-			Expect(len(gcpBroker.ServiceBrokerMap)).To(Equal(len(broker.GetEnabledServices())))
-		})
 
 		It("should have a default client", func() {
 			Expect(brokerConfig.HttpConfig).NotTo(Equal(&jwt.Config{}))
@@ -170,74 +185,11 @@ var _ = Describe("Brokers", func() {
 	})
 
 	Describe("getting broker catalog", func() {
-		It("should have 11 services available", func() {
+		It("should have the right number of enabled services available", func() {
 			serviceList, err := gcpBroker.Services(context.Background())
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(len(serviceList)).To(Equal(len(broker.GetEnabledServices())))
-		})
-
-		It("should have 4 storage plans available", func() {
-			serviceList, err := gcpBroker.Services(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			for _, s := range serviceList {
-				if s.ID == serviceNameToId[models.StorageName] {
-					Expect(len(s.Plans)).To(Equal(4))
-				}
-			}
-
-		})
-
-		It("should have 15 cloudsql plans available", func() {
-			serviceList, err := gcpBroker.Services(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			for _, s := range serviceList {
-				if s.ID == serviceNameToId[models.CloudsqlMySQLName] {
-					Expect(len(s.Plans)).To(Equal(15))
-				}
-			}
-
-		})
-
-		It("should have 2 bigtable plans available", func() {
-			serviceList, err := gcpBroker.Services(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			for _, s := range serviceList {
-				if s.ID == serviceNameToId[models.BigtableName] {
-					Expect(len(s.Plans)).To(Equal(2))
-				}
-			}
-
-		})
-
-		It("should have 1 debugger plan available", func() {
-			serviceList, err := gcpBroker.Services(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			for _, s := range serviceList {
-				if s.ID == serviceNameToId[models.StackdriverDebuggerName] {
-					Expect(len(s.Plans)).To(Equal(1))
-				}
-			}
-		})
-
-		It("should have 1 profiler plan available", func() {
-			serviceList, err := gcpBroker.Services(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			for _, s := range serviceList {
-				if s.ID == serviceNameToId[models.StackdriverProfilerName] {
-					Expect(len(s.Plans)).To(Equal(1))
-				}
-			}
-		})
-
-		It("should have 1 datastore plan available", func() {
-			serviceList, err := gcpBroker.Services(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			for _, s := range serviceList {
-				if s.ID == serviceNameToId[models.DatastoreName] {
-					Expect(len(s.Plans)).To(Equal(1))
-				}
-			}
 		})
 	})
 
@@ -247,7 +199,7 @@ var _ = Describe("Brokers", func() {
 				bqId := serviceNameToId[models.BigqueryName]
 				_, err := gcpBroker.Provision(context.Background(), instanceId, bqProvisionDetails, true)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[bqId].(*brokerfakes.FakeServiceProvider).ProvisionCallCount()).To(Equal(1))
+				Expect(serviceBrokerMap[bqId].ProvisionCallCount()).To(Equal(1))
 			})
 
 		})
@@ -300,7 +252,7 @@ var _ = Describe("Brokers", func() {
 					ServiceID: bqId,
 				}, true)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[bqId].(*brokerfakes.FakeServiceProvider).DeprovisionCallCount()).To(Equal(1))
+				Expect(serviceBrokerMap[bqId].DeprovisionCallCount()).To(Equal(1))
 			})
 		})
 
@@ -326,15 +278,15 @@ var _ = Describe("Brokers", func() {
 	Describe("bind", func() {
 		Context("when bind is called on storage", func() {
 			It("it should call storage bind", func() {
-				_, err = gcpBroker.Provision(context.Background(), instanceId, bqProvisionDetails, true)
+				_, err = gcpBroker.Provision(context.Background(), instanceId, storageProvisionDetails, true)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = gcpBroker.Bind(context.Background(), instanceId, bindingId, storageBindDetails)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.StorageName]].(*brokerfakes.FakeServiceProvider).BindCallCount()).To(Equal(1))
+				Expect(serviceBrokerMap[serviceNameToId[models.StorageName]].BindCallCount()).To(Equal(1))
 			})
 
 			It("it should reject bad roles", func() {
-				_, err = gcpBroker.Provision(context.Background(), instanceId, bqProvisionDetails, true)
+				_, err = gcpBroker.Provision(context.Background(), instanceId, storageProvisionDetails, true)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = gcpBroker.Bind(context.Background(), instanceId, bindingId, storageBadBindDetails)
 				Expect(err).To(HaveOccurred())
@@ -343,7 +295,7 @@ var _ = Describe("Brokers", func() {
 
 		Context("when bind is called more than once on the same id", func() {
 			It("it should throw an error", func() {
-				_, err = gcpBroker.Provision(context.Background(), instanceId, bqProvisionDetails, true)
+				_, err = gcpBroker.Provision(context.Background(), instanceId, storageProvisionDetails, true)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = gcpBroker.Bind(context.Background(), instanceId, bindingId, storageBindDetails)
 				Expect(err).NotTo(HaveOccurred())
@@ -354,32 +306,31 @@ var _ = Describe("Brokers", func() {
 
 		Context("when bind is called", func() {
 			It("it should update credentials with instance information", func() {
-				_, err = gcpBroker.Provision(context.Background(), instanceId, bqProvisionDetails, true)
+				_, err = gcpBroker.Provision(context.Background(), instanceId, storageProvisionDetails, true)
 				Expect(err).NotTo(HaveOccurred())
 				_, err := gcpBroker.Bind(context.Background(), instanceId, bindingId, storageBindDetails)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.StorageName]].(*brokerfakes.FakeServiceProvider).BuildInstanceCredentialsCallCount()).To(Equal(1))
+				Expect(serviceBrokerMap[serviceNameToId[models.StorageName]].BuildInstanceCredentialsCallCount()).To(Equal(1))
 			})
 		})
-
 	})
 
 	Describe("unbind", func() {
 		Context("when unbind is called on storage", func() {
 			It("it should call storage unbind", func() {
-				_, err = gcpBroker.Provision(context.Background(), instanceId, bqProvisionDetails, true)
+				_, err = gcpBroker.Provision(context.Background(), instanceId, storageProvisionDetails, true)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = gcpBroker.Bind(context.Background(), instanceId, bindingId, storageBindDetails)
 				Expect(err).NotTo(HaveOccurred())
 				err = gcpBroker.Unbind(context.Background(), instanceId, bindingId, storageUnbindDetails)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.StorageName]].(*brokerfakes.FakeServiceProvider).UnbindCallCount()).To(Equal(1))
+				Expect(serviceBrokerMap[serviceNameToId[models.StorageName]].UnbindCallCount()).To(Equal(1))
 			})
 		})
 
 		Context("when unbind is called more than once on the same id", func() {
 			It("it should throw an error", func() {
-				_, err = gcpBroker.Provision(context.Background(), instanceId, bqProvisionDetails, true)
+				_, err = gcpBroker.Provision(context.Background(), instanceId, storageProvisionDetails, true)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = gcpBroker.Bind(context.Background(), instanceId, bindingId, storageBindDetails)
 				Expect(err).NotTo(HaveOccurred())
@@ -414,7 +365,7 @@ var _ = Describe("Brokers", func() {
 				Expect(err).NotTo(HaveOccurred())
 				_, err = gcpBroker.LastOperation(context.Background(), instanceId, "operationtoken")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(gcpBroker.ServiceBrokerMap[serviceNameToId[models.CloudsqlMySQLName]].(*brokerfakes.FakeServiceProvider).PollInstanceCallCount()).To(Equal(1))
+				Expect(serviceBrokerMap[serviceNameToId[models.CloudsqlMySQLName]].PollInstanceCallCount()).To(Equal(1))
 			})
 		})
 

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -15,10 +15,13 @@
 package cloudsql
 
 import (
+	"code.cloudfoundry.org/lager"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -287,6 +290,10 @@ func mysqlServiceDefinition() *broker.ServiceDefinition {
 					"role": "cloudsql.editor",
 				},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &CloudSQLBroker{BrokerBase: bb}
 		},
 	}
 }

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -15,10 +15,13 @@
 package cloudsql
 
 import (
+	"code.cloudfoundry.org/lager"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -239,6 +242,10 @@ func postgresServiceDefinition() *broker.ServiceDefinition {
 					"role": "cloudsql.editor",
 				},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &CloudSQLBroker{BrokerBase: bb}
 		},
 	}
 }

--- a/brokerapi/brokers/datastore/definition.go
+++ b/brokerapi/brokers/datastore/definition.go
@@ -15,8 +15,11 @@
 package datastore
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -59,6 +62,10 @@ func init() {
 				ProvisionParams: map[string]interface{}{},
 				BindParams:      map[string]interface{}{},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &DatastoreBroker{BrokerBase: bb}
 		},
 	}
 

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -15,11 +15,14 @@
 package pubsub
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -180,6 +183,10 @@ again during that time (on a best-effort basis).
 					"role": "pubsub.publisher",
 				},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &PubSubBroker{BrokerBase: bb}
 		},
 	}
 }

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -15,11 +15,14 @@
 package spanner
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -146,6 +149,10 @@ func serviceDefinition() *broker.ServiceDefinition {
 				ProvisionParams: map[string]interface{}{"name": "auth-database", "location": "nam3"},
 				BindParams:      map[string]interface{}{"role": "spanner.databaseAdmin"},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &SpannerBroker{BrokerBase: bb}
 		},
 	}
 }

--- a/brokerapi/brokers/stackdriver_debugger/definition.go
+++ b/brokerapi/brokers/stackdriver_debugger/definition.go
@@ -15,8 +15,11 @@
 package stackdriver_debugger
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -60,6 +63,10 @@ func init() {
 				ProvisionParams: map[string]interface{}{},
 				BindParams:      map[string]interface{}{},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &StackdriverDebuggerBroker{BrokerBase: bb}
 		},
 	}
 

--- a/brokerapi/brokers/stackdriver_profiler/definition.go
+++ b/brokerapi/brokers/stackdriver_profiler/definition.go
@@ -15,8 +15,11 @@
 package stackdriver_profiler
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -60,6 +63,10 @@ func init() {
 				ProvisionParams: map[string]interface{}{},
 				BindParams:      map[string]interface{}{},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &StackdriverProfilerBroker{BrokerBase: bb}
 		},
 	}
 

--- a/brokerapi/brokers/stackdriver_trace/definition.go
+++ b/brokerapi/brokers/stackdriver_trace/definition.go
@@ -15,8 +15,11 @@
 package stackdriver_trace
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -60,6 +63,10 @@ func init() {
 				ProvisionParams: map[string]interface{}{},
 				BindParams:      map[string]interface{}{},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &StackdriverTraceBroker{BrokerBase: bb}
 		},
 	}
 

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -15,11 +15,14 @@
 package storage
 
 import (
+	"code.cloudfoundry.org/lager"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"golang.org/x/oauth2/jwt"
 )
 
 func init() {
@@ -152,6 +155,10 @@ func serviceDefinition() *broker.ServiceDefinition {
 					"location": "us-west1",
 				},
 			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &StorageBroker{BrokerBase: bb}
 		},
 	}
 }

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -23,11 +23,16 @@ import (
 	"github.com/spf13/viper"
 )
 
-var brokerRegistry = make(map[string]*ServiceDefinition)
+// BrokerRegistry holds the list of ServiceDefinitions that can be provisioned
+// by the GCP Service Broker.
+type BrokerRegistry map[string]*ServiceDefinition
+
+var DefaultRegistry = BrokerRegistry{}
 
 // Registers a ServiceDefinition with the service registry that various commands
 // poll to create the catalog, documentation, etc.
-func Register(service *ServiceDefinition) {
+func Register(service *ServiceDefinition) { DefaultRegistry.Register(service) }
+func (brokerRegistry BrokerRegistry) Register(service *ServiceDefinition) {
 	name := service.Name
 
 	if _, ok := brokerRegistry[name]; ok {
@@ -52,10 +57,11 @@ func Register(service *ServiceDefinition) {
 
 // GetEnabledServices returns a list of all registered brokers that the user
 // has enabled the use of.
-func GetEnabledServices() []*ServiceDefinition {
+func GetEnabledServices() []*ServiceDefinition { return DefaultRegistry.GetEnabledServices() }
+func (brokerRegistry *BrokerRegistry) GetEnabledServices() []*ServiceDefinition {
 	var out []*ServiceDefinition
 
-	for _, svc := range GetAllServices() {
+	for _, svc := range brokerRegistry.GetAllServices() {
 		if svc.IsEnabled() {
 			out = append(out, svc)
 		}
@@ -67,7 +73,8 @@ func GetEnabledServices() []*ServiceDefinition {
 // GetAllServices returns a list of all registered brokers whether or not the
 // user has enabled them. The brokers are sorted in lexocographic order based
 // on name.
-func GetAllServices() []*ServiceDefinition {
+func GetAllServices() []*ServiceDefinition { return DefaultRegistry.GetAllServices() }
+func (brokerRegistry BrokerRegistry) GetAllServices() []*ServiceDefinition {
 	var out []*ServiceDefinition
 
 	for _, svc := range brokerRegistry {
@@ -82,7 +89,8 @@ func GetAllServices() []*ServiceDefinition {
 
 // GetServiceById returns the service with the given ID, if it does not exist
 // or one of the services has a parse error then an error is returned.
-func GetServiceById(id string) (*ServiceDefinition, error) {
+func GetServiceById(id string) (*ServiceDefinition, error) { return DefaultRegistry.GetServiceById(id) }
+func (brokerRegistry BrokerRegistry) GetServiceById(id string) (*ServiceDefinition, error) {
 	for _, svc := range brokerRegistry {
 		if entry, err := svc.CatalogEntry(); err != nil {
 			return nil, err

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -19,11 +19,13 @@ import (
 	"fmt"
 	"strings"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
 	"github.com/spf13/viper"
+	"golang.org/x/oauth2/jwt"
 )
 
 // ServiceDefinition holds the necessary details to describe an OSB service and
@@ -39,6 +41,9 @@ type ServiceDefinition struct {
 	PlanVariables              []BrokerVariable
 	Examples                   []ServiceExample
 	DefaultRoleWhitelist       []string
+
+	// ProviderBuilder creates a new provider given the project, auth, and logger.
+	ProviderBuilder func(projectId string, auth *jwt.Config, logger lager.Logger) ServiceProvider
 }
 
 // EnabledProperty computes the Viper property name for the boolean the user


### PR DESCRIPTION
Move the services to having their own constructors that are defined in the service definition.

This moves us towards supporting multiple back-ends and gives a clear distinction between what the registry is and the GCPServiceBroker. Fixes #250 