### PR TITLE
added ability to set environment variables

### DIFF
--- a/docs/brokerpak-specification.md
+++ b/docs/brokerpak-specification.md
@@ -47,6 +47,7 @@ and which services it will provide.
 | platforms* | array of platform | The platforms this brokerpak will be executed on. |
 | terraform_binaries* | array of Terraform resource | The list of Terraform providers and Terraform that'll be bundled with the brokerpak. |
 | service_definitions* | array of string | Each entry points to a file relative to the manifest that defines a service as part of the brokerpak. |
+| parameters | array of parameter | These values are set as environment variables when Terraform is executed. |
 
 #### Platform object
 
@@ -68,6 +69,15 @@ This structure holds information about a specific Terraform version or Resource.
 | source* | string | The URL to a zip of the source code for the resource. |
 | url_template | string | (optional) A custom URL template to get the release of the given tool. Available parameters are ${name}, ${version}, ${os}, and ${arch}. If unspecified the default Hashicorp Terraform download server is used. |
 
+#### Parameter object
+
+This structure holds information about an environment variable that the user can set on the Terraform instance.
+These variables are first resolved from the configuration of the brokerpak then against a global set of values.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| name* | string | The environment variable that will be injected e.g. `PROJECT_ID`. |
+| description* | string | A human readable description of what the variable represents. |
 
 ### Example
 
@@ -93,6 +103,9 @@ service_definitions:
 - custom-cloud-storage.yml
 - custom-redis.yml
 - service-mesh.yml
