### PR TITLE
added support for fetching brokerpaks from GCS

### DIFF
--- a/cmd/get_plan_info.go
+++ b/cmd/get_plan_info.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"log"
 
-	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
@@ -30,7 +29,7 @@ func init() {
 		Short: "Dump plan information from the database",
 		Long:  `Dump plan information from the database.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			logger := lager.NewLogger("get_plan_info_cmd")
+			logger := utils.NewLogger("get_plan_info_cmd")
 			db := db_service.SetupDb(logger)
 
 			var pds []*models.PlanDetailsV1

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -15,10 +15,8 @@
 package cmd
 
 import (
-	"os"
-
-	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -28,8 +26,7 @@ func init() {
 		Short: "Upgrade your database",
 		Long:  `Upgrade your database to be compatible with this service broker.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			logger := lager.NewLogger("migrations-cmd")
-			logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.DEBUG))
+			logger := utils.NewLogger("migrations-cmd")
 
 			logger.Debug("Setting up the database")
 			db := db_service.SetupDb(logger)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"net/http"
-	"os"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers"
@@ -28,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/compatibility"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/server"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/toggles"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -62,9 +62,7 @@ func init() {
 
 func serve() {
 
-	logger := lager.NewLogger("gcp-service-broker")
-	logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.ERROR))
-	logger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+	logger := utils.NewLogger("gcp-service-broker")
 
 	models.ProductionizeUserAgent()
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 
-	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
@@ -58,7 +57,7 @@ func addDumpTableCommand(parent *cobra.Command, name string, value interface{}) 
 }
 
 func tableToJson(results interface{}) {
-	logger := lager.NewLogger("show-command")
+	logger := utils.NewLogger("show-command")
 	db := db_service.SetupDb(logger)
 
 	if err := db.Find(results).Error; err != nil {

--- a/cmd/tf.go
+++ b/cmd/tf.go
@@ -22,11 +22,11 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/tf"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/tf/wrapper"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/jinzhu/gorm"
 	"github.com/spf13/cobra"
 )
@@ -40,9 +40,7 @@ func init() {
 		Short: "Interact with the Terraform backend",
 		Long:  `Interact with the Terraform backend`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-			logger := lager.NewLogger("tf")
-			logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.ERROR))
-			logger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+			logger := utils.NewLogger("tf")
 			db = db_service.New(logger)
 
 			jobRunner, err = tf.NewTfJobRunerFromEnv()

--- a/pkg/brokerpak/cmd.go
+++ b/pkg/brokerpak/cmd.go
@@ -159,6 +159,8 @@ func RegisterAll(registry broker.BrokerRegistry) error {
 	}
 	defer os.RemoveAll(pakDir)
 
