### PR TITLE
naming mistake, plans -> services

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1384,7 +1384,7 @@ To specify a custom plan manually, create the plan as JSON in a JSON array and s
 
 For example:
 <code>
-[{"id":"00000000-0000-0000-0000-000000000000", "name": "custom-plan-1", "uri": setme, "service_prefix": setme, "excluded_plans": setme, "config": setme, "notes": setme},...]
+[{"id":"00000000-0000-0000-0000-000000000000", "name": "custom-plan-1", "uri": setme, "service_prefix": setme, "excluded_services": setme, "config": setme, "notes": setme},...]
 </code>
 
 <table>
@@ -1451,11 +1451,11 @@ For example:
 </tr>
 
 <tr>
-  <td><tt>excluded_plans</tt></td>
+  <td><tt>excluded_services</tt></td>
   <td><i>text</i></td>
-  <td>Excluded Plans</td>
+  <td>Excluded Services</td>
   <td>
-  A list of UUIDs of plans to exclude, one per line.
+  A list of UUIDs of services to exclude, one per line.
 
 
 <ul>

--- a/pkg/brokerpak/config.go
+++ b/pkg/brokerpak/config.go
@@ -40,22 +40,22 @@ type BrokerpakSourceConfig struct {
 	BrokerpakUri string `json:"uri" validate:"required,uri"`
 	// ServicePrefix holds an optional prefix that will be prepended to every service name.
 	ServicePrefix string `json:"service_prefix" validate:"omitempty,osbname"`
-	// ExcludedPlans holds a newline delimited list of service plan UUIDs that will be excluded at registration time.
-	ExcludedPlans string `json:"excluded_plans"`
+	// ExcludedServices holds a newline delimited list of service UUIDs that will be excluded at registration time.
+	ExcludedServices string `json:"excluded_services"`
 	// Config holds the configuration options for the Brokerpak as a JSON object.
 	Config string `json:"config" validate:"required,json"`
 	// Notes holds user-defined notes about the Brokerpak and shouldn't be used programatically.
 	Notes string `json:"notes"`
 }
 
-// ExcludedPlansSlice gets the ExcludedPlans as a slice of UUIDs.
-func (b *BrokerpakSourceConfig) ExcludedPlansSlice() []string {
-	return utils.SplitNewlineDelimitedList(b.ExcludedPlans)
+// ExcludedServicesSlice gets the ExcludedServices as a slice of UUIDs.
+func (b *BrokerpakSourceConfig) ExcludedServicesSlice() []string {
+	return utils.SplitNewlineDelimitedList(b.ExcludedServices)
 }
 
-// SetExcludedPlans sets the ExcludedPlans from a slice of UUIDs.
-func (b *BrokerpakSourceConfig) SetExcludedPlans(plans []string) {
-	b.ExcludedPlans = strings.Join(plans, "\n")
+// SetExcludedServices sets the ExcludedServices from a slice of UUIDs.
+func (b *BrokerpakSourceConfig) SetExcludedServices(services []string) {
+	b.ExcludedServices = strings.Join(services, "\n")
 }
 
 // NewBrokerpakSourceConfigFromPath creates a new BrokerpakSourceConfig from a path.

--- a/pkg/brokerpak/config_test.go
+++ b/pkg/brokerpak/config_test.go
@@ -37,28 +37,28 @@ func TestNewBrokerpakSourceConfigFromPath(t *testing.T) {
 		}
 	})
 
