### PR TITLE
added memorystore for redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The GCP Service Broker provides support for:
 * [Datastore](https://cloud.google.com/datastore/)
 * [Dialogflow](https://cloud.google.com/dialogflow-enterprise/)
 * [Firestore](https://cloud.google.com/firestore/)
+* [Memorystore for Redis](https://cloud.google.com/memorystore/docs/redis/) (preview)
 * [ML APIs](https://cloud.google.com/ml/)
 * [PubSub](https://cloud.google.com/pubsub/)
 * [Spanner](https://cloud.google.com/spanner/)

--- a/cmd/pak.go
+++ b/cmd/pak.go
@@ -104,7 +104,11 @@ dependencies, services it provides, and the contents.
 				log.Fatalf("error while packing %q: %v", directory, err)
 			}
 
-			fmt.Printf("created: %v\n", pakPath)
+			if err := brokerpak.Validate(pakPath); err != nil {
+				log.Fatalf("created: %v, but it failed validity checking: %v\n", pakPath, err)
+			} else {
+				fmt.Printf("created: %v\n", pakPath)
+			}
 		},
 	})
 

--- a/cmd/tf.go
+++ b/cmd/tf.go
@@ -92,11 +92,17 @@ func init() {
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.StripEscape)
-			fmt.Fprintln(w, "ID\tLast Operation\tState\tLast Updated\tMessage")
+			fmt.Fprintln(w, "ID\tLast Operation\tState\tLast Updated\tElapsed\tMessage")
 
 			for _, result := range results {
 				lastUpdate := result.UpdatedAt.Format(time.RFC822)
-				fmt.Fprintf(w, "%q\t%s\t%s\t%s\t%q\n", result.ID, result.LastOperationType, result.LastOperationState, lastUpdate, result.LastOperationMessage)
+
+				elapsed := ""
+				if result.LastOperationState == tf.InProgress {
+					elapsed = time.Now().Sub(result.UpdatedAt).Truncate(time.Second).String()
+				}
+
+				fmt.Fprintf(w, "%q\t%s\t%s\t%s\t%s\t%q\n", result.ID, result.LastOperationType, result.LastOperationState, lastUpdate, elapsed, result.LastOperationMessage)
 			}
 			w.Flush()
 		},

--- a/google-brokers/google-redis.yml
+++ b/google-brokers/google-redis.yml
@@ -1,0 +1,162 @@
+# Copyright 2018 the Service Broker Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+version: 1
+name: google-redis
+id: 0e86ad78-99b3-48b6-a986-b594e7995fd6
+description: Cloud Memorystore for Redis is a fully managed Redis service for the
+  Google Cloud Platform.
+display_name: Google Cloud Memorystore for Redis
+image_url: https://cloud.google.com/_static/images/cloud/products/logos/svg/cache.svg
+documentation_url: https://cloud.google.com/memorystore/docs/redis/
+support_url: https://cloud.google.com/support/
+tags: [gcp, redis, preview]
+plans:
+- name: basic
+  id: 6ed44104-8777-4b57-8c03-826b3af7d0be
+  description: A basic plan with no failover. Data will be lost on maintenance or cluster changes.
+  display_name: "Basic"
+  properties:
+    service_tier: BASIC
+- name: ha
+  id: 8c85c90c-f8e3-4337-9069-c03036243894
+  description: A highly available plan with automatic failover.
+  display_name: "High Availability"
+  properties:
+    service_tier: STANDARD_HA
+provision:
+  plan_inputs:
+  - field_name: service_tier
+    required: true
+    type: string
+    details: The service tier of the instance.
+    enum:
+      BASIC: standalone instance
+      STANDARD_HA: highly available primary/replica instances
+  user_inputs:
+  - field_name: memory_size_gb
+    type: integer
+    details: The size of the instance in gigabytes.
+    default: 4
+    constraints:
+      maximum: 300
+      minimum: 1
+  - field_name: instance_id
+    type: string
+    details: Permanent identifier for your instance
+    default: pcf-sb-${counter.next()}-${time.nano()}
+    constraints:
+      maxLength: 30
+      minLength: 6
+      pattern: ^[a-z][a-z0-9-]+$
+  - field_name: display_name
+    type: string
+    details: For display purposes only
+    default: ${instance_id}
+    constraints:
+      maxLength: 80
+  - field_name: region
+    type: string
+    details: The region of the Redis instance.
+    default: us-central1
+    constraints:
+      examples:
+      - us-central1
+      - asia-northeast1
+      pattern: ^[A-Za-z][-a-z0-9A-Z]+$
+  - field_name: authorized_network
+    type: string
+    details:  The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
+      This will look something like /projects/PROJECTID/global/networks/NETWORKNAME.
+    default: ''
+  computed_inputs:
+  - name: labels
+    default: ${json.marshal(request.default_labels)}
+    overwrite: true
+    type: object
+  template: |-
+    variable service_tier { type = "string" }
+    variable authorized_network { type = "string" }
+    variable display_name { type = "string" }
+    variable instance_id { type = "string" }
+    variable region { type = "string" }
+    variable memory_size_gb { type = "string" }
+    variable labels { type = "map" }
+
+    data "google_compute_network" "default-network" {
+      name = "default"
+    }
+
+    resource "google_redis_instance" "instance" {
+      name               = "${var.instance_id}"
+      tier               = "${var.service_tier}"
+      memory_size_gb     = "${var.memory_size_gb}"
+      display_name       = "${var.display_name}"
+      region             = "${var.region}"
+      authorized_network = "${coalesce(var.authorized_network, data.google_compute_network.default-network.self_link)}"
+      labels             = "${var.labels}"
+
+      timeouts {
+        create = "15m"
+        update = "15m"
+        delete = "15m"
+      }
+    }
+
+    output memory_size_gb { value = "${google_redis_instance.instance.memory_size_gb}" }
+    output service_tier { value = "${google_redis_instance.instance.tier}" }
+    output redis_version { value = "${google_redis_instance.instance.redis_version}" }
+    output host { value = "${google_redis_instance.instance.host}" }
+    output port { value = "${google_redis_instance.instance.port}" }
+  outputs:
+  - required: true
+    field_name: memory_size_gb
+    type: string
+    details: The size of the instance in gigabytes.
+  - required: true
+    field_name: service_tier
+    type: string
+    details: The service tier of the instance.
+    enum:
+      BASIC: standalone instance
+      STANDARD_HA: highly available primary/replica instances
+  - field_name: redis_version
+    type: string
+    details: The version of the instance.
+    enum:
+      "": most recent version
+      REDIS_3_2: Redis 3.2
+  - field_name: host
+    type: string
+    details: Hostname or IP address of the exposed Redis endpoint used by clients to connect to the service.
+  - field_name: port
+    type: string
+    details: The port number of the exposed Redis endpoint.
+bind:
+  plan_inputs: []
+  user_inputs: []
+  computed_inputs: []
+  template: ''
+  outputs: []
+examples:
+- name: Development Configuration
+  description: Create a small Redis instance for development.
+  plan_id: 6ed44104-8777-4b57-8c03-826b3af7d0be
+  provision_params: {"memory_size_gb": 1}
+  bind_params: {}
+- name: HA Configuration
+  description: Create a small, highly available Redis instance for production.
+  plan_id: 8c85c90c-f8e3-4337-9069-c03036243894
+  provision_params: {"memory_size_gb": 1}
+  bind_params: {}

--- a/google-brokers/manifest.yml
+++ b/google-brokers/manifest.yml
@@ -17,3 +17,4 @@ terraform_binaries:
   source: https://github.com/terraform-providers/terraform-provider-google/archive/v1.19.0.zip
 service_definitions:
 - cloud-storage.yml
+- google-redis.yml

--- a/pkg/broker/variables.go
+++ b/pkg/broker/variables.go
@@ -41,7 +41,7 @@ type BrokerVariable struct {
 	// The name of the JSON field this variable serializes/deserializes to
 	FieldName string `yaml:"field_name" validate:"required"`
 	// The JSONSchema type of the field
-	Type JsonType `yaml:"type" validate:"required"`
+	Type JsonType `yaml:"type" validate:"required,jsonschema_type"`
 	// Human readable info about the field.
 	Details string `yaml:"details" validate:"required"`
 	// The default value of the field.

--- a/pkg/providers/tf/wrapper/workspace.go
+++ b/pkg/providers/tf/wrapper/workspace.go
@@ -220,6 +220,8 @@ func (workspace *TerraformWorkspace) teardownFs() error {
 
 // Outputs gets the Terraform outputs from the state for the instance with the
 // given name. This function DOES NOT invoke Terraform and instead uses the stored state.
+// If no instance exists with the given name, it could be that Terraform pruned it due
+// to having no contents so a blank map is returned.
 func (workspace *TerraformWorkspace) Outputs(instance string) (map[string]interface{}, error) {
 	state, err := NewTfstate(workspace.State)
 	if err != nil {
@@ -228,8 +230,10 @@ func (workspace *TerraformWorkspace) Outputs(instance string) (map[string]interf
 
 	// All root project modules get put under the "root" namespace
 	module := state.GetModule("root", instance)
+
+	// Terraform prunes modules with no contents, so we return blank results.
 	if module == nil {
-		return nil, fmt.Errorf("no instance exists with name %q", instance)
+		return map[string]interface{}{}, nil
 	}
 
 	return module.GetOutputs(), nil


### PR DESCRIPTION
Fixes #210 

There are a few other enhancements with this commit:

* brokerpaks get validated on creation
* `tf list` now shows a duration if the operation is in progress so using it with `watch` is more friendly and can point to stalled processes.
* workspace returns an empty map rather than erroring if the tfstate file doesn't contain the contents of a workspace because Terraform prunes empty workspaces.
* brokervariables now get their JSONSchema type validated against the valid types.