+	// XXX(josephlewis42): this could be parallelized to increase performance
+	// if we find people are pulling lots of data from the network.
 	for i, packSource := range viper.GetStringSlice("brokerpak.packs") {
 		destFile := filepath.Join(pakDir, fmt.Sprintf("pack-%d.brokerpak", i))
 		registerLogger.Debug("importing brokerpak", lager.Data{

--- a/pkg/brokerpak/fetch_test.go
+++ b/pkg/brokerpak/fetch_test.go
@@ -1,0 +1,68 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package brokerpak
+
+import (
+	"testing"
+
+	getter "github.com/hashicorp/go-getter"
+)
+
+func TestDefaultGetters(t *testing.T) {
+	getters := defaultGetters()
+
+	// gcs SHOULD NOT be in there
+	for _, prefix := range []string{"gs", "gcs"} {
+		if getters[prefix] != nil {
+			t.Errorf("expected default getters not to contain %q", prefix)
+		}
+	}
+
+	for _, prefix := range []string{"http", "https", "git", "hg"} {
+		if getters[prefix] == nil {
+			t.Errorf("expected default getters not to contain %q", prefix)
+		}
+	}
+}
+
+func TestNewFileGetterClient(t *testing.T) {
+	source := "http://www.example.com/foo/bar/bazz"
+	dest := "/tmp/path/to/dest"
+	client := newFileGetterClient(source, dest)
+
+	if client.Src != source {
+		t.Errorf("Expected Src to be %q got %q", source, client.Src)
+	}
+
+	if client.Dst != dest {
+		t.Errorf("Expected Dst to be %q got %q", dest, client.Dst)
+	}
+
+	if client.Mode != getter.ClientModeFile {
+		t.Errorf("Expected Dst to be %q got %q", getter.ClientModeFile, client.Mode)
+	}
+
+	if client.Getters == nil {
+		t.Errorf("Expected getters to be set")
+	}
+
+	if client.Decompressors == nil {
+		t.Errorf("Expected decompressors to be set")
+	}
+
+	if len(client.Decompressors) != 0 {
+		t.Errorf("Expected decompressors to be empty")
+	}
+}

--- a/pkg/providers/tf/job_runner.go
+++ b/pkg/providers/tf/job_runner.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"code.cloudfoundry.org/lager"
@@ -121,9 +120,7 @@ func (runner *TfJobRunner) hydrateWorkspace(ctx context.Context, deployment *mod
 
 	ws.Executor = runner.Executor
 
-	logger := lager.NewLogger("job-runner")
-	logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.ERROR))
-	logger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+	logger := utils.NewLogger("job-runner")
 	logger.Info("wrapping", lager.Data{
 		"wrapper": ws,
 	})

--- a/pkg/providers/tf/wrapper/workspace.go
+++ b/pkg/providers/tf/wrapper/workspace.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 )
 
 // DefaultInstanceName is the default name of an instance of a particular module.
@@ -321,9 +322,7 @@ func CustomTerraformExecutor(tfBinaryPath, tfPluginDir string, wrapped Terraform
 // DefaultExecutor is the default executor that shells out to Terraform
 // and logs results to stdout.
 func DefaultExecutor(c *exec.Cmd) error {
-	logger := lager.NewLogger("terraform@" + c.Dir)
-	logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.ERROR))
-	logger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+	logger := utils.NewLogger("terraform@" + c.Dir)
 
 	logger.Info("starting process", lager.Data{
 		"path": c.Path,

--- a/utils/stream/stream.go
+++ b/utils/stream/stream.go
@@ -99,6 +99,11 @@ func FromReadCloserError(rc io.ReadCloser, err error) Source {
 	}
 }
 
+// FromReadCloser reads the contents of the readcloser and takes ownership of closing it.
+func FromReadCloser(rc io.ReadCloser) Source {
+	return FromReadCloserError(rc, nil)
+}
+
 // FromReader converts a Reader to a Source.
 func FromReader(rc io.Reader) Source {
 	return func() (io.ReadCloser, error) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -18,9 +18,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/pivotal-cf/brokerapi"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2/google"
@@ -207,4 +209,15 @@ func SingleLineErrorFormatter(es []error) string {
 	}
 
 	return fmt.Sprintf("%d error(s) occurred: %s", len(es), strings.Join(points, "; "))
+}
+
+// NewLogger creates a new lager.Logger with the given name that has correct
+// writing settings.
+func NewLogger(name string) lager.Logger {
+	logger := lager.NewLogger(name)
+
+	logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.ERROR))
+	logger.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+
+	return logger
 }


### PR DESCRIPTION
Adds support for getting brokerpaks from Cloud Storage buckets using URLs like gsutil produces e.g. `gs://brokerpaks/my-pak.brokerpak`

Testing manually works just fine, but I can't seem to come up with a good way to write unit-tests for the fetcher without massively increasing the code size and complexity due to the way the GCS client library is structured. This is similar to the issue I faced when creating the cloud storage beat for Elastic.

If you have thoughts beyond testing this with our integration tests I'm happy to hear them.