### PR TITLE
cleanup definitions and add auto-casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Preview support for Dataflow.
  - Default roles for ML, BigQuery, BigTable, CloudSQL, Pub/Sub, Spanner, and Cloud Storage.
  - `/docs` endpoint that serves docs for your installation.
+ - Varcontext now supports casting computed HIL values.
 
 ### Changed
  - Support links for services now point to service-specific pages where possible.

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -242,7 +242,7 @@ func (b *CloudSQLBroker) BuildInstanceCredentials(ctx context.Context, bindRecor
 
 	return varcontext.Builder().
 		MergeMap(combinedCreds).
-		MergeEvalResult("uri", uriFormat).
+		MergeEvalResult("uri", uriFormat, varcontext.TypeString).
 		BuildMap()
 }
 

--- a/google-brokers/cloud-storage.yml
+++ b/google-brokers/cloud-storage.yml
@@ -9,14 +9,12 @@ documentation_url: https://cloud.google.com/storage/docs/overview
 support_url: https://cloud.google.com/storage/docs/getting-support
 tags: [preview, gcp, terraform, storage]
 plans:
-- serviceplan:
-    id: e1d11f65-da66-46ad-977c-6d56513baf43
-    name: standard
-    description: Standard storage class.
-    free: false
-    metadata:
-      displayname: Standard
-  serviceproperties:
+- name: standard
+  id: e1d11f65-da66-46ad-977c-6d56513baf43
+  description: Standard storage class.
+  free: false
+  display_name: Standard
+  properties:
     storage_class: STANDARD
 provision:
   plan_inputs:
@@ -49,15 +47,18 @@ provision:
   - name: labels
     default: ${json.marshal(request.default_labels)}
     overwrite: true
+    type: object
   template: |-
     variable name {type = "string"}
     variable location {type = "string"}
     variable storage_class {type = "string"}
