### PR TITLE
remove osdfgen from unit tests

### DIFF
--- a/ci/tasks/go-test.yml
+++ b/ci/tasks/go-test.yml
@@ -10,6 +10,6 @@ inputs:
 run:
   dir: src
   path: go.ash
-  args: ['test', '-v', './...']
+  args: ['test', '-v', './...', '-tags=service_broker']
 params:
   PROJECT_ROOT: github.com/GoogleCloudPlatform/gcp-service-broker

--- a/tools/osdfgen/osdfgen_test.go
+++ b/tools/osdfgen/osdfgen_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !service_broker
+
 package main
 
 import (


### PR DESCRIPTION
osdfgen should not be run during broker unit-tests because the dependencies are intentionally not in the vendor directory and will therefore fail the tests.