### PR TITLE
Remove default registry

### DIFF
--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the ML service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"ml.developer",

--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
+func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"ml.developer",
 		"ml.viewer",
@@ -33,7 +33,7 @@ func init() {
 		"ml.operationOwner",
 	}
 
-	bs := &broker.ServiceDefinition{
+	return &broker.ServiceDefinition{
 		Name: models.MlName,
 		DefaultServiceDefinition: `
 		{
@@ -83,6 +83,4 @@ func init() {
 			return &ApiServiceBroker{BrokerBase: bb}
 		},
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -25,11 +25,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
-	broker.Register(serviceDefinition())
-}
-
-func serviceDefinition() *broker.ServiceDefinition {
+func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"bigquery.dataViewer",
 		"bigquery.dataEditor",

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the BigQuery service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"bigquery.dataViewer",

--- a/brokerapi/brokers/bigtable/broker_test.go
+++ b/brokerapi/brokers/bigtable/broker_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestBigTableBroker_ProvisionVariables(t *testing.T) {
-	service := serviceDefinition()
+	service := ServiceDefinition()
 
 	hddPlan := "65a49268-2c73-481e-80f3-9fde5bd5a654"
 	ssdPlan := "38aa0e65-624b-4998-9c06-f9194b56d252"

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -24,11 +24,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
-	broker.Register(serviceDefinition())
-}
-
-func serviceDefinition() *broker.ServiceDefinition {
+func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"bigtable.user",
 		"bigtable.reader",

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the Bigtable service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"bigtable.user",

--- a/brokerapi/brokers/broker_config.go
+++ b/brokerapi/brokers/broker_config.go
@@ -15,7 +15,11 @@
 package brokers
 
 import (
+	"fmt"
+
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/brokerpak"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/toggles"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"golang.org/x/oauth2/jwt"
@@ -41,10 +45,15 @@ func NewBrokerConfigFromEnv() (*BrokerConfig, error) {
 		return nil, err
 	}
 
+	registry := builtin.BuiltinBrokerRegistry()
+	if err := brokerpak.RegisterAll(registry); err != nil {
+		return nil, fmt.Errorf("Error loading brokerpaks: %v", err)
+	}
+
 	return &BrokerConfig{
 		ProjectId:             projectId,
 		HttpConfig:            conf,
 		EnableInputValidation: enableInputValidation.IsActive(),
-		Registry:              broker.DefaultRegistry,
+		Registry:              registry,
 	}, nil
 }

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker/brokerfakes"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 
@@ -81,11 +82,11 @@ var _ = Describe("Brokers", func() {
 		os.Setenv("SECURITY_USER_NAME", "username")
 		os.Setenv("SECURITY_USER_PASSWORD", "password")
 
-		registry := broker.BrokerRegistry{}
-		for name, defn := range broker.DefaultRegistry {
-			copy := *defn
-			registry[name] = &copy
-		}
+		registry := builtin.BuiltinBrokerRegistry()
+		// for name, defn := range broker.DefaultRegistry {
+		// 	copy := *defn
+		// 	registry[name] = &copy
+		// }
 		brokerConfig, err = NewBrokerConfigFromEnv()
 		Expect(err).To(BeNil())
 		brokerConfig.Registry = registry
@@ -189,7 +190,8 @@ var _ = Describe("Brokers", func() {
 			serviceList, err := gcpBroker.Services(context.Background())
 			Expect(err).ToNot(HaveOccurred())
 
-			enabledServices, err := broker.GetEnabledServices()
+			builtinRegistry := builtin.BuiltinBrokerRegistry()
+			enabledServices, err := builtinRegistry.GetEnabledServices()
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(len(serviceList)).To(Equal(len(enabledServices)))

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -83,10 +83,6 @@ var _ = Describe("Brokers", func() {
 		os.Setenv("SECURITY_USER_PASSWORD", "password")
 
 		registry := builtin.BuiltinBrokerRegistry()
-		// for name, defn := range broker.DefaultRegistry {
-		// 	copy := *defn
-		// 	registry[name] = &copy
-		// }
 		brokerConfig, err = NewBrokerConfigFromEnv()
 		Expect(err).To(BeNil())
 		brokerConfig.Registry = registry

--- a/brokerapi/brokers/cloudsql/broker.go
+++ b/brokerapi/brokers/cloudsql/broker.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/broker_base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
 
@@ -221,15 +220,11 @@ func (b *CloudSQLBroker) Bind(ctx context.Context, vc *varcontext.VarContext) (m
 }
 
 func (b *CloudSQLBroker) BuildInstanceCredentials(ctx context.Context, bindRecord models.ServiceBindingCredentials, instanceRecord models.ServiceInstanceDetails) (map[string]interface{}, error) {
-	service, err := broker.GetServiceById(instanceRecord.ServiceId)
-	if err != nil {
-		return nil, err
-	}
 	uriFormat := ""
-	switch service.Name {
-	case models.CloudsqlMySQLName:
+	switch instanceRecord.ServiceId {
+	case MySqlServiceId:
 		uriFormat = `${str.queryEscape(UriPrefix)}mysql://${str.queryEscape(Username)}:${str.queryEscape(Password)}@${str.queryEscape(host)}/${str.queryEscape(database_name)}?ssl_mode=required`
-	case models.CloudsqlPostgresName:
+	case PostgresServiceId:
 		uriFormat = `${str.queryEscape(UriPrefix)}postgres://${str.queryEscape(Username)}:${str.queryEscape(Password)}@${str.queryEscape(host)}/${str.queryEscape(database_name)}?sslmode=require&sslcert=${str.queryEscape(ClientCert)}&sslkey=${str.queryEscape(ClientKey)}&sslrootcert=${str.queryEscape(CaCert)}`
 	default:
 		return map[string]interface{}{}, errors.New("Unknown service")

--- a/brokerapi/brokers/cloudsql/broker_test.go
+++ b/brokerapi/brokers/cloudsql/broker_test.go
@@ -62,7 +62,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		ErrContains string
 	}{
 		"blank instance names get generated": {
-			Service:    mysqlServiceDefinition(),
+			Service:    MysqlServiceDefinition(),
 			PlanId:     mysqlFirstgenPlan,
 			UserParams: `{"instance_name":""}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -73,7 +73,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		},
 
 		"tiers matching (D|d)\\d+ get firstgen outputs for MySQL": {
-			Service:    mysqlServiceDefinition(),
+			Service:    MysqlServiceDefinition(),
 			PlanId:     mysqlFirstgenPlan,
 			UserParams: `{"name":""}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -84,7 +84,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		},
 
 		"first-gen MySQL defaults": {
-			Service:    mysqlServiceDefinition(),
+			Service:    MysqlServiceDefinition(),
 			PlanId:     mysqlFirstgenPlan,
 			UserParams: `{}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -106,7 +106,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 			},
 		},
 		"second-gen MySQL defaults": {
-			Service:    mysqlServiceDefinition(),
+			Service:    MysqlServiceDefinition(),
 			PlanId:     mysqlSecondGenPlan,
 			UserParams: `{}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -128,7 +128,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 			},
 		},
 		"PostgreSQL defaults": {
-			Service:    postgresServiceDefinition(),
+			Service:    PostgresServiceDefinition(),
 			PlanId:     postgresPlan,
 			UserParams: `{}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -151,7 +151,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		},
 
 		"partial maintenance window day": {
-			Service:    mysqlServiceDefinition(),
+			Service:    MysqlServiceDefinition(),
 			PlanId:     mysqlSecondGenPlan,
 			UserParams: `{"maintenance_window_day":"4"}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -166,7 +166,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		},
 
 		"partial maintenance window hour": {
-			Service:    mysqlServiceDefinition(),
+			Service:    MysqlServiceDefinition(),
 			PlanId:     mysqlSecondGenPlan,
 			UserParams: `{"maintenance_window_hour":"23"}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -181,7 +181,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		},
 
 		"full maintenance window ": {
-			Service:    mysqlServiceDefinition(),
+			Service:    MysqlServiceDefinition(),
 			PlanId:     mysqlSecondGenPlan,
 			UserParams: `{"maintenance_window_day":"4","maintenance_window_hour":"23"}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -200,7 +200,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		},
 
 		"instance info generates db on blank ": {
-			Service:    mysqlServiceDefinition(),
+			Service:    MysqlServiceDefinition(),
 			PlanId:     mysqlSecondGenPlan,
 			UserParams: `{"database_name":""}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -211,7 +211,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		},
 
 		"instance info has name and db name ": {
-			Service:    mysqlServiceDefinition(),
+			Service:    MysqlServiceDefinition(),
 			PlanId:     mysqlSecondGenPlan,
 			UserParams: `{"database_name":"foo", "instance_name": "bar"}`,
 			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
@@ -226,7 +226,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		},
 
 		"mysql disk size greater than operator specified max fails": {
-			Service:     mysqlServiceDefinition(),
+			Service:     MysqlServiceDefinition(),
 			PlanId:      mysqlSecondGenPlan,
 			UserParams:  `{"disk_size":"99999"}`,
 			Validate:    func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {},
@@ -234,7 +234,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 		},
 
 		"postgres disk size greater than operator specified max fails": {
-			Service:     postgresServiceDefinition(),
+			Service:     PostgresServiceDefinition(),
 			PlanId:      postgresPlan,
 			UserParams:  `{"disk_size":"99999"}`,
 			Validate:    func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {},
@@ -282,7 +282,7 @@ func TestCreateProvisionRequest(t *testing.T) {
 }
 
 func TestPostgresCustomMachineTypes(t *testing.T) {
-	sd, err := postgresServiceDefinition().ServiceDefinition()
+	sd, err := PostgresServiceDefinition().ServiceDefinition()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -26,6 +26,7 @@ import (
 
 const MySqlServiceId = "4bc59b9a-8520-409f-85da-1c7552315863"
 
+// MysqlServiceDefinition creates a new ServiceDefinition object for the Bigtable service.
 func MysqlServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: models.CloudsqlMySQLName,

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -24,11 +24,9 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
-	broker.Register(mysqlServiceDefinition())
-}
+const MySqlServiceId = "4bc59b9a-8520-409f-85da-1c7552315863"
 
-func mysqlServiceDefinition() *broker.ServiceDefinition {
+func MysqlServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: models.CloudsqlMySQLName,
 		DefaultServiceDefinition: `{

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -24,11 +24,9 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
-	broker.Register(postgresServiceDefinition())
-}
+const PostgresServiceId = "cbad6d78-a73c-432d-b8ff-b219a17a803a"
 
-func postgresServiceDefinition() *broker.ServiceDefinition {
+func PostgresServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: models.CloudsqlPostgresName,
 		DefaultServiceDefinition: `{

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -26,6 +26,7 @@ import (
 
 const PostgresServiceId = "cbad6d78-a73c-432d-b8ff-b219a17a803a"
 
+// PostgresServiceDefinition creates a new ServiceDefinition object for the PostgreSQL service.
 func PostgresServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: models.CloudsqlPostgresName,

--- a/brokerapi/brokers/dataflow/definition.go
+++ b/brokerapi/brokers/dataflow/definition.go
@@ -22,10 +22,10 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
+func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{"dataflow.viewer", "dataflow.developer"}
 
-	bs := &broker.ServiceDefinition{
+	return &broker.ServiceDefinition{
 		Name: "google-dataflow",
 		DefaultServiceDefinition: `{
       "id": "3e897eb3-9062-4966-bd4f-85bda0f73b3d",
@@ -76,6 +76,4 @@ func init() {
 			return &DataflowBroker{BrokerBase: bb}
 		},
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/dataflow/definition.go
+++ b/brokerapi/brokers/dataflow/definition.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the Dataflow service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{"dataflow.viewer", "dataflow.developer"}
 

--- a/brokerapi/brokers/datastore/definition.go
+++ b/brokerapi/brokers/datastore/definition.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the Datastore service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: "google-datastore",

--- a/brokerapi/brokers/datastore/definition.go
+++ b/brokerapi/brokers/datastore/definition.go
@@ -23,8 +23,8 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
-	bs := &broker.ServiceDefinition{
+func ServiceDefinition() *broker.ServiceDefinition {
+	return &broker.ServiceDefinition{
 		Name: "google-datastore",
 		DefaultServiceDefinition: `{
       "id": "76d4abb2-fee7-4c8f-aee1-bcea2837f02b",
@@ -98,6 +98,4 @@ func init() {
 			return &DatastoreBroker{BrokerBase: bb}
 		},
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/dialogflow/definition.go
+++ b/brokerapi/brokers/dialogflow/definition.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the Dialogflow service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: "google-dialogflow",

--- a/brokerapi/brokers/dialogflow/definition.go
+++ b/brokerapi/brokers/dialogflow/definition.go
@@ -22,8 +22,8 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
-	bs := &broker.ServiceDefinition{
+func ServiceDefinition() *broker.ServiceDefinition {
+	return &broker.ServiceDefinition{
 		Name: "google-dialogflow",
 		DefaultServiceDefinition: `{
       "id": "e84b69db-3de9-4688-8f5c-26b9d5b1f129",
@@ -67,6 +67,4 @@ func init() {
 			return &DialogflowBroker{BrokerBase: bb}
 		},
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/firestore/definition.go
+++ b/brokerapi/brokers/firestore/definition.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the Firestore service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	// NOTE(jlewisiii) Firestore has some intentional differences from other services.
 	// First, it doesn't require legacy compatibility so we won't allow operators to override the whitelist.

--- a/brokerapi/brokers/firestore/definition.go
+++ b/brokerapi/brokers/firestore/definition.go
@@ -22,11 +22,11 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
+func ServiceDefinition() *broker.ServiceDefinition {
 	// NOTE(jlewisiii) Firestore has some intentional differences from other services.
 	// First, it doesn't require legacy compatibility so we won't allow operators to override the whitelist.
 	// Second, Firestore uses the old datastore IAM role model so the roles will look strange.
-	bs := &broker.ServiceDefinition{
+	return &broker.ServiceDefinition{
 		Name: "google-firestore",
 		DefaultServiceDefinition: `{
       "id": "a2b7b873-1e34-4530-8a42-902ff7d66b43",
@@ -78,6 +78,4 @@ func init() {
 			return &FirestoreBroker{BrokerBase: bb}
 		},
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -72,7 +72,7 @@ func New(cfg *BrokerConfig, logger lager.Logger) (*GCPServiceBroker, error) {
 func (gcpBroker *GCPServiceBroker) Services(ctx context.Context) ([]brokerapi.Service, error) {
 	svcs := []brokerapi.Service{}
 
-	enabledServices, err := broker.GetEnabledServices()
+	enabledServices, err := gcpBroker.registry.GetEnabledServices()
 	if err != nil {
 		return nil, err
 	}

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -28,21 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
-
-	// import the brokers to register them
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/api_service"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/bigquery"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/bigtable"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/cloudsql"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/dataflow"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/datastore"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/dialogflow"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/firestore"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/pubsub"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/spanner"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/stackdriver"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/storage"
-	_ "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/tf"
 )
 
 // GCPServiceBroker is a brokerapi.ServiceBroker that can be used to generate an OSB compatible service broker.

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the Pub/Sub service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"pubsub.publisher",

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -25,11 +25,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
-	broker.Register(serviceDefinition())
-}
-
-func serviceDefinition() *broker.ServiceDefinition {
+func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"pubsub.publisher",
 		"pubsub.subscriber",

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the Spanner service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"spanner.databaseAdmin",

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -25,11 +25,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
-	broker.Register(serviceDefinition())
-}
-
-func serviceDefinition() *broker.ServiceDefinition {
+func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"spanner.databaseAdmin",
 		"spanner.databaseReader",

--- a/brokerapi/brokers/stackdriver/debugger_definition.go
+++ b/brokerapi/brokers/stackdriver/debugger_definition.go
@@ -19,8 +19,8 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
-func init() {
-	bs := &broker.ServiceDefinition{
+func StackdriverDebuggerServiceDefinition() *broker.ServiceDefinition {
+	return &broker.ServiceDefinition{
 		Name: "google-stackdriver-debugger",
 		DefaultServiceDefinition: `{
 		      "id": "83837945-1547-41e0-b661-ea31d76eed11",
@@ -63,6 +63,4 @@ func init() {
 		},
 		ProviderBuilder: NewStackdriverAccountProvider,
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/stackdriver/debugger_definition.go
+++ b/brokerapi/brokers/stackdriver/debugger_definition.go
@@ -19,6 +19,8 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
+// StackdriverDebuggerServiceDefinition creates a new ServiceDefinition object
+// for the Stackdriver Debugger service.
 func StackdriverDebuggerServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: "google-stackdriver-debugger",

--- a/brokerapi/brokers/stackdriver/monitoring_definition.go
+++ b/brokerapi/brokers/stackdriver/monitoring_definition.go
@@ -19,8 +19,8 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
-func init() {
-	bs := &broker.ServiceDefinition{
+func StackdriverMonitoringServiceDefinition() *broker.ServiceDefinition {
+	return &broker.ServiceDefinition{
 		Name: "google-stackdriver-monitoring",
 		DefaultServiceDefinition: `{
       "id": "2bc0d9ed-3f68-4056-b842-4a85cfbc727f",
@@ -62,6 +62,4 @@ func init() {
 		},
 		ProviderBuilder: NewStackdriverAccountProvider,
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/stackdriver/monitoring_definition.go
+++ b/brokerapi/brokers/stackdriver/monitoring_definition.go
@@ -19,6 +19,8 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
+// StackdriverMonitoringServiceDefinition creates a new ServiceDefinition object
+// for the Stackdriver Monitoring service.
 func StackdriverMonitoringServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: "google-stackdriver-monitoring",

--- a/brokerapi/brokers/stackdriver/profiler_definition.go
+++ b/brokerapi/brokers/stackdriver/profiler_definition.go
@@ -19,6 +19,8 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
+// StackdriverProfilerServiceDefinition creates a new ServiceDefinition object
+// for the Stackdriver Profiler service.
 func StackdriverProfilerServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: "google-stackdriver-profiler",

--- a/brokerapi/brokers/stackdriver/profiler_definition.go
+++ b/brokerapi/brokers/stackdriver/profiler_definition.go
@@ -19,8 +19,8 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
-func init() {
-	bs := &broker.ServiceDefinition{
+func StackdriverProfilerServiceDefinition() *broker.ServiceDefinition {
+	return &broker.ServiceDefinition{
 		Name: "google-stackdriver-profiler",
 		DefaultServiceDefinition: `{
 		      "id": "00b9ca4a-7cd6-406a-a5b7-2f43f41ade75",
@@ -63,6 +63,4 @@ func init() {
 		},
 		ProviderBuilder: NewStackdriverAccountProvider,
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/stackdriver/trace_definition.go
+++ b/brokerapi/brokers/stackdriver/trace_definition.go
@@ -19,8 +19,8 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
-func init() {
-	bs := &broker.ServiceDefinition{
+func StackdriverTraceServiceDefinition() *broker.ServiceDefinition {
+	return &broker.ServiceDefinition{
 		Name: "google-stackdriver-trace",
 		DefaultServiceDefinition: `{
       "id": "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a",
@@ -63,6 +63,4 @@ func init() {
 		},
 		ProviderBuilder: NewStackdriverAccountProvider,
 	}
-
-	broker.Register(bs)
 }

--- a/brokerapi/brokers/stackdriver/trace_definition.go
+++ b/brokerapi/brokers/stackdriver/trace_definition.go
@@ -19,6 +19,8 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
+// StackdriverTraceServiceDefinition creates a new ServiceDefinition object
+// for the Stackdriver Trace service.
 func StackdriverTraceServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Name: "google-stackdriver-trace",

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
+// ServiceDefinition creates a new ServiceDefinition object for the Cloud Storage service.
 func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"storage.objectCreator",

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -25,11 +25,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func init() {
-	broker.Register(serviceDefinition())
-}
-
-func serviceDefinition() *broker.ServiceDefinition {
+func ServiceDefinition() *broker.ServiceDefinition {
 	roleWhitelist := []string{
 		"storage.objectCreator",
 		"storage.objectViewer",

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -18,8 +18,8 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/client"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/spf13/cobra"
 )
@@ -121,7 +121,7 @@ user-defined plans.
 				log.Fatalf("Error creating client: %v", err)
 			}
 
-			if err := client.RunExamplesForService(broker.DefaultRegistry, apiClient, serviceName); err != nil {
+			if err := client.RunExamplesForService(builtin.BuiltinBrokerRegistry(), apiClient, serviceName); err != nil {
 				log.Fatalf("Error executing examples: %v", err)
 			}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -17,8 +17,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/generator"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +43,7 @@ func init() {
 
 	`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(generator.CatalogDocumentation(broker.DefaultRegistry))
+			fmt.Println(generator.CatalogDocumentation(builtin.BuiltinBrokerRegistry()))
 		},
 	})
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -22,8 +22,6 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/brokerpak"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/compatibility"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/server"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/toggles"
@@ -71,10 +69,6 @@ func serve() {
 
 	db_service.New(logger)
 
-	if err := brokerpak.RegisterAll(broker.DefaultRegistry); err != nil {
-		logger.Fatal("Error loading brokerpaks: %v", err)
-	}
-
 	// init broker
 	cfg, err := brokers.NewBrokerConfigFromEnv()
 	if err != nil {
@@ -120,6 +114,6 @@ func serve() {
 
 	brokerAPI := brokerapi.New(serviceBroker, logger, credentials)
 	http.Handle("/", brokerAPI)
-	http.Handle("/docs", server.NewDocsHandler(broker.DefaultRegistry))
+	http.Handle("/docs", server.NewDocsHandler(cfg.Registry))
 	http.ListenAndServe(":"+port, nil)
 }

--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/models"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/jinzhu/gorm"
 	googlecloudsql "google.golang.org/api/sqladmin/v1beta4"
@@ -70,6 +70,7 @@ func RunMigrations(db *gorm.DB) error {
 			return fmt.Errorf("couldn't get Project ID for database upgrades %s", err)
 		}
 
+		builtinServices := builtin.BuiltinBrokerRegistry()
 		for _, pr := range prs {
 			var si models.ServiceInstanceDetailsV1
 			if err := db.Where("id = ?", pr.ServiceInstanceId).First(&si).Error; err != nil {
@@ -82,7 +83,7 @@ func RunMigrations(db *gorm.DB) error {
 			newOd := make(map[string]string)
 
 			// cloudsql
-			svc, err := broker.GetServiceById(si.ServiceId)
+			svc, err := builtinServices.GetServiceById(si.ServiceId)
 			if err != nil {
 				return err
 			}

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -42,12 +42,8 @@ var (
 // by the GCP Service Broker.
 type BrokerRegistry map[string]*ServiceDefinition
 
-// DefaultRegistry is the broker registry all service broker definitions implicitly register with.
-var DefaultRegistry = BrokerRegistry{}
-
 // Registers a ServiceDefinition with the service registry that various commands
 // poll to create the catalog, documentation, etc.
-func Register(service *ServiceDefinition) { DefaultRegistry.Register(service) }
 func (brokerRegistry BrokerRegistry) Register(service *ServiceDefinition) {
 	name := service.Name
 
@@ -77,7 +73,6 @@ func (brokerRegistry BrokerRegistry) Register(service *ServiceDefinition) {
 
 // GetEnabledServices returns a list of all registered brokers that the user
 // has enabled the use of.
-func GetEnabledServices() ([]*ServiceDefinition, error) { return DefaultRegistry.GetEnabledServices() }
 func (brokerRegistry *BrokerRegistry) GetEnabledServices() ([]*ServiceDefinition, error) {
 	var out []*ServiceDefinition
 
@@ -107,7 +102,6 @@ func (brokerRegistry *BrokerRegistry) GetEnabledServices() ([]*ServiceDefinition
 // GetAllServices returns a list of all registered brokers whether or not the
 // user has enabled them. The brokers are sorted in lexocographic order based
 // on name.
-func GetAllServices() []*ServiceDefinition { return DefaultRegistry.GetAllServices() }
 func (brokerRegistry BrokerRegistry) GetAllServices() []*ServiceDefinition {
 	var out []*ServiceDefinition
 
@@ -123,7 +117,6 @@ func (brokerRegistry BrokerRegistry) GetAllServices() []*ServiceDefinition {
 
 // GetServiceById returns the service with the given ID, if it does not exist
 // or one of the services has a parse error then an error is returned.
-func GetServiceById(id string) (*ServiceDefinition, error) { return DefaultRegistry.GetServiceById(id) }
 func (brokerRegistry BrokerRegistry) GetServiceById(id string) (*ServiceDefinition, error) {
 	for _, svc := range brokerRegistry {
 		if entry, err := svc.CatalogEntry(); err != nil {

--- a/pkg/compatibility/three_to_four.go
+++ b/pkg/compatibility/three_to_four.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/pivotal-cf/brokerapi"
 )
 
@@ -153,7 +153,8 @@ func (t *ThreeToFour) Unbind(ctx context.Context, instanceID, bindingID string, 
 // Services returns the list of enabled services, with dummy services injected
 // for legacy compatibility.
 func (t *ThreeToFour) Services(ctx context.Context) ([]brokerapi.Service, error) {
-	services, err := broker.GetEnabledServices()
+	builtinServices := builtin.BuiltinBrokerRegistry()
+	services, err := builtinServices.GetEnabledServices()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/toggles"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	yaml "gopkg.in/yaml.v2"
@@ -98,7 +99,7 @@ func GenerateForms() TileFormsSections {
 // generateEnableDisableForm generates the form to enable and disable services.
 func generateEnableDisableForm() Form {
 	enablers := []FormProperty{}
-	for _, svc := range broker.GetAllServices() {
+	for _, svc := range builtin.BuiltinBrokerRegistry() {
 		entry, err := svc.CatalogEntry()
 		if err != nil {
 			log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
@@ -127,8 +128,10 @@ func generateEnableDisableForm() Form {
 // whitelist validation for new service accounts bound to the service.
 // They are opt-out and on by default for safety.
 func generateRoleWhitelistForm() Form {
+	builtinServices := builtin.BuiltinBrokerRegistry()
+
 	enablers := []FormProperty{}
-	for _, svc := range broker.GetAllServices() {
+	for _, svc := range builtinServices.GetAllServices() {
 		entry, err := svc.CatalogEntry()
 		if err != nil {
 			log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
@@ -161,8 +164,10 @@ func generateRoleWhitelistForm() Form {
 // generateDefaultOverrideForm generates a form for users to override the
 // defaults in a plan.
 func generateDefaultOverrideForm() Form {
+	builtinServices := builtin.BuiltinBrokerRegistry()
+
 	formElements := []FormProperty{}
-	for _, svc := range broker.GetAllServices() {
+	for _, svc := range builtinServices.GetAllServices() {
 		entry, err := svc.CatalogEntry()
 		if err != nil {
 			log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
@@ -260,9 +265,10 @@ func generateCompatibilityForm() Form {
 // generateServicePlanForms generates customized service plan forms for all
 // registered services that have the ability to customize their variables.
 func generateServicePlanForms() []Form {
+	builtinServices := builtin.BuiltinBrokerRegistry()
 	out := []Form{}
 
-	for _, svc := range broker.GetAllServices() {
+	for _, svc := range builtinServices.GetAllServices() {
 		planVars := svc.PlanVariables
 
 		if planVars == nil || len(planVars) == 0 {

--- a/pkg/providers/builtin/registry.go
+++ b/pkg/providers/builtin/registry.go
@@ -30,6 +30,10 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
+// NOTE(josephlewis42) unless there are extenuating circumstances, as of 2019
+// no new builtin providers should be added. Instead, providers should be
+// added using downloadable brokerpaks.
+
 // BuiltinBrokerRegistry creates a new registry with all the built-in brokers
 // added to it.
 func BuiltinBrokerRegistry() broker.BrokerRegistry {

--- a/pkg/providers/builtin/registry.go
+++ b/pkg/providers/builtin/registry.go
@@ -1,0 +1,59 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builtin
+
+import (
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/api_service"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/bigquery"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/bigtable"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/cloudsql"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/dataflow"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/datastore"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/dialogflow"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/firestore"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/pubsub"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/spanner"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/stackdriver"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers/storage"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+)
+
+// BuiltinBrokerRegistry creates a new registry with all the built-in brokers
+// added to it.
+func BuiltinBrokerRegistry() broker.BrokerRegistry {
+	out := broker.BrokerRegistry{}
+	RegisterBuiltinBrokers(out)
+	return out
+}
+
+// RegisterBuiltinBrokers adds the built-in brokers to the given registry.
+func RegisterBuiltinBrokers(registry broker.BrokerRegistry) {
+	registry.Register(api_service.ServiceDefinition())
+	registry.Register(bigquery.ServiceDefinition())
+	registry.Register(bigtable.ServiceDefinition())
+	registry.Register(cloudsql.MysqlServiceDefinition())
+	registry.Register(cloudsql.PostgresServiceDefinition())
+	registry.Register(dataflow.ServiceDefinition())
+	registry.Register(datastore.ServiceDefinition())
+	registry.Register(dialogflow.ServiceDefinition())
+	registry.Register(firestore.ServiceDefinition())
+	registry.Register(pubsub.ServiceDefinition())
+	registry.Register(spanner.ServiceDefinition())
+	registry.Register(stackdriver.StackdriverDebuggerServiceDefinition())
+	registry.Register(stackdriver.StackdriverMonitoringServiceDefinition())
+	registry.Register(stackdriver.StackdriverProfilerServiceDefinition())
+	registry.Register(stackdriver.StackdriverTraceServiceDefinition())
+	registry.Register(storage.ServiceDefinition())
+}

--- a/pkg/providers/builtin/registry_test.go
+++ b/pkg/providers/builtin/registry_test.go
@@ -14,10 +14,52 @@
 
 package builtin
 
-// No new builtin providers should be added after this point.
-// Going forward, all new providers should be handled through brokerpaks.
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
 
-// TODO validate exact number of brokers
-// TODO validate broker names
-// TODO validate broker plans
-// TODO validate free == false
+func TestBuiltinBrokerRegistry(t *testing.T) {
+	builtinServiceNames := []string{
+		"google-bigquery",
+		"google-bigtable",
+		"google-cloudsql-mysql",
+		"google-cloudsql-postgres",
+		"google-dataflow",
+		"google-datastore",
+		"google-dialogflow",
+		"google-firestore",
+		"google-ml-apis",
+		"google-pubsub",
+		"google-spanner",
+		"google-stackdriver-debugger",
+		"google-stackdriver-monitoring",
+		"google-stackdriver-profiler",
+		"google-stackdriver-trace",
+		"google-storage",
+	}
+
+	sort.Strings(builtinServiceNames)
+
+	t.Run("service-count", func(t *testing.T) {
+		expectedServiceCount := len(builtinServiceNames)
+		actualServiceCount := len(BuiltinBrokerRegistry())
+		if actualServiceCount != expectedServiceCount {
+			t.Errorf("Expected %d services, registered: %d", expectedServiceCount, actualServiceCount)
+		}
+	})
+
+	t.Run("service-names", func(t *testing.T) {
+		var actual []string
+		registry := BuiltinBrokerRegistry()
+		for name, _ := range registry {
+			actual = append(actual, name)
+		}
+
+		sort.Strings(actual)
+		if !reflect.DeepEqual(builtinServiceNames, actual) {
+			t.Errorf("Expected service names: %v, got: %v", builtinServiceNames, actual)
+		}
+	})
+}

--- a/pkg/providers/builtin/registry_test.go
+++ b/pkg/providers/builtin/registry_test.go
@@ -1,0 +1,23 @@
+// Copyright 2018 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builtin
+
+// No new builtin providers should be added after this point.
+// Going forward, all new providers should be handled through brokerpaks.
+
+// TODO validate exact number of brokers
+// TODO validate broker names
+// TODO validate broker plans
+// TODO validate free == false

--- a/pkg/server/docs_test.go
+++ b/pkg/server/docs_test.go
@@ -20,13 +20,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 )
 
 func TestNewDocsHandler(t *testing.T) {
+	registry := builtin.BuiltinBrokerRegistry()
 	// Test that the handler sets the correct header and contains some imporant
 	// strings that will indicate (but not prove!) that the rendering was correct.
-	handler := NewDocsHandler(broker.DefaultRegistry)
+	handler := NewDocsHandler(registry)
 	request := httptest.NewRequest(http.MethodGet, "/docs", nil)
 	w := httptest.NewRecorder()
 
@@ -42,7 +43,7 @@ func TestNewDocsHandler(t *testing.T) {
 	}
 
 	importantStrings := []string{"<html", "bootstrap.min.css"}
-	for _, svc := range broker.DefaultRegistry.GetAllServices() {
+	for _, svc := range registry.GetAllServices() {
 		importantStrings = append(importantStrings, svc.Name)
 	}
 


### PR DESCRIPTION
Refactors the broker to explicitly register services into a specific registry rather than them doing it automatically on `init()`.

This marks the beginning of our transformation to deprecate builtin providers and move to a brokerpak focused broker.