### PR TITLE
fix #291, add namespace for datastore

### DIFF
--- a/brokerapi/brokers/datastore/broker.go
+++ b/brokerapi/brokers/datastore/broker.go
@@ -23,14 +23,34 @@ import (
 	"github.com/pivotal-cf/brokerapi"
 )
 
+// InstanceInformation holds the details needed to bind a service to a DatastoreBroker.
+type InstanceInformation struct {
+	Namespace string `json:"namespace,omitempty"`
+}
+
 // DatastoreBroker is the service-broker back-end for creating and binding Datastore instances.
 type DatastoreBroker struct {
 	broker_base.BrokerBase
 }
 
-// Provision is a no-op call because only service accounts need to be bound/unbound for Datastore.
+// Provision stores the namespace for future reference.
 func (b *DatastoreBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
-	return models.ServiceInstanceDetails{}, nil
+	// return models.ServiceInstanceDetails{}, nil
+
+	ii := InstanceInformation{
+		Namespace: provisionContext.GetString("namespace"),
+	}
+
+	if err := provisionContext.Error(); err != nil {
+		return models.ServiceInstanceDetails{}, err
+	}
+
+	details := models.ServiceInstanceDetails{}
+	if err := details.SetOtherDetails(ii); err != nil {
+		return models.ServiceInstanceDetails{}, err
+	}
+
+	return details, nil
 }
 
 // Deprovision is a no-op call because only service accounts need to be bound/unbound for Datastore.

--- a/docs/use.md
+++ b/docs/use.md
@@ -580,7 +580,10 @@ Google Cloud Datastore is a NoSQL document database built for automatic scaling,
 
 **Request Parameters**
 
-_No parameters supported._
+
+ * `namespace` _string_ - A context for the identifiers in your entity’s dataset. This ensures that different systems can all interpret an entity's data the same way, based on the rules for the entity’s particular namespace. Blank means the default namespace will be used. Default: ``.
+    * The string must have at most 100 characters.
+    * The string must match the regular expression `^[A-Za-z0-9_-]*$`.
 
 
 ## Binding
@@ -606,6 +609,9 @@ _No parameters supported._
     * The string must match the regular expression `^[a-z0-9-]+$`.
  * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
     * Examples: [112447814736626230844].
+ * `namespace` _string_ - A context for the identifiers in your entity’s dataset.
+    * The string must have at most 100 characters.
+    * The string must match the regular expression `^[A-Za-z0-9_-]*$`.
 
 ## Plans
 
@@ -643,6 +649,34 @@ Uses plan: `05f1fb6b-b5f0-48a2-9c2b-a5f236507a97`.
 
 <pre>
 $ cf create-service google-datastore default my-google-datastore-example -c `{}`
+$ cf bind-service my-app my-google-datastore-example -c `{}`
+</pre>
+
+
+### Custom Namespace
+
+
+Creates a datastore and returns the provided namespace along with bind calls.
+Uses plan: `05f1fb6b-b5f0-48a2-9c2b-a5f236507a97`.
+
+**Provision**
+
+```javascript
+{
+    "namespace": "my-namespace"
+}
+```
+
+**Bind**
+
+```javascript
+{}
+```
+
+**Cloud Foundry Example**
+
+<pre>
+$ cf create-service google-datastore default my-google-datastore-example -c `{"namespace":"my-namespace"}`
 $ cf bind-service my-app my-google-datastore-example -c `{}`
 </pre>
 
@@ -1194,7 +1228,7 @@ or disabled by the broker administrator.
 ### Basic Configuration
 
 
-Creates an account with the permission `monitoring.metricWriter`.
+Creates an account with the permission `monitoring.metricWriter` for writing metrics.
 Uses plan: `2e4b85c1-0ce6-46e4-91f5-eebeb373e3f5`.
 
 **Provision**


### PR DESCRIPTION
This adds namespaces for datastore that will be returned with the bind call so SpringCloudGcpDatastore can autoconfigure with the right namespace and we can achieve "multi-tenancy" on datastore.

fixes #291 

E2E tests are provided through the run-examples command.