### PR TITLE
enable compression during zip creation

### DIFF
--- a/utils/ziputil/zip.go
+++ b/utils/ziputil/zip.go
@@ -154,6 +154,7 @@ func Archive(sourceFolder, destinationZip string) error {
 			return err
 		}
 		header.Name = Clean(strings.TrimPrefix(path, sourceFolder))
+		header.Method = zip.Deflate
 
 		if info.IsDir() {
 			w.CreateHeader(header)


### PR DESCRIPTION
This cuts the size of a basic brokerpak to about 1/3rd.