### PR TITLE
added Firestore support

### DIFF
--- a/brokerapi/brokers/account_managers/service_account_manager.go
+++ b/brokerapi/brokers/account_managers/service_account_manager.go
@@ -223,6 +223,25 @@ func ServiceAccountBindInputVariables(serviceName string, defaultWhitelist []str
 	}
 }
 
+// ServiceAccountWhitelistWithDefault holds non-overridable whitelists with default values.
+// This function SHOULD be used for new services over ServiceAccountBindInputVariables.
+func ServiceAccountWhitelistWithDefault(whitelist []string, defaultValue string) []broker.BrokerVariable {
+	whitelistEnum := make(map[interface{}]string)
+	for _, val := range whitelist {
+		whitelistEnum[val] = roleResourcePrefix + val
+	}
+
+	return []broker.BrokerVariable{
+		{
+			FieldName: "role",
+			Type:      broker.JsonTypeString,
+			Details:   `The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details.`,
+			Enum:      whitelistEnum,
+			Default:   defaultValue,
+		},
+	}
+}
+
 // ServiceAccountBindComputedVariables holds computed variables required to provision service accounts, label them and ensure they are unique.
 func ServiceAccountBindComputedVariables() []varcontext.DefaultVariable {
 	return []varcontext.DefaultVariable{

--- a/brokerapi/brokers/firestore/broker.go
+++ b/brokerapi/brokers/firestore/broker.go
@@ -1,0 +1,39 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firestore
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"github.com/pivotal-cf/brokerapi"
+)
+
+// FirestoreBroker is the service-broker back-end for creating and binding Firestore clients.
+type FirestoreBroker struct {
+	broker_base.BrokerBase
+}
+
+// Provision is a no-op call because only service accounts need to be bound/unbound for Firestore.
+func (b *FirestoreBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
+	return models.ServiceInstanceDetails{}, nil
+}
+
+// Deprovision is a no-op call because only service accounts need to be bound/unbound for Firestore.
+func (b *FirestoreBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
+	return nil, nil
+}

--- a/brokerapi/brokers/firestore/definition.go
+++ b/brokerapi/brokers/firestore/definition.go
@@ -1,0 +1,83 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firestore
+
+import (
+	"code.cloudfoundry.org/lager"
+	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"golang.org/x/oauth2/jwt"
+)
+
+func init() {
+	// NOTE(jlewisiii) Firestore has some intentional differences from other services.
+	// First, it doesn't require legacy compatibility so we won't allow operators to override the whitelist.
+	// Second, Firestore uses the old datastore IAM role model so the roles will look strange.
+	bs := &broker.ServiceDefinition{
+		Name: "google-firestore",
+		DefaultServiceDefinition: `{
+      "id": "a2b7b873-1e34-4530-8a42-902ff7d66b43",
+      "description": "Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL document database that simplifies storing, syncing, and querying data for your mobile, web, and IoT apps at global scale.",
+      "name": "google-firestore",
+      "bindable": true,
+      "plan_updateable": false,
+      "metadata": {
+        "displayName": "Google Cloud Firestore",
+        "longDescription": "Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL document database that simplifies storing, syncing, and querying data for your mobile, web, and IoT apps at global scale.",
+        "documentationUrl": "https://cloud.google.com/firestore/docs/",
+        "supportUrl": "https://cloud.google.com/support/",
+        "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/firestore.svg"
+      },
+      "tags": ["gcp", "firestore", "preview", "beta"],
+      "plans": [
+        {
+         "id": "64403af0-4413-4ef3-a813-37f0306ef498",
+         "name": "default",
+         "display_name": "Default",
+         "description": "Firestore default plan.",
+         "service_properties": {}
+        }
+      ]
+    }`,
+		ProvisionInputVariables: []broker.BrokerVariable{},
+		BindInputVariables:      accountmanagers.ServiceAccountWhitelistWithDefault([]string{"datastore.user", "datastore.viewer"}, "datastore.user"),
+		BindOutputVariables:     accountmanagers.ServiceAccountBindOutputVariables(),
+		BindComputedVariables:   accountmanagers.ServiceAccountBindComputedVariables(),
+		Examples: []broker.ServiceExample{
+			{
+				Name:            "Reader Writer",
+				Description:     "Creates a general Firestore user and grants it permission to read and write entities.",
+				PlanId:          "64403af0-4413-4ef3-a813-37f0306ef498",
+				ProvisionParams: map[string]interface{}{},
+				BindParams:      map[string]interface{}{},
+			},
+
+			{
+				Name:            "Read Only",
+				Description:     "Creates a Firestore user that can only view entities.",
+				PlanId:          "64403af0-4413-4ef3-a813-37f0306ef498",
+				ProvisionParams: map[string]interface{}{},
+				BindParams:      map[string]interface{}{"role": "datastore.user"},
+			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := broker_base.NewBrokerBase(projectId, auth, logger)
+			return &FirestoreBroker{BrokerBase: bb}
+		},
+	}
+
+	broker.Register(bs)
+}

--- a/brokerapi/brokers/firestore/definition.go
+++ b/brokerapi/brokers/firestore/definition.go
@@ -38,7 +38,7 @@ func init() {
         "displayName": "Google Cloud Firestore",
         "longDescription": "Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL document database that simplifies storing, syncing, and querying data for your mobile, web, and IoT apps at global scale.",
         "documentationUrl": "https://cloud.google.com/firestore/docs/",
-        "supportUrl": "https://cloud.google.com/support/",
+        "supportUrl": "https://cloud.google.com/firestore/docs/getting-support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/firestore.svg"
       },
       "tags": ["gcp", "firestore", "preview", "beta"],
@@ -70,7 +70,7 @@ func init() {
 				Description:     "Creates a Firestore user that can only view entities.",
 				PlanId:          "64403af0-4413-4ef3-a813-37f0306ef498",
 				ProvisionParams: map[string]interface{}{},
-				BindParams:      map[string]interface{}{"role": "datastore.user"},
+				BindParams:      map[string]interface{}{"role": "datastore.viewer"},
 			},
 		},
 		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/cloudsql"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/datastore"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/dialogflow"
+	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/firestore"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/pubsub"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/spanner"
 	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/stackdriver"

--- a/docs/use.md
+++ b/docs/use.md
@@ -690,7 +690,7 @@ $ cf bind-service my-app my-google-datastore-example -c `{}`
 Dialogflow is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices.
 
  * [Documentation](https://cloud.google.com/dialogflow-enterprise/docs/)
- * [Support](https://cloud.google.com/support/)
+ * [Support](https://cloud.google.com/dialogflow-enterprise/docs/support)
  * Catalog Metadata ID: `e84b69db-3de9-4688-8f5c-26b9d5b1f129`
  * Tags: gcp, dialogflow, preview
  * Service Name: `google-dialogflow`
@@ -763,6 +763,121 @@ Uses plan: `3ac4e1bd-b22d-4a99-864b-d3a3ac582348`.
 <pre>
 $ cf create-service google-dialogflow default my-google-dialogflow-example -c `{}`
 $ cf bind-service my-app my-google-dialogflow-example -c `{}`
+</pre>
+
+
+
+
+--------------------------------------------------------------------------------
+
+# ![](https://cloud.google.com/_static/images/cloud/products/logos/svg/firestore.svg) Google Cloud Firestore
+
+Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL document database that simplifies storing, syncing, and querying data for your mobile, web, and IoT apps at global scale.
+
+ * [Documentation](https://cloud.google.com/firestore/docs/)
+ * [Support](https://cloud.google.com/support/)
+ * Catalog Metadata ID: `a2b7b873-1e34-4530-8a42-902ff7d66b43`
+ * Tags: gcp, firestore, preview, beta
+ * Service Name: `google-firestore`
+
+## Provisioning
+
+**Request Parameters**
+
+_No parameters supported._
+
+
+## Binding
+
+**Request Parameters**
+
+
+ * `role` _string_ - The role for the account without the "roles/" prefix. See: https://cloud.google.com/iam/docs/understanding-roles for more details. Default: `datastore.user`.
+    * The value must be one of: [datastore.user datastore.viewer].
+
+**Response Parameters**
+
+ * `Email` _string_ - **Required** Email address of the service account.
+    * Examples: [pcf-binding-ex312029@my-project.iam.gserviceaccount.com].
+    * The string must match the regular expression `^pcf-binding-[a-z0-9-]+@.+\.gserviceaccount\.com$`.
+ * `Name` _string_ - **Required** The name of the service account.
+    * Examples: [pcf-binding-ex312029].
+ * `PrivateKeyData` _string_ - **Required** Service account private key data. Base64 encoded JSON.
+    * The string must have at least 512 characters.
+    * The string must match the regular expression `^[A-Za-z0-9+/]*=*$`.
+ * `ProjectId` _string_ - **Required** ID of the project that owns the service account.
+    * Examples: [my-project].
+    * The string must have at most 30 characters.
+    * The string must have at least 6 characters.
+    * The string must match the regular expression `^[a-z0-9-]+$`.
+ * `UniqueId` _string_ - **Required** Unique and stable ID of the service account.
+    * Examples: [112447814736626230844].
+
+## Plans
+
+The following plans are built-in to the GCP Service Broker and may be overriden
+or disabled by the broker administrator.
+
+
+  * **default**: Firestore default plan. Plan ID: `64403af0-4413-4ef3-a813-37f0306ef498`.
+
+
+## Examples
+
+
+
+
+### Reader Writer
+
+
+Creates a general Firestore user and grants it permission to read and write entities.
+Uses plan: `64403af0-4413-4ef3-a813-37f0306ef498`.
+
+**Provision**
+
+```javascript
+{}
+```
+
+**Bind**
+
+```javascript
+{}
+```
+
+**Cloud Foundry Example**
+
+<pre>
+$ cf create-service google-firestore default my-google-firestore-example -c `{}`
+$ cf bind-service my-app my-google-firestore-example -c `{}`
+</pre>
+
+
+### Read Only
+
+
+Creates a Firestore user that can only view entities.
+Uses plan: `64403af0-4413-4ef3-a813-37f0306ef498`.
+
+**Provision**
+
+```javascript
+{}
+```
+
+**Bind**
+
+```javascript
+{
+    "role": "datastore.user"
+}
+```
+
+**Cloud Foundry Example**
+
+<pre>
+$ cf create-service google-firestore default my-google-firestore-example -c `{}`
+$ cf bind-service my-app my-google-firestore-example -c `{"role":"datastore.user"}`
 </pre>
 
 


### PR DESCRIPTION
Add support for Firestore.

Two oddities about this service:

1) We're not allowing overriding the role whitelist because this service is new and won't have anyone relying on that.
2) Firestore uses the old datastore.* IAM roles, but that's called out in a comment.

From what I read Firestore does not support namespaces like Datastore did (instead, you do them yourself) so I left that property out and this is a purely IAM based service.