### PR TITLE
moved environment variable configuration to a custom executor

### DIFF
--- a/pkg/providers/tf/job_runner.go
+++ b/pkg/providers/tf/job_runner.go
@@ -112,13 +112,15 @@ func (runner *TfJobRunner) hydrateWorkspace(ctx context.Context, deployment *mod
 		return nil, err
 	}
 
-	// set environment variables
-	ws.Environment = map[string]string{
+	// TODO(josephlewis42) don't assume every pak needs Google specific creds
+	// GOOGLE_CREDENTIALS needs to be set to the JSON key and GOOGLE_PROJECT
+	// needs to be set to the project
+	env := map[string]string{
 		"GOOGLE_CREDENTIALS": runner.ServiceAccount,
 		"GOOGLE_PROJECT":     runner.ProjectId,
 	}
 
-	ws.Executor = runner.Executor
+	ws.Executor = wrapper.CustomEnvironmentExecutor(env, runner.Executor)
 
 	logger := utils.NewLogger("job-runner")
 	logger.Info("wrapping", lager.Data{

--- a/pkg/providers/tf/wrapper/workspace_test.go
+++ b/pkg/providers/tf/wrapper/workspace_test.go
@@ -15,6 +15,7 @@
 package wrapper
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -140,5 +141,23 @@ func TestCustomTerraformExecutor(t *testing.T) {
 				t.Errorf("args weren't updated correctly, expected: %#v, actual: %#v", tc.Expected.Args, actual.Args)
 			}
 		})
+	}
+}
+
+func TestCustomEnvironmentExecutor(t *testing.T) {
+	c := exec.Command("/path/to/terraform", "apply")
+	c.Env = []string{"ORIGINAL=value"}
+
+	actual := exec.Command("!actual-never-got-called!")
+	executor := CustomEnvironmentExecutor(map[string]string{"FOO": "bar"}, func(c *exec.Cmd) error {
+		actual = c
+		return nil
+	})
+
+	executor(c)
+	expected := []string{"ORIGINAL=value", "FOO=bar"}
+
+	if !reflect.DeepEqual(expected, actual.Env) {
+		fmt.Errorf("Expected %v actual %v", expected, actual)
 	}
 }


### PR DESCRIPTION
This PR moves environment variable overrides into a separate TerraformExecutor simplifying TerraformWorkspace and allowing environment variable overrides to be tested.

Integration tests with brokerpaks continue working with this change.