### PR TITLE
Added Dialogflow support

### DIFF
--- a/brokerapi/brokers/dialogflow/broker.go
+++ b/brokerapi/brokers/dialogflow/broker.go
@@ -1,0 +1,39 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dialogflow
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"github.com/pivotal-cf/brokerapi"
+)
+
+// DialogflowBroker is the service-broker back-end for creating and binding Dialogflow clients.
+type DialogflowBroker struct {
+	broker_base.BrokerBase
+}
+
+// Provision is a no-op call because only service accounts need to be bound/unbound for Dialogflow.
+func (b *DialogflowBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
+	return models.ServiceInstanceDetails{}, nil
+}
+
+// Deprovision is a no-op call because only service accounts need to be bound/unbound for Dialogflow.
+func (b *DialogflowBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
+	return nil, nil
+}

--- a/brokerapi/brokers/dialogflow/definition.go
+++ b/brokerapi/brokers/dialogflow/definition.go
@@ -1,0 +1,72 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dialogflow
+
+import (
+	"code.cloudfoundry.org/lager"
+	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"golang.org/x/oauth2/jwt"
+)
+
+func init() {
+	bs := &broker.ServiceDefinition{
+		Name: "google-dialogflow",
+		DefaultServiceDefinition: `{
+      "id": "e84b69db-3de9-4688-8f5c-26b9d5b1f129",
+      "description": "Dialogflow is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices.",
+      "name": "google-dialogflow",
+      "bindable": true,
+      "plan_updateable": false,
+      "metadata": {
+        "displayName": "Google Cloud Dialogflow",
+        "longDescription": "Dialogflow is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices.",
+        "documentationUrl": "https://cloud.google.com/dialogflow-enterprise/docs/",
+        "supportUrl": "https://cloud.google.com/support/",
+        "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/dialogflow-enterprise.svg"
+      },
+      "tags": ["gcp", "dialogflow", "preview"],
+      "plans": [
+        {
+         "id": "3ac4e1bd-b22d-4a99-864b-d3a3ac582348",
+         "name": "default",
+         "display_name": "Default",
+         "description": "Dialogflow default plan.",
+         "service_properties": {}
+        }
+      ]
+    }`,
+		ProvisionInputVariables: []broker.BrokerVariable{},
+		BindInputVariables:      []broker.BrokerVariable{},
+		BindComputedVariables:   accountmanagers.FixedRoleBindComputedVariables("dialogflow.client"),
+		BindOutputVariables:     accountmanagers.ServiceAccountBindOutputVariables(),
+		Examples: []broker.ServiceExample{
+			{
+				Name:            "Reader",
+				Description:     "Creates a Dialogflow user and grants it permission to detect intent and read/write session properties (contexts, session entity types, etc.).",
+				PlanId:          "3ac4e1bd-b22d-4a99-864b-d3a3ac582348",
+				ProvisionParams: map[string]interface{}{},
+				BindParams:      map[string]interface{}{},
+			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &DialogflowBroker{BrokerBase: bb}
+		},
+	}
+
+	broker.Register(bs)
+}

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/bigtable"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/cloudsql"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/datastore"
+	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/dialogflow"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/pubsub"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/spanner"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/stackdriver"

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -174,6 +174,17 @@ You can configure the following environment variables:
   <li>Default: <code>true</code></li>
 </ul>
 
+<b><tt>GSB_SERVICE_GOOGLE_DIALOGFLOW_ENABLED</tt></b> - <i>boolean</i> - Let the broker create and bind Google Cloud Dialogflow instances.
+
+
+
+
+
+<ul>
+  <li><b>Required</b></li>
+  <li>Default: <code>true</code></li>
+</ul>
+
 <b><tt>GSB_SERVICE_GOOGLE_ML_APIS_ENABLED</tt></b> - <i>boolean</i> - Let the broker create and bind Google Machine Learning APIs instances.
 
 

--- a/docs/use.md
+++ b/docs/use.md
@@ -651,6 +651,91 @@ $ cf bind-service my-app my-google-datastore-example -c `{}`
 
 --------------------------------------------------------------------------------
 
+# ![](https://cloud.google.com/_static/images/cloud/products/logos/svg/dialogflow-enterprise.svg) Google Cloud Dialogflow
+
+Dialogflow is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices.
+
+ * [Documentation](https://cloud.google.com/dialogflow-enterprise/docs/)
+ * [Support](https://cloud.google.com/support/)
+ * Catalog Metadata ID: `e84b69db-3de9-4688-8f5c-26b9d5b1f129`
+ * Tags: gcp, dialogflow, preview
+ * Service Name: `google-dialogflow`
+
+## Provisioning
+
+**Request Parameters**
+
+_No parameters supported._
+
+
+## Binding
+
+**Request Parameters**
+
+_No parameters supported._
+
+**Response Parameters**
+
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
+
+## Plans
+
+The following plans are built-in to the GCP Service Broker and may be overriden
+or disabled by the broker administrator.
+
+
+  * **default**: Dialogflow default plan. Plan ID: `3ac4e1bd-b22d-4a99-864b-d3a3ac582348`.
+
+
+## Examples
+
+
+
+
+### Reader
+
+
+Creates a Dialogflow user and grants it permission to detect intent and read/write session properties (contexts, session entity types, etc.).
+Uses plan: `3ac4e1bd-b22d-4a99-864b-d3a3ac582348`.
+
+**Provision**
+
+```javascript
+{}
+```
+
+**Bind**
+
+```javascript
+{}
+```
+
+**Cloud Foundry Example**
+
+<pre>
+$ cf create-service google-dialogflow default my-google-dialogflow-example -c `{}`
+$ cf bind-service my-app my-google-dialogflow-example -c `{}`
+</pre>
+
+
+
+
+--------------------------------------------------------------------------------
+
 # ![](https://cloud.google.com/_static/images/cloud/products/logos/svg/machine-learning.svg) Google Machine Learning APIs
 
 Machine Learning APIs including Vision, Translate, Speech, and Natural Language.
@@ -1194,7 +1279,7 @@ or disabled by the broker administrator.
 ### Basic Configuration
 
 
-Creates an account with the permission `monitoring.metricWriter`.
+Creates an account with the permission `monitoring.metricWriter` for writing metrics.
 Uses plan: `2e4b85c1-0ce6-46e4-91f5-eebeb373e3f5`.
 
 **Provision**

--- a/tile.yml
+++ b/tile.yml
@@ -569,4 +569,3 @@ service_plan_forms:
     label: Storage Class
     description: 'The storage class of the bucket. See: https://cloud.google.com/storage/docs/storage-classes.'
     configurable: true
-

--- a/tile.yml
+++ b/tile.yml
@@ -135,6 +135,11 @@ forms:
     default: true
     label: Let the broker create and bind Google Cloud Datastore instances.
     configurable: true
+  - name: gsb_service_google_dialogflow_enabled
+    type: boolean
+    default: true
+    label: Let the broker create and bind Google Cloud Dialogflow instances.
+    configurable: true
   - name: gsb_service_google_ml_apis_enabled
     type: boolean
     default: true
@@ -405,10 +410,10 @@ service_plan_forms:
       for more information.'
     configurable: true
     options:
-    - name: SSD
-      label: SSD - Solid-state Drive
     - name: HDD
       label: HDD - Hard Disk Drive
+    - name: SSD
+      label: SSD - Solid-state Drive
   - name: num_nodes
     type: string
     default: "3"
@@ -564,3 +569,4 @@ service_plan_forms:
     label: Storage Class
     description: 'The storage class of the bucket. See: https://cloud.google.com/storage/docs/storage-classes.'
     configurable: true
+


### PR DESCRIPTION
Added Dialogflow support due to an out-of-band customter request.

This is another API only service. Clients will use models provided by Dialogflow and people will train/configure it using the cloud console.