-	t.Run("has-no-excluded-plans-by-default", func(t *testing.T) {
+	t.Run("has-no-excluded-services-by-default", func(t *testing.T) {
 		cfg := NewBrokerpakSourceConfigFromPath("/path/to/my/pak.brokerpak")
-		if cfg.ExcludedPlans != "" {
-			t.Fatalf("Expected no excluded plans, got: %v", cfg.ExcludedPlans)
+		if cfg.ExcludedServices != "" {
+			t.Fatalf("Expected no excluded services, got: %v", cfg.ExcludedServices)
 		}
 	})
 }
 
-func ExampleBrokerpakSourceConfig_ExcludedPlansSlice() {
-	cfg := BrokerpakSourceConfig{ExcludedPlans: "FOO\nBAR"}
+func ExampleBrokerpakSourceConfig_ExcludedServicesSlice() {
+	cfg := BrokerpakSourceConfig{ExcludedServices: "FOO\nBAR"}
 
-	fmt.Println(cfg.ExcludedPlansSlice())
+	fmt.Println(cfg.ExcludedServicesSlice())
 
 	// Output: [FOO BAR]
 }
 
-func ExampleBrokerpakSourceConfig_SetExcludedPlans() {
+func ExampleBrokerpakSourceConfig_SetExcludedServices() {
 	cfg := BrokerpakSourceConfig{}
-	cfg.SetExcludedPlans([]string{"plan1", "plan2"})
+	cfg.SetExcludedServices([]string{"plan1", "plan2"})
 
-	fmt.Println("slice:", cfg.ExcludedPlansSlice())
-	fmt.Println("text:", cfg.ExcludedPlans)
+	fmt.Println("slice:", cfg.ExcludedServicesSlice())
+	fmt.Println("text:", cfg.ExcludedServices)
 
 	// Output: slice: [plan1 plan2]
 	// text: plan1

--- a/pkg/brokerpak/registrar.go
+++ b/pkg/brokerpak/registrar.go
@@ -44,9 +44,9 @@ func (r *Registrar) Register(registry broker.BrokerRegistry) error {
 
 	return r.walk(func(name string, pak BrokerpakSourceConfig, vc *varcontext.VarContext) error {
 		registerLogger.Info("registering", lager.Data{
-			"name":           name,
-			"excluded-plans": pak.ExcludedPlansSlice(),
-			"prefix":         pak.ServicePrefix,
+			"name":              name,
+			"excluded-services": pak.ExcludedServicesSlice(),
+			"prefix":            pak.ServicePrefix,
 		})
 
 		brokerPak, err := DownloadAndOpenBrokerpak(pak.BrokerpakUri)
@@ -82,7 +82,7 @@ func (r *Registrar) Register(registry broker.BrokerRegistry) error {
 func (Registrar) toDefinitions(services []tf.TfServiceDefinitionV1, config BrokerpakSourceConfig, executor wrapper.TerraformExecutor) ([]*broker.ServiceDefinition, error) {
 	var out []*broker.ServiceDefinition
 
-	toIgnore := utils.NewStringSet(config.ExcludedPlansSlice()...)
+	toIgnore := utils.NewStringSet(config.ExcludedServicesSlice()...)
 	for _, svc := range services {
 		if toIgnore.Contains(svc.Id) {
 			continue

--- a/pkg/brokerpak/registrar_test.go
+++ b/pkg/brokerpak/registrar_test.go
@@ -76,7 +76,7 @@ func TestRegistrar_toDefinitions(t *testing.T) {
 				fakeDefn("bar", "f71f1327-2bce-41b4-a833-0ec6430dd7ca"),
 			},
 			Config: BrokerpakSourceConfig{
-				ExcludedPlans: "",
+				ExcludedServices: "",
 				ServicePrefix: "",
 			},
 			ExpectedNames: []string{"service-foo", "service-bar"},
@@ -87,7 +87,7 @@ func TestRegistrar_toDefinitions(t *testing.T) {
 				fakeDefn("bar", "f71f1327-2bce-41b4-a833-0ec6430dd7ca"),
 			},
 			Config: BrokerpakSourceConfig{
-				ExcludedPlans: "",
+				ExcludedServices: "",
 				ServicePrefix: "pre-",
 			},
 			ExpectedNames: []string{"pre-service-foo", "pre-service-bar"},
@@ -98,7 +98,7 @@ func TestRegistrar_toDefinitions(t *testing.T) {
 				fakeDefn("bar", "f71f1327-2bce-41b4-a833-0ec6430dd7ca"),
 			},
 			Config: BrokerpakSourceConfig{
-				ExcludedPlans: "b69a96ad-0c38-4e84-84a3-be9513e3c645",
+				ExcludedServices: "b69a96ad-0c38-4e84-84a3-be9513e3c645",
 				ServicePrefix: "",
 			},
 			ExpectedNames: []string{"service-bar"},

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -384,10 +384,10 @@ func brokerpakConfigurationForm() Form {
 				Configurable: true,
 			},
 			{
-				Name:         "excluded_plans",
-				Label:        "Excluded Plans",
+				Name:         "excluded_services",
+				Label:        "Excluded Services",
 				Type:         "text",
-				Description:  "A list of UUIDs of plans to exclude, one per line.",
+				Description:  "A list of UUIDs of services to exclude, one per line.",
 				Optional:     true,
 				Configurable: true,
 			},

--- a/tile.yml
+++ b/tile.yml
@@ -663,10 +663,10 @@ service_plan_forms:
       you may want to include a trailing dash.
     configurable: true
     optional: true
-  - name: excluded_plans
+  - name: excluded_services
     type: text
-    label: Excluded Plans
-    description: A list of UUIDs of plans to exclude, one per line.
+    label: Excluded Services
+    description: A list of UUIDs of services to exclude, one per line.
     configurable: true
     optional: true
   - name: config


### PR DESCRIPTION
Requesting one review, renamed plans -> services to accurately reflect what the field is being used for.