+    variable labels {type = "map"}
 
     resource "google_storage_bucket" "bucket" {
       name     = "${var.name}"
       location = "${var.location}"
       storage_class = "${var.storage_class}"
+      labels = "${var.labels}"
     }
 
     output id {value = "${google_storage_bucket.bucket.id}"}

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -236,7 +236,7 @@ func (svc *ServiceDefinition) ServiceDefinition() (*Service, error) {
 func (svc *ServiceDefinition) provisionDefaults() []varcontext.DefaultVariable {
 	var out []varcontext.DefaultVariable
 	for _, provisionVar := range svc.ProvisionInputVariables {
-		out = append(out, varcontext.DefaultVariable{Name: provisionVar.FieldName, Default: provisionVar.Default, Overwrite: false})
+		out = append(out, varcontext.DefaultVariable{Name: provisionVar.FieldName, Default: provisionVar.Default, Overwrite: false, Type: string(provisionVar.Type)})
 	}
 	return out
 }
@@ -244,7 +244,7 @@ func (svc *ServiceDefinition) provisionDefaults() []varcontext.DefaultVariable {
 func (svc *ServiceDefinition) bindDefaults() []varcontext.DefaultVariable {
 	var out []varcontext.DefaultVariable
 	for _, v := range svc.BindInputVariables {
-		out = append(out, varcontext.DefaultVariable{Name: v.FieldName, Default: v.Default, Overwrite: false})
+		out = append(out, varcontext.DefaultVariable{Name: v.FieldName, Default: v.Default, Overwrite: false, Type: string(v.Type)})
 	}
 	return out
 }

--- a/pkg/providers/tf/definition_test.go
+++ b/pkg/providers/tf/definition_test.go
@@ -15,11 +15,13 @@
 package tf
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"github.com/pivotal-cf/brokerapi"
 )
 
 func TestTfServiceDefinitionV1Action_ValidateTemplateIO(t *testing.T) {
@@ -118,4 +120,50 @@ func TestNewExampleTfServiceDefinition(t *testing.T) {
 	if err := example.Validate(); err != nil {
 		t.Fatalf("example service definition should be valid, but got error: %v", err)
 	}
+}
+
+func TestTfServiceDefinitionV1Plan_ToPlan(t *testing.T) {
+	cases := map[string]struct {
+		Definition TfServiceDefinitionV1Plan
+		Expected   broker.ServicePlan
+	}{
+		"full": {
+			Definition: TfServiceDefinitionV1Plan{
+				Id:          "00000000-0000-0000-0000-000000000001",
+				Name:        "example-email-plan",
+				DisplayName: "example.com email builder",
+				Description: "Builds emails for example.com.",
+				Bullets:     []string{"information point 1", "information point 2", "some caveat here"},
+				Free:        false,
+				Properties: map[string]string{
+					"domain": "example.com",
+				},
+			},
+			Expected: broker.ServicePlan{
+				ServicePlan: brokerapi.ServicePlan{
+					ID:          "00000000-0000-0000-0000-000000000001",
+					Name:        "example-email-plan",
+					Description: "Builds emails for example.com.",
+					Free:        brokerapi.FreeValue(false),
+					Metadata: &brokerapi.ServicePlanMetadata{
+						Bullets:     []string{"information point 1", "information point 2", "some caveat here"},
+						DisplayName: "example.com email builder",
+					},
+				},
+				ServiceProperties: map[string]string{"domain": "example.com"}},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual := tc.Definition.ToPlan()
+			if !reflect.DeepEqual(actual, tc.Expected) {
+				t.Fatalf("Expected: %v Actual: %v", tc.Expected, actual)
+			}
+		})
+	}
+}
+
+func TestTfServiceDefinitionV1Variable_ToBrokerVariable(t *testing.T) {
+	// adsf
 }

--- a/pkg/validation/struct_validator.go
+++ b/pkg/validation/struct_validator.go
@@ -30,6 +30,7 @@ func init() {
 	validate.RegisterValidation("json", jsonValidation)
 	validate.RegisterValidation("hcl", hclValidation)
 	validate.RegisterValidation("terraform_identifier", regexValidation(`^[a-z_]*$`))
+	validate.RegisterValidation("jsonschema_type", regexValidation(`^(|object|boolean|array|number|string|integer)$`))
 }
 
 // ValidateStruct executes the validation tags on a struct and returns any

--- a/pkg/validation/struct_validator_test.go
+++ b/pkg/validation/struct_validator_test.go
@@ -36,6 +36,10 @@ type terraformIdentifierStruct struct {
 	Id string `validate:"terraform_identifier"`
 }
 
+type jsonschemaTypeStruct struct {
+	Type string `validate:"jsonschema_type"`
+}
+
 func TestValidateStruct(t *testing.T) {
 	cases := map[string]struct {
 		Validate  interface{}
@@ -139,6 +143,34 @@ func TestValidateStruct(t *testing.T) {
 		"terraform identifier blank": {
 			Validate:  terraformIdentifierStruct{Id: ""},
 			ExpectErr: false,
+		},
+		"jsonschema type blank": {
+			Validate:  jsonschemaTypeStruct{Type: ""},
+			ExpectErr: false,
+		},
+		"jsonschema type object": {
+			Validate:  jsonschemaTypeStruct{Type: "object"},
+			ExpectErr: false,
+		},
+		"jsonschema type boolean": {
+			Validate:  jsonschemaTypeStruct{Type: "boolean"},
+			ExpectErr: false,
+		},
+		"jsonschema type number": {
+			Validate:  jsonschemaTypeStruct{Type: "number"},
+			ExpectErr: false,
+		},
+		"jsonschema type string": {
+			Validate:  jsonschemaTypeStruct{Type: "string"},
+			ExpectErr: false,
+		},
+		"jsonschema type integer": {
+			Validate:  jsonschemaTypeStruct{Type: "integer"},
+			ExpectErr: false,
+		},
+		"jsonschema type invalid": {
+			Validate:  jsonschemaTypeStruct{Type: "invalid"},
+			ExpectErr: true,
 		},
 	}
 


### PR DESCRIPTION
I ran integration tests on this and the existing services still work.

This PR simplifies the way plans are defined and variables are computed to make brokerpaks more approachable.

The structure of plans now mimics that of the service so the fields are easier to explain and HIL values now support casting to JSONSchema approved types so we can more easily use things like Maps of auto-computed labels.

Together these should allow us to implement some non-trivial examples with these brokerpaks.