+parameters:
+- name: TF_VAR_redis_version
+  description: Set this to override the Redis version globally via injected Terraform variable.
 ```
 
 ## Services

--- a/pkg/brokerpak/cmd_test.go
+++ b/pkg/brokerpak/cmd_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/tf"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils/stream"
 )
@@ -67,6 +66,9 @@ func fakeBrokerpak() (string, error) {
 			},
 		},
 		ServiceDefinitions: []string{"example-service-definition.yml"},
+		Parameters: []ManifestParameter{
+			{Name: "TEST_PARAM", Description: "An example paramater that will be injected into Terraform's environment variables."},
+		},
 	}
 
 	if err := stream.Copy(stream.FromYaml(exampleManifest), stream.ToFile(dir, manifestName)); err != nil {
@@ -119,6 +121,9 @@ func TestFinfo(t *testing.T) {
 		"my-services-pack", // name
 		"1.0.0",            // version
 
+		"Parameters", // heading
+		"TEST_PARAM", // value
+
 		"Dependencies",                   // heading
 		"terraform",                      // dependency
 		"terraform-provider-google-beta", // dependency
@@ -143,7 +148,7 @@ func TestFinfo(t *testing.T) {
 	}
 }
 
-func TestRegisterPak(t *testing.T) {
+func TestRegistryFromLocalBrokerpak(t *testing.T) {
 	pk, err := fakeBrokerpak()
 	defer os.Remove(pk)
 
@@ -156,8 +161,8 @@ func TestRegisterPak(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	registry := broker.BrokerRegistry{}
-	if err := registerPak(NewBrokerpakSourceConfigFromPath(abs), registry); err != nil {
+	registry, err := registryFromLocalBrokerpak(abs)
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/brokerpak/config.go
+++ b/pkg/brokerpak/config.go
@@ -24,6 +24,16 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	brokerpakSourcesKey = "brokerpak.sources"
+	brokerpakConfigKey  = "brokerpak.config"
+)
+
+func init() {
+	viper.SetDefault(brokerpakSourcesKey, "{}")
+	viper.SetDefault(brokerpakConfigKey, "{}")
+}
+
 // BrokerpakSourceConfig represents a single configuration of a brokerpak.
 type BrokerpakSourceConfig struct {
 	// BrokerpakUri holds the URI for loading the Brokerpak.
@@ -73,13 +83,13 @@ func (cfg *ServerConfig) Validate() error {
 // NewServerConfigFromEnv loads the global Brokerpak config from Viper.
 func NewServerConfigFromEnv() (*ServerConfig, error) {
 	paks := map[string]BrokerpakSourceConfig{}
-	sources := viper.GetString("brokerpak.sources")
+	sources := viper.GetString(brokerpakSourcesKey)
 	if err := json.Unmarshal([]byte(sources), &paks); err != nil {
 		return nil, fmt.Errorf("couldn't deserialize brokerpak source config: %v", err)
 	}
 
 	cfg := ServerConfig{
-		Config:     viper.GetString("brokerpak.config"),
+		Config:     viper.GetString(brokerpakConfigKey),
 		Brokerpaks: paks,
 	}
 
@@ -88,4 +98,13 @@ func NewServerConfigFromEnv() (*ServerConfig, error) {
 	}
 
 	return &cfg, nil
+}
+
+func newLocalFileServerConfig(path string) *ServerConfig {
+	return &ServerConfig{
+		Config: viper.GetString(brokerpakConfigKey),
+		Brokerpaks: map[string]BrokerpakSourceConfig{
+			"local-brokerpak": NewBrokerpakSourceConfigFromPath(path),
+		},
+	}
 }

--- a/pkg/brokerpak/manifest.go
+++ b/pkg/brokerpak/manifest.go
@@ -132,7 +132,7 @@ func (m *Manifest) packDefinitions(tmp, base string) error {
 // passed to the executed Terraform instance.
 type ManifestParameter struct {
 	// NOTE: Future fields should take inspiration from the CNAB spec because they
-	// solve a similar problem.https://github.com/deislabs/cnab-spec
+	// solve a similar problem. https://github.com/deislabs/cnab-spec
 	Name        string `yaml:"name" validate:"required"`
 	Description string `yaml:"description" validate:"required"`
 }

--- a/pkg/brokerpak/manifest.go
+++ b/pkg/brokerpak/manifest.go
@@ -40,6 +40,7 @@ type Manifest struct {
 	Platforms          []Platform          `yaml:"platforms" validate:"required,dive"`
 	TerraformResources []TerraformResource `yaml:"terraform_binaries" validate:"required,dive"`
 	ServiceDefinitions []string            `yaml:"service_definitions" validate:"required"`
+	Parameters         []ManifestParameter `yaml:"parameters" validate:"dive"`
 }
 
 // Validate will run struct validation on the fields of this manifest.
@@ -127,6 +128,15 @@ func (m *Manifest) packDefinitions(tmp, base string) error {
 	return stream.Copy(stream.FromYaml(manifestCopy), stream.ToFile(tmp, manifestName))
 }
 
+// ManifestParameter holds environment variables that will be looked up and
+// passed to the executed Terraform instance.
+type ManifestParameter struct {
+	// NOTE: Future fields should take inspiration from the CNAB spec because they
+	// solve a similar problem.https://github.com/deislabs/cnab-spec
+	Name        string `yaml:"name" validate:"required"`
+	Description string `yaml:"description" validate:"required"`
+}
+
 // NewExampleManifest creates a new manifest with sample values for the service broker suitable for giving a user a template to manually edit.
 func NewExampleManifest() Manifest {
 	return Manifest{
@@ -153,5 +163,8 @@ func NewExampleManifest() Manifest {
 			},
 		},
 		ServiceDefinitions: []string{"example-service-definition.yml"},
+		Parameters: []ManifestParameter{
+			{Name: "MY_ENVIRONMENT_VARIABLE", Description: "Set this to whatever you like."},
+		},
 	}
 }

--- a/pkg/brokerpak/registrar.go
+++ b/pkg/brokerpak/registrar.go
@@ -1,0 +1,168 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package brokerpak
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/tf"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/tf/wrapper"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
+	"github.com/spf13/cast"
+)
+
+type registrarWalkFunc func(name string, pak BrokerpakSourceConfig, vc *varcontext.VarContext) error
+
+// Registrar is responsible for registering brokerpaks with BrokerRegistries
+// subject to the settings provided by a ServerConfig like injecting
+// environment variables and skipping certain services.
+type Registrar struct {
+	config *ServerConfig
+}
+
+// Register fetches the brokerpaks and registers them with the given registry.
+func (r *Registrar) Register(registry broker.BrokerRegistry) error {
+	registerLogger := utils.NewLogger("brokerpak-registration")
+
+	return r.walk(func(name string, pak BrokerpakSourceConfig, vc *varcontext.VarContext) error {
+		registerLogger.Info("registering", lager.Data{
+			"name":           name,
+			"excluded-plans": pak.ExcludedPlansSlice(),
+			"prefix":         pak.ServicePrefix,
+		})
+
+		brokerPak, err := DownloadAndOpenBrokerpak(pak.BrokerpakUri)
+		if err != nil {
+			return fmt.Errorf("couldn't open brokerpak: %q: %v", pak.BrokerpakUri, err)
+		}
+		defer brokerPak.Close()
+
+		executor, err := r.createExecutor(brokerPak, vc)
+		if err != nil {
+			return err
+		}
+
+		// register the services
+		services, err := brokerPak.Services()
+		if err != nil {
+			return err
+		}
+
+		defns, err := r.toDefinitions(services, pak, executor)
+		if err != nil {
+			return err
+		}
+
+		for _, defn := range defns {
+			registry.Register(defn)
+		}
+
+		return nil
+	})
+}
+
+func (Registrar) toDefinitions(services []tf.TfServiceDefinitionV1, config BrokerpakSourceConfig, executor wrapper.TerraformExecutor) ([]*broker.ServiceDefinition, error) {
+	var out []*broker.ServiceDefinition
+
+	toIgnore := utils.NewStringSet(config.ExcludedPlansSlice()...)
+	for _, svc := range services {
+		if toIgnore.Contains(svc.Id) {
+			continue
+		}
+
+		svc.Name = config.ServicePrefix + svc.Name
+
+		bs, err := svc.ToService(executor)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, bs)
+	}
+
+	return out, nil
+}
+
+func (r *Registrar) createExecutor(brokerPak *BrokerPakReader, vc *varcontext.VarContext) (wrapper.TerraformExecutor, error) {
+	dir, err := ioutil.TempDir("", "brokerpak")
+	if err != nil {
+		return nil, err
+	}
+
+	// extract the Terraform directory
+	if err := brokerPak.ExtractPlatformBins(dir); err != nil {
+		return nil, err
+	}
+
+	binPath := filepath.Join(dir, "terraform")
+	executor := wrapper.CustomTerraformExecutor(binPath, dir, wrapper.DefaultExecutor)
+
+	manifest, err := brokerPak.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	params := r.resolveParameters(manifest.Parameters, vc)
+	executor = wrapper.CustomEnvironmentExecutor(params, executor)
+
+	return executor, nil
+}
+
+// resolveParameters resolves environment variables from the given global and
+// brokerpak specific
+func (Registrar) resolveParameters(params []ManifestParameter, vc *varcontext.VarContext) map[string]string {
+	out := make(map[string]string)
+
+	context := vc.ToMap()
+	for _, p := range params {
+		val, ok := context[p.Name]
+		if ok {
+			out[p.Name] = cast.ToString(val)
+		}
+	}
+
+	return out
+}
+
+func (r *Registrar) walk(callback registrarWalkFunc) error {
+	for name, pak := range r.config.Brokerpaks {
+		vc, err := varcontext.Builder().
+			MergeJsonObject(json.RawMessage(r.config.Config)).
+			MergeJsonObject(json.RawMessage(pak.Config)).
+			Build()
+
+		if err != nil {
+			return fmt.Errorf("couldn't merge config for brokerpak %q: %v", name, err)
+		}
+
+		if err := callback(name, pak, vc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NewRegistrar constructs a new registrar with the given configuration.
+// Registrar expects to become the owner of the configuration afterwards.
+func NewRegistrar(sc *ServerConfig) *Registrar {
+	return &Registrar{config: sc}
+}

--- a/pkg/brokerpak/registrar.go
+++ b/pkg/brokerpak/registrar.go
@@ -127,7 +127,7 @@ func (r *Registrar) createExecutor(brokerPak *BrokerPakReader, vc *varcontext.Va
 }
 
 // resolveParameters resolves environment variables from the given global and
-// brokerpak specific
+// brokerpak specific.
 func (Registrar) resolveParameters(params []ManifestParameter, vc *varcontext.VarContext) map[string]string {
 	out := make(map[string]string)
 

--- a/pkg/brokerpak/registrar_test.go
+++ b/pkg/brokerpak/registrar_test.go
@@ -1,0 +1,323 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package brokerpak
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/tf"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+)
+
+func TestNewRegistrar(t *testing.T) {
+	// Create a dummy brokerpak
+	pk, err := fakeBrokerpak()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(pk)
+
+	abs, err := filepath.Abs(pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := newLocalFileServerConfig(abs)
+	registry := broker.BrokerRegistry{}
+	err = NewRegistrar(config).Register(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(registry) != 1 {
+		t.Fatal("expected length to be 1 got", len(registry))
+	}
+}
+
+func TestRegistrar_toDefinitions(t *testing.T) {
+	nopExecutor := func(c *exec.Cmd) error {
+		return nil
+	}
+
+	fakeDefn := func(name, id string) tf.TfServiceDefinitionV1 {
+		ex := tf.NewExampleTfServiceDefinition()
+		ex.Id = id
+		ex.Name = "service-" + name
+
+		return ex
+	}
+
+	goodCases := map[string]struct {
+		Services      []tf.TfServiceDefinitionV1
+		Config        BrokerpakSourceConfig
+		ExpectedNames []string
+	}{
+		"straight though": {
+			Services: []tf.TfServiceDefinitionV1{
+				fakeDefn("foo", "b69a96ad-0c38-4e84-84a3-be9513e3c645"),
+				fakeDefn("bar", "f71f1327-2bce-41b4-a833-0ec6430dd7ca"),
+			},
+			Config: BrokerpakSourceConfig{
+				ExcludedPlans: "",
+				ServicePrefix: "",
+			},
+			ExpectedNames: []string{"service-foo", "service-bar"},
+		},
+		"prefix": {
+			Services: []tf.TfServiceDefinitionV1{
+				fakeDefn("foo", "b69a96ad-0c38-4e84-84a3-be9513e3c645"),
+				fakeDefn("bar", "f71f1327-2bce-41b4-a833-0ec6430dd7ca"),
+			},
+			Config: BrokerpakSourceConfig{
+				ExcludedPlans: "",
+				ServicePrefix: "pre-",
+			},
+			ExpectedNames: []string{"pre-service-foo", "pre-service-bar"},
+		},
+		"exclude-foo": {
+			Services: []tf.TfServiceDefinitionV1{
+				fakeDefn("foo", "b69a96ad-0c38-4e84-84a3-be9513e3c645"),
+				fakeDefn("bar", "f71f1327-2bce-41b4-a833-0ec6430dd7ca"),
+			},
+			Config: BrokerpakSourceConfig{
+				ExcludedPlans: "b69a96ad-0c38-4e84-84a3-be9513e3c645",
+				ServicePrefix: "",
+			},
+			ExpectedNames: []string{"service-bar"},
+		},
+	}
+
+	for tn, tc := range goodCases {
+		t.Run(tn, func(t *testing.T) {
+			r := NewRegistrar(nil)
+			defns, err := r.toDefinitions(tc.Services, tc.Config, nopExecutor)
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+
+			var actualNames []string
+			for _, defn := range defns {
+				actualNames = append(actualNames, defn.Name)
+			}
+
+			if !reflect.DeepEqual(actualNames, tc.ExpectedNames) {
+				t.Errorf("Expected names to be %v, got %v", tc.ExpectedNames, actualNames)
+			}
+		})
+	}
+
+	badCases := map[string]struct {
+		Services      []tf.TfServiceDefinitionV1
+		Config        BrokerpakSourceConfig
+		ExpectedError string
+	}{
+		"bad service": {
+			Services: []tf.TfServiceDefinitionV1{
+				fakeDefn("foo", "bad uuid"),
+			},
+			Config:        BrokerpakSourceConfig{},
+			ExpectedError: "Key: 'TfServiceDefinitionV1.Id' Error:Field validation for 'Id' failed on the 'uuid' tag",
+		},
+	}
+
+	for tn, tc := range badCases {
+		t.Run(tn, func(t *testing.T) {
+			r := NewRegistrar(nil)
+			defns, err := r.toDefinitions(tc.Services, tc.Config, nopExecutor)
+			if err == nil {
+				t.Fatal("Expected error, got: <nil>")
+			}
+
+			if defns != nil {
+				t.Errorf("Expected defns to be nil got %v", defns)
+			}
+
+			if err.Error() != tc.ExpectedError {
+				t.Errorf("Expected error to be %q got %v", tc.ExpectedError, err)
+			}
+		})
+	}
+}
+
+func TestRegistrar_resolveParameters(t *testing.T) {
+	r := NewRegistrar(nil)
+
+	cases := map[string]struct {
+		Context  map[string]interface{}
+		Params   []ManifestParameter
+		Expected map[string]string
+	}{
+		"no-params": {
+			Context:  map[string]interface{}{"n": 1, "s": "two", "b": true},
+			Params:   []ManifestParameter{},
+			Expected: map[string]string{},
+		},
+		"missing-in-context": {
+			Context: map[string]interface{}{"n": 1, "s": "two", "b": true},
+			Params: []ManifestParameter{
+				{Name: "foo", Description: "some missing param"},
+			},
+			Expected: map[string]string{},
+		},
+		"contained-in-context": {
+			Context: map[string]interface{}{"n": 1, "s": "two", "b": true},
+			Params: []ManifestParameter{
+				{Name: "s", Description: "a string param"},
+				{Name: "b", Description: "a bool param"},
+				{Name: "n", Description: "a numeric param"},
+			},
+			Expected: map[string]string{"s": "two", "b": "true", "n": "1"},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			vc, err := varcontext.Builder().MergeMap(tc.Context).Build()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual := r.resolveParameters(tc.Params, vc)
+			if !reflect.DeepEqual(actual, tc.Expected) {
+				t.Errorf("Expected params to be: %v got %v", tc.Expected, actual)
+			}
+		})
+	}
+}
+
+func TestRegistrar_walk(t *testing.T) {
+	goodCases := map[string]struct {
+		Config   *ServerConfig
+		Expected map[string]map[string]interface{}
+	}{
+		"basic": {
+			Config: &ServerConfig{
+				Config: `{}`,
+				Brokerpaks: map[string]BrokerpakSourceConfig{
+					"example": {Config: `{}`},
+				},
+			},
+			Expected: map[string]map[string]interface{}{
+				"example": map[string]interface{}{},
+			},
+		},
+		"server-config": {
+			Config: &ServerConfig{
+				Config: `{"foo":"bar"}`,
+				Brokerpaks: map[string]BrokerpakSourceConfig{
+					"example": {Config: `{}`},
+				},
+			},
+			Expected: map[string]map[string]interface{}{
+				"example": map[string]interface{}{"foo": "bar"},
+			},
+		},
+		"override": {
+			Config: &ServerConfig{
+				Config: `{"foo":"bar"}`,
+				Brokerpaks: map[string]BrokerpakSourceConfig{
+					"example": {Config: `{"foo":"bazz"}`},
+				},
+			},
+			Expected: map[string]map[string]interface{}{
+				"example": map[string]interface{}{"foo": "bazz"},
+			},
+		},
+		"additive configs": {
+			Config: &ServerConfig{
+				Config: `{"foo":"bar"}`,
+				Brokerpaks: map[string]BrokerpakSourceConfig{
+					"example": {Config: `{"bar":"bazz"}`},
+				},
+			},
+			Expected: map[string]map[string]interface{}{
+				"example": map[string]interface{}{"foo": "bar", "bar": "bazz"},
+			},
+		},
+	}
+
+	for tn, tc := range goodCases {
+		t.Run(tn, func(t *testing.T) {
+			actual := make(map[string]map[string]interface{})
+			err := NewRegistrar(tc.Config).walk(func(name string, pak BrokerpakSourceConfig, vc *varcontext.VarContext) error {
+				actual[name] = vc.ToMap()
+				return nil
+			})
+
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.Expected, actual) {
+				t.Errorf("Expected %v got %v", tc.Expected, actual)
+			}
+		})
+	}
+
+	badCases := map[string]struct {
+		Config   *ServerConfig
+		Expected string
+	}{
+		"bad global config": {
+			Config: &ServerConfig{
+				Config: `a`,
+				Brokerpaks: map[string]BrokerpakSourceConfig{
+					"example": {Config: `{}`},
+				},
+			},
+			Expected: "couldn't merge config for brokerpak \"example\": 1 error(s) occurred: invalid character 'a' looking for beginning of value",
+		},
+		"bad local config": {
+			Config: &ServerConfig{
+				Config: `{}`,
+				Brokerpaks: map[string]BrokerpakSourceConfig{
+					"example": {Config: `b`},
+				},
+			},
+			Expected: "couldn't merge config for brokerpak \"example\": 1 error(s) occurred: invalid character 'b' looking for beginning of value",
+		},
+		"walk error": {
+			Config: &ServerConfig{
+				Config: `{}`,
+				Brokerpaks: map[string]BrokerpakSourceConfig{
+					"example": {Config: `{}`},
+				},
+			},
+			Expected: "walk raised error",
+		},
+	}
+
+	for tn, tc := range badCases {
+		t.Run(tn, func(t *testing.T) {
+			err := NewRegistrar(tc.Config).walk(func(name string, pak BrokerpakSourceConfig, vc *varcontext.VarContext) error {
+				return errors.New("walk raised error")
+			})
+
+			if err == nil {
+				t.Fatalf("expected error %q, got: nil", tc.Expected)
+			}
+
+			if tc.Expected != err.Error() {
+				t.Errorf("Expected: %q got: %q", tc.Expected, err.Error())
+			}
+		})
+	}
+}

--- a/pkg/brokerpak/registrar_test.go
+++ b/pkg/brokerpak/registrar_test.go
@@ -48,7 +48,7 @@ func TestNewRegistrar(t *testing.T) {
 	}
 
 	if len(registry) != 1 {
-		t.Fatal("expected length to be 1 got", len(registry))
+		t.Fatal("Expected length to be 1 got", len(registry))
 	}
 }
 
@@ -263,7 +263,7 @@ func TestRegistrar_walk(t *testing.T) {
 			})
 
 			if err != nil {
-				t.Fatalf("expected no error, got: %v", err)
+				t.Fatalf("Expected no error, got: %v", err)
 			}
 
 			if !reflect.DeepEqual(tc.Expected, actual) {
@@ -312,7 +312,7 @@ func TestRegistrar_walk(t *testing.T) {
 			})
 
 			if err == nil {
-				t.Fatalf("expected error %q, got: nil", tc.Expected)
+				t.Fatalf("Expected error %q, got: nil", tc.Expected)
 			}
 
 			if tc.Expected != err.Error() {


### PR DESCRIPTION
Fixes #387

This adds support for injecting custom environment variables into Terraform. We won't use this feature immediately, but it is something that's needed for people building paks that need credentials other than Google's and is our path towards multi-project support.