### PR TITLE
added startup validation for schemas and IO of templates

### DIFF
--- a/pkg/providers/tf/cloud-storage.go
+++ b/pkg/providers/tf/cloud-storage.go
@@ -39,9 +39,9 @@ func init() {
 		Id:               "68d094ae-e727-4c14-af07-ee34133c8dfb",
 		Description:      "Experimental Google Cloud Storage that uses the Terraform back-end and grants service accounts IAM permissions directly on the bucket.",
 		DisplayName:      "Experimental Google Cloud Storage",
-		ImageUrl:         "",
-		DocumentationUrl: "",
-		SupportUrl:       "",
+		ImageUrl:         "https://cloud.google.com/_static/images/cloud/products/logos/svg/storage.svg",
+		DocumentationUrl: "https://cloud.google.com/storage/docs/overview",
+		SupportUrl:       "https://cloud.google.com/storage/docs/getting-support",
 		Tags:             []string{"preview", "gcp", "terraform", "storage"},
 		Plans: []broker.ServicePlan{
 			{

--- a/pkg/providers/tf/definition_test.go
+++ b/pkg/providers/tf/definition_test.go
@@ -1,0 +1,113 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+)
+
+func TestTfServiceDefinitionV1Action_ValidateTemplateIO(t *testing.T) {
+	cases := map[string]struct {
+		Action      TfServiceDefinitionV1Action
+		ErrContains string
+	}{
+		"nomainal": {
+			Action: TfServiceDefinitionV1Action{
+				PlanInputs: []broker.BrokerVariable{{FieldName: "storage_class"}},
+				UserInputs: []broker.BrokerVariable{{FieldName: "name"}},
+				Computed:   []varcontext.DefaultVariable{{Name: "labels"}},
+				Template: `
+      	variable storage_class {type = "string"}
+      	variable name {type = "string"}
+      	variable labels {type = "string"}
+
+      	output bucket_name {value = "${var.name}"}
+      	`,
+				Outputs: []broker.BrokerVariable{{FieldName: "bucket_name"}},
+			},
+			ErrContains: "",
+		},
+		"extra inputs okay": {
+			Action: TfServiceDefinitionV1Action{
+				PlanInputs: []broker.BrokerVariable{{FieldName: "storage_class"}},
+				UserInputs: []broker.BrokerVariable{{FieldName: "name"}},
+				Computed:   []varcontext.DefaultVariable{{Name: "labels"}},
+				Template: `
+      	variable storage_class {type = "string"}
+      	`,
+			},
+			ErrContains: "",
+		},
+		"missing inputs": {
+			Action: TfServiceDefinitionV1Action{
+				PlanInputs: []broker.BrokerVariable{{FieldName: "storage_class"}},
+				UserInputs: []broker.BrokerVariable{{FieldName: "name"}},
+				Computed:   []varcontext.DefaultVariable{{Name: "labels"}},
+				Template: `
+        variable storage_class {type = "string"}
+        variable not_defined {type = "string"}
+        `,
+			},
+			ErrContains: "The Terraform template requires the fields [not_defined] which are missing from the declared inputs.",
+		},
+
+		"extra template outputs": {
+			Action: TfServiceDefinitionV1Action{
+				Template: `
+        output storage_class {value = "${var.name}"}
+        output name {value = "${var.name}"}
+        output labels {value = "${var.name}"}
+        output bucket_name {value = "${var.name}"}
+        `,
+				Outputs: []broker.BrokerVariable{{FieldName: "bucket_name"}},
+			},
+			ErrContains: "MUST match the service declared outputs",
+		},
+
+		"missing template outputs": {
+			Action: TfServiceDefinitionV1Action{
+				Template: `
+        `,
+				Outputs: []broker.BrokerVariable{{FieldName: "bucket_name"}},
+			},
+			ErrContains: "MUST match the service declared outputs",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			err := tc.Action.ValidateTemplateIO()
+			if err == nil {
+				if tc.ErrContains == "" {
+					return
+				}
+
+				t.Fatalf("Expected error to contain %q, got: <nil>", tc.ErrContains)
+			} else {
+				if tc.ErrContains == "" {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+
+				if !strings.Contains(err.Error(), tc.ErrContains) {
+					t.Fatalf("Expected error to contain %q, got: %v", tc.ErrContains, err)
+				}
+			}
+		})
+	}
+}

--- a/utils/set.go
+++ b/utils/set.go
@@ -14,7 +14,11 @@
 
 package utils
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
 
 // NewStringSet creates a new string set with the given contents.
 func NewStringSet(contents ...string) StringSet {
@@ -33,13 +37,14 @@ func (set StringSet) Add(str ...string) {
 	}
 }
 
-// ToSlice converts the set to a slice with undefined contents order.
+// ToSlice converts the set to a slice with sort.Strings order.
 func (set StringSet) ToSlice() []string {
 	out := []string{}
 	for k := range set {
 		out = append(out, k)
 	}
 
+	sort.Strings(out)
 	return out
 }
 
@@ -58,4 +63,22 @@ func (set StringSet) Equals(other StringSet) bool {
 func (set StringSet) Contains(other string) bool {
 	_, ok := set[other]
 	return ok
+}
+
+// Returns a copy of this set with every string in the other removed.
+func (set StringSet) Minus(other StringSet) StringSet {
+	difference := NewStringSet()
+
+	for k, _ := range set {
+		if !other.Contains(k) {
+			difference.Add(k)
+		}
+	}
+
+	return difference
+}
+
+// String converts this set to a human readable string.
+func (set StringSet) String() string {
+	return fmt.Sprintf("%v", set.ToSlice())
 }

--- a/utils/set_test.go
+++ b/utils/set_test.go
@@ -1,0 +1,93 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "fmt"
+
+func ExampleStringSet_Add() {
+	set := NewStringSet()
+	set.Add("a")
+	set.Add("b")
+
+	fmt.Println(set)
+	set.Add("a")
+	fmt.Println(set)
+
+	// Output: [a b]
+	// [a b]
+}
+
+func ExampleNewStringSet() {
+	a := NewStringSet()
+	a.Add("a")
+	a.Add("b")
+
+	b := NewStringSet("b", "a")
+
+	fmt.Println(a.Equals(b))
+
+	// Output: true
+}
+
+func ExampleStringSet_ToSlice() {
+	a := NewStringSet()
+	a.Add("z")
+	a.Add("b")
+
+	fmt.Println(a.ToSlice())
+
+	// Output: [b z]
+}
+
+func ExampleStringSet_IsEmpty() {
+	a := NewStringSet()
+
+	fmt.Println(a.IsEmpty())
+	a.Add("a")
+	fmt.Println(a.IsEmpty())
+
+	// Output: true
+	// false
+}
+
+func ExampleStringSet_Equals() {
+	a := NewStringSet("a", "b")
+	b := NewStringSet("a", "b", "c")
+	fmt.Println(a.Equals(b))
+
+	a.Add("c")
+	fmt.Println(a.Equals(b))
+
+	// Output: false
+	// true
+}
+
+func ExampleStringSet_Contains() {
+	a := NewStringSet("a", "b")
+	fmt.Println(a.Contains("z"))
+	fmt.Println(a.Contains("a"))
+
+	// Output: false
+	// true
+}
+
+func ExampleStringSet_Minus() {
+	a := NewStringSet("a", "b")
+	b := NewStringSet("b", "c")
+	delta := a.Minus(b)
+
+	fmt.Println(delta)
+	// Output: [a]
+}


### PR DESCRIPTION
This adds validation of HCL templates to the Terraform PR when they get converted into ServiceDefinitions. It also basic validation that the variables the HCL template use and produce match up with those that the user has defined.