### PR TITLE
add optional executor to jobrunner

### DIFF
--- a/pkg/providers/tf/definition.go
+++ b/pkg/providers/tf/definition.go
@@ -186,7 +186,8 @@ func (tfb *TfServiceDefinitionV1) ToService() (*broker.ServiceDefinition, error)
 		PlanVariables:       append(tfb.ProvisionSettings.PlanInputs, tfb.BindSettings.PlanInputs...),
 		Examples:            tfb.Examples,
 		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
-			return NewTerraformProvider(projectId, auth, logger, *tfb)
+			jobRunner := NewTfJobRunnerForProject(projectId)
+			return NewTerraformProvider(jobRunner, logger, *tfb)
 		},
 	}, nil
 }

--- a/pkg/providers/tf/provider.go
+++ b/pkg/providers/tf/provider.go
@@ -23,16 +23,14 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/tf/wrapper"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
-	"golang.org/x/oauth2/jwt"
 )
 
 // NewTerraformProvider creates a new ServiceProvider backed by Terraform module definitions for provision and bind.
-func NewTerraformProvider(projectId string, auth *jwt.Config, logger lager.Logger, serviceDefinition TfServiceDefinitionV1) broker.ServiceProvider {
+func NewTerraformProvider(jobRunner *TfJobRunner, logger lager.Logger, serviceDefinition TfServiceDefinitionV1) broker.ServiceProvider {
 	return &terraformProvider{
 		serviceDefinition: serviceDefinition,
-		jobRunner:         TfJobRunner{ProjectId: projectId, ServiceAccount: utils.GetServiceAccountJson()},
+		jobRunner:         jobRunner,
 		logger:            logger.Session("terraform-" + serviceDefinition.Name),
 	}
 }
@@ -40,7 +38,7 @@ func NewTerraformProvider(projectId string, auth *jwt.Config, logger lager.Logge
 type terraformProvider struct {
 	// broker_base.BrokerBase
 	logger            lager.Logger
-	jobRunner         TfJobRunner
+	jobRunner         *TfJobRunner
 	serviceDefinition TfServiceDefinitionV1
 }
 

--- a/pkg/providers/tf/wrapper/workspace.go
+++ b/pkg/providers/tf/wrapper/workspace.go
@@ -297,7 +297,7 @@ func (workspace *TerraformWorkspace) runTf(subCommand string, args ...string) er
 
 // CustomTerraformExecutor executes a custom Terraform binary that uses plugins
 // from a given plugin directory rather than the Terraform that's on the PATH
-// and downloading the binaries from the web.
+// which will download provider binaries from the web.
 func CustomTerraformExecutor(tfBinaryPath, tfPluginDir string, wrapped TerraformExecutor) TerraformExecutor {
 	return func(c *exec.Cmd) error {
 		c.Path = tfBinaryPath
@@ -311,6 +311,8 @@ func CustomTerraformExecutor(tfBinaryPath, tfPluginDir string, wrapped Terraform
 	}
 }
 
+// DefaultExecutor is the default executor that shells out to Terraform
+// and logs results to stdout.
 func DefaultExecutor(c *exec.Cmd) error {
 	logger := lager.NewLogger("terraform@" + c.Dir)
 	logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.ERROR))


### PR DESCRIPTION
Adds support for a custom executor that lets you override the Terraform binary and paths used along with support for setting that up in the JobRunner.

Providers now accept a custom JobRunner rather than constructing it themselves. This will help when there are multiple versions of Terraform or plugin paths we want to load from.