### PR TITLE
removed individual disable flags

### DIFF
--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -50,7 +50,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/support/",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/machine-learning.svg"
       },
-      "tags": ["gcp", "ml"],
+      "tags": ["gcp", "ml", "builtin"],
       "plans":  [
         {
          "id": "be7954e1-ecfb-4936-a0b6-db35e6424c7a",

--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -50,7 +50,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/support/",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/machine-learning.svg"
       },
-      "tags": ["gcp", "ml", "builtin"],
+      "tags": ["gcp", "ml"],
       "plans":  [
         {
          "id": "be7954e1-ecfb-4936-a0b6-db35e6424c7a",
@@ -83,5 +83,6 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &ApiServiceBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -50,7 +50,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
           "supportUrl": "https://cloud.google.com/bigquery/support",
           "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigquery.svg"
         },
-        "tags": ["gcp", "bigquery", "builtin"],
+        "tags": ["gcp", "bigquery"],
         "plans": [
           {
             "id": "10ff4e72-6e84-44eb-851f-bdb38a791914",
@@ -119,5 +119,6 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &BigQueryBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -50,7 +50,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
           "supportUrl": "https://cloud.google.com/bigquery/support",
           "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigquery.svg"
         },
-        "tags": ["gcp", "bigquery"],
+        "tags": ["gcp", "bigquery", "builtin"],
         "plans": [
           {
             "id": "10ff4e72-6e84-44eb-851f-bdb38a791914",

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -47,7 +47,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
           "supportUrl": "https://cloud.google.com/bigtable/docs/support/getting-support",
           "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigtable.svg"
       },
-      "tags": ["gcp", "bigtable"],
+      "tags": ["gcp", "bigtable", "builtin"],
       "plans": [
         {
           "id": "65a49268-2c73-481e-80f3-9fde5bd5a654",

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -47,7 +47,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
           "supportUrl": "https://cloud.google.com/bigtable/docs/support/getting-support",
           "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/bigtable.svg"
       },
-      "tags": ["gcp", "bigtable", "builtin"],
+      "tags": ["gcp", "bigtable"],
       "plans": [
         {
           "id": "65a49268-2c73-481e-80f3-9fde5bd5a654",
@@ -170,5 +170,6 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &BigTableBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -43,7 +43,7 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 		      "supportUrl": "https://cloud.google.com/sql/docs/getting-support",
 		      "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/sql.svg"
 		    },
-		    "tags": ["gcp", "cloudsql", "mysql"],
+		    "tags": ["gcp", "cloudsql", "mysql", "builtin"],
 		    "plans": [
 				    {
 				        "service_properties": {

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -43,7 +43,7 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 		      "supportUrl": "https://cloud.google.com/sql/docs/getting-support",
 		      "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/sql.svg"
 		    },
-		    "tags": ["gcp", "cloudsql", "mysql", "builtin"],
+		    "tags": ["gcp", "cloudsql", "mysql"],
 		    "plans": [
 				    {
 				        "service_properties": {
@@ -294,5 +294,6 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &CloudSQLBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -259,5 +259,6 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &CloudSQLBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -43,7 +43,7 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 	          "supportUrl": "https://cloud.google.com/support/",
 	          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/sql.svg"
         },
-        "tags": ["gcp", "cloudsql", "postgres", "builtin"],
+        "tags": ["gcp", "cloudsql", "postgres"],
         "plans":[
 				    {
 				        "service_properties": { "tier": "db-f1-micro", "max_disk_size": "3062" },

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -43,7 +43,7 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 	          "supportUrl": "https://cloud.google.com/support/",
 	          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/sql.svg"
         },
-        "tags": ["gcp", "cloudsql", "postgres"],
+        "tags": ["gcp", "cloudsql", "postgres", "builtin"],
         "plans":[
 				    {
 				        "service_properties": { "tier": "db-f1-micro", "max_disk_size": "3062" },

--- a/brokerapi/brokers/dataflow/definition.go
+++ b/brokerapi/brokers/dataflow/definition.go
@@ -41,7 +41,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/dataflow/docs/support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/dataflow.svg"
       },
-      "tags": ["gcp", "dataflow", "preview", "builtin"],
+      "tags": ["gcp", "dataflow", "preview"],
       "plans": [
         {
          "id": "8e956dd6-8c0f-470c-9a11-065537d81872",
@@ -76,5 +76,6 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &DataflowBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/dataflow/definition.go
+++ b/brokerapi/brokers/dataflow/definition.go
@@ -41,7 +41,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/dataflow/docs/support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/dataflow.svg"
       },
-      "tags": ["gcp", "dataflow", "preview"],
+      "tags": ["gcp", "dataflow", "preview", "builtin"],
       "plans": [
         {
          "id": "8e956dd6-8c0f-470c-9a11-065537d81872",

--- a/brokerapi/brokers/datastore/definition.go
+++ b/brokerapi/brokers/datastore/definition.go
@@ -40,7 +40,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/datastore/docs/getting-support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/datastore.svg"
       },
-      "tags": ["gcp", "datastore", "builtin"],
+      "tags": ["gcp", "datastore"],
       "plans": [
         {
          "id": "05f1fb6b-b5f0-48a2-9c2b-a5f236507a97",
@@ -98,5 +98,6 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &DatastoreBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/datastore/definition.go
+++ b/brokerapi/brokers/datastore/definition.go
@@ -40,7 +40,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/datastore/docs/getting-support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/datastore.svg"
       },
-      "tags": ["gcp", "datastore"],
+      "tags": ["gcp", "datastore", "builtin"],
       "plans": [
         {
          "id": "05f1fb6b-b5f0-48a2-9c2b-a5f236507a97",

--- a/brokerapi/brokers/dialogflow/definition.go
+++ b/brokerapi/brokers/dialogflow/definition.go
@@ -39,7 +39,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/dialogflow-enterprise/docs/support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/dialogflow-enterprise.svg"
       },
-      "tags": ["gcp", "dialogflow", "preview", "builtin"],
+      "tags": ["gcp", "dialogflow", "preview"],
       "plans": [
         {
          "id": "3ac4e1bd-b22d-4a99-864b-d3a3ac582348",
@@ -67,5 +67,6 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &DialogflowBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/dialogflow/definition.go
+++ b/brokerapi/brokers/dialogflow/definition.go
@@ -39,7 +39,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/dialogflow-enterprise/docs/support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/dialogflow-enterprise.svg"
       },
-      "tags": ["gcp", "dialogflow", "preview"],
+      "tags": ["gcp", "dialogflow", "preview", "builtin"],
       "plans": [
         {
          "id": "3ac4e1bd-b22d-4a99-864b-d3a3ac582348",

--- a/brokerapi/brokers/firestore/definition.go
+++ b/brokerapi/brokers/firestore/definition.go
@@ -42,7 +42,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/firestore/docs/getting-support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/firestore.svg"
       },
-      "tags": ["gcp", "firestore", "preview", "beta", "builtin"],
+      "tags": ["gcp", "firestore", "preview", "beta"],
       "plans": [
         {
          "id": "64403af0-4413-4ef3-a813-37f0306ef498",
@@ -78,5 +78,6 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &FirestoreBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/firestore/definition.go
+++ b/brokerapi/brokers/firestore/definition.go
@@ -42,7 +42,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/firestore/docs/getting-support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/firestore.svg"
       },
-      "tags": ["gcp", "firestore", "preview", "beta"],
+      "tags": ["gcp", "firestore", "preview", "beta", "builtin"],
       "plans": [
         {
          "id": "64403af0-4413-4ef3-a813-37f0306ef498",

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -49,7 +49,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/pubsub/docs/support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/pubsub.svg"
       },
-      "tags": ["gcp", "pubsub"],
+      "tags": ["gcp", "pubsub", "builtin"],
       "plans": [
         {
           "id": "622f4da3-8731-492a-af29-66a9146f8333",

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -49,7 +49,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/pubsub/docs/support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/pubsub.svg"
       },
-      "tags": ["gcp", "pubsub", "builtin"],
+      "tags": ["gcp", "pubsub"],
       "plans": [
         {
           "id": "622f4da3-8731-492a-af29-66a9146f8333",
@@ -185,5 +185,6 @@ again during that time (on a best-effort basis).
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &PubSubBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -50,7 +50,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				"supportUrl": "https://cloud.google.com/spanner/docs/support",
 				"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/spanner.svg"
 			},
-			"tags": ["gcp", "spanner", "builtin"],
+			"tags": ["gcp", "spanner"],
 			"plans": [
 				{
 					"id": "44828436-cfbd-47ae-b4bc-48854564347b",
@@ -152,5 +152,6 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &SpannerBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -50,7 +50,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				"supportUrl": "https://cloud.google.com/spanner/docs/support",
 				"imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/spanner.svg"
 			},
-			"tags": ["gcp", "spanner"],
+			"tags": ["gcp", "spanner", "builtin"],
 			"plans": [
 				{
 					"id": "44828436-cfbd-47ae-b4bc-48854564347b",

--- a/brokerapi/brokers/stackdriver/debugger_definition.go
+++ b/brokerapi/brokers/stackdriver/debugger_definition.go
@@ -37,7 +37,7 @@ func StackdriverDebuggerServiceDefinition() *broker.ServiceDefinition {
 		        "supportUrl": "https://cloud.google.com/stackdriver/docs/getting-support",
 		        "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/debugger.svg"
 		      },
-		      "tags": ["gcp", "stackdriver", "debugger"],
+		      "tags": ["gcp", "stackdriver", "debugger", "builtin"],
 		      "plans": [
 		        {
 		          "id": "10866183-a775-49e8-96e3-4e7a901e4a79",

--- a/brokerapi/brokers/stackdriver/debugger_definition.go
+++ b/brokerapi/brokers/stackdriver/debugger_definition.go
@@ -37,7 +37,7 @@ func StackdriverDebuggerServiceDefinition() *broker.ServiceDefinition {
 		        "supportUrl": "https://cloud.google.com/stackdriver/docs/getting-support",
 		        "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/debugger.svg"
 		      },
-		      "tags": ["gcp", "stackdriver", "debugger", "builtin"],
+		      "tags": ["gcp", "stackdriver", "debugger"],
 		      "plans": [
 		        {
 		          "id": "10866183-a775-49e8-96e3-4e7a901e4a79",
@@ -64,5 +64,6 @@ func StackdriverDebuggerServiceDefinition() *broker.ServiceDefinition {
 			},
 		},
 		ProviderBuilder: NewStackdriverAccountProvider,
+		IsBuiltin:       true,
 	}
 }

--- a/brokerapi/brokers/stackdriver/monitoring_definition.go
+++ b/brokerapi/brokers/stackdriver/monitoring_definition.go
@@ -37,7 +37,7 @@ func StackdriverMonitoringServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/stackdriver/docs/getting-support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/stackdriver.svg"
       },
-      "tags": ["gcp", "stackdriver", "monitoring", "preview", "builtin"],
+      "tags": ["gcp", "stackdriver", "monitoring", "preview"],
       "plans": [
         {
           "id": "2e4b85c1-0ce6-46e4-91f5-eebeb373e3f5",
@@ -63,5 +63,6 @@ func StackdriverMonitoringServiceDefinition() *broker.ServiceDefinition {
 			},
 		},
 		ProviderBuilder: NewStackdriverAccountProvider,
+		IsBuiltin:       true,
 	}
 }

--- a/brokerapi/brokers/stackdriver/monitoring_definition.go
+++ b/brokerapi/brokers/stackdriver/monitoring_definition.go
@@ -37,7 +37,7 @@ func StackdriverMonitoringServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/stackdriver/docs/getting-support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/stackdriver.svg"
       },
-      "tags": ["gcp", "stackdriver", "monitoring", "preview"],
+      "tags": ["gcp", "stackdriver", "monitoring", "preview", "builtin"],
       "plans": [
         {
           "id": "2e4b85c1-0ce6-46e4-91f5-eebeb373e3f5",

--- a/brokerapi/brokers/stackdriver/profiler_definition.go
+++ b/brokerapi/brokers/stackdriver/profiler_definition.go
@@ -37,7 +37,7 @@ func StackdriverProfilerServiceDefinition() *broker.ServiceDefinition {
 		        "supportUrl": "https://cloud.google.com/stackdriver/docs/getting-support",
 		        "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/stackdriver.svg"
 		      },
-		      "tags": ["gcp", "stackdriver", "profiler", "builtin"],
+		      "tags": ["gcp", "stackdriver", "profiler"],
 		      "plans": [
 		        {
 		          "id": "594627f6-35f5-462f-9074-10fb033fb18a",
@@ -64,5 +64,6 @@ func StackdriverProfilerServiceDefinition() *broker.ServiceDefinition {
 			},
 		},
 		ProviderBuilder: NewStackdriverAccountProvider,
+		IsBuiltin:       true,
 	}
 }

--- a/brokerapi/brokers/stackdriver/profiler_definition.go
+++ b/brokerapi/brokers/stackdriver/profiler_definition.go
@@ -37,7 +37,7 @@ func StackdriverProfilerServiceDefinition() *broker.ServiceDefinition {
 		        "supportUrl": "https://cloud.google.com/stackdriver/docs/getting-support",
 		        "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/stackdriver.svg"
 		      },
-		      "tags": ["gcp", "stackdriver", "profiler"],
+		      "tags": ["gcp", "stackdriver", "profiler", "builtin"],
 		      "plans": [
 		        {
 		          "id": "594627f6-35f5-462f-9074-10fb033fb18a",

--- a/brokerapi/brokers/stackdriver/trace_definition.go
+++ b/brokerapi/brokers/stackdriver/trace_definition.go
@@ -37,7 +37,7 @@ func StackdriverTraceServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/stackdriver/docs/getting-support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/trace.svg"
       },
-      "tags": ["gcp", "stackdriver", "trace"],
+      "tags": ["gcp", "stackdriver", "trace", "builtin"],
       "plans": [
         {
           "id": "ab6c2287-b4bc-4ff4-a36a-0575e7910164",

--- a/brokerapi/brokers/stackdriver/trace_definition.go
+++ b/brokerapi/brokers/stackdriver/trace_definition.go
@@ -37,7 +37,7 @@ func StackdriverTraceServiceDefinition() *broker.ServiceDefinition {
         "supportUrl": "https://cloud.google.com/stackdriver/docs/getting-support",
         "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/trace.svg"
       },
-      "tags": ["gcp", "stackdriver", "trace", "builtin"],
+      "tags": ["gcp", "stackdriver", "trace"],
       "plans": [
         {
           "id": "ab6c2287-b4bc-4ff4-a36a-0575e7910164",
@@ -64,5 +64,6 @@ func StackdriverTraceServiceDefinition() *broker.ServiceDefinition {
 			},
 		},
 		ProviderBuilder: NewStackdriverAccountProvider,
+		IsBuiltin:       true,
 	}
 }

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -48,7 +48,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 	          "supportUrl": "https://cloud.google.com/storage/docs/getting-support",
 	          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/storage.svg"
 	        },
-	        "tags": ["gcp", "storage", "builtin"],
+	        "tags": ["gcp", "storage"],
 	        "plans": [
 	          {
 	            "id": "e1d11f65-da66-46ad-977c-6d56513baf43",
@@ -189,5 +189,6 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			bb := broker_base.NewBrokerBase(projectId, auth, logger)
 			return &StorageBroker{BrokerBase: bb}
 		},
+		IsBuiltin: true,
 	}
 }

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -48,7 +48,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 	          "supportUrl": "https://cloud.google.com/storage/docs/getting-support",
 	          "imageUrl": "https://cloud.google.com/_static/images/cloud/products/logos/svg/storage.svg"
 	        },
-	        "tags": ["gcp", "storage"],
+	        "tags": ["gcp", "storage", "builtin"],
 	        "plans": [
 	          {
 	            "id": "e1d11f65-da66-46ad-977c-6d56513baf43",

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -26,16 +26,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-func ExampleServiceDefinition_EnabledProperty() {
-	service := ServiceDefinition{
-		Name: "left-handed-smoke-sifter",
-	}
-
-	fmt.Println(service.EnabledProperty())
-
-	// Output: service.left-handed-smoke-sifter.enabled
-}
-
 func ExampleServiceDefinition_DefinitionProperty() {
 	service := ServiceDefinition{
 		Name: "left-handed-smoke-sifter",
@@ -54,21 +44,6 @@ func ExampleServiceDefinition_UserDefinedPlansProperty() {
 	fmt.Println(service.UserDefinedPlansProperty())
 
 	// Output: service.left-handed-smoke-sifter.plans
-}
-
-func ExampleServiceDefinition_IsEnabled() {
-	service := ServiceDefinition{
-		Name: "left-handed-smoke-sifter",
-	}
-
-	viper.Set(service.EnabledProperty(), true)
-	fmt.Println(service.IsEnabled())
-
-	viper.Set(service.EnabledProperty(), false)
-	fmt.Println(service.IsEnabled())
-
-	// Output: true
-	// false
 }
 
 func ExampleServiceDefinition_IsRoleWhitelistEnabled() {

--- a/pkg/broker/catalog.go
+++ b/pkg/broker/catalog.go
@@ -14,7 +14,9 @@
 
 package broker
 
-import "github.com/pivotal-cf/brokerapi"
+import (
+	"github.com/pivotal-cf/brokerapi"
+)
 
 // Service overrides the canonical Service Broker service type using a custom
 // type for Plans, everything else is the same.

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -35,6 +35,7 @@ var (
 		"beta":         toggles.Compatibility.Toggle("enable-gcp-beta-services", true, "Enable services that are in GCP Beta. These have no SLA or support policy."),
 		"deprecated":   toggles.Compatibility.Toggle("enable-gcp-deprecated-services", false, "Enable services that use deprecated GCP components."),
 		"terraform":    toggles.Compatibility.Toggle("enable-terraform-services", false, "Enable services that use the experimental, unstable, Terraform back-end."),
+		"builtin":      toggles.Compatibility.Toggle("enable-builtin-services", true, "Enable services that are built in to the broker i.e. not brokerpaks."),
 	}
 )
 
@@ -56,9 +57,6 @@ func (brokerRegistry BrokerRegistry) Register(service *ServiceDefinition) {
 	env := utils.PropertyToEnvUnprefixed(service.Name)
 	viper.BindEnv(service.DefinitionProperty(), env)
 
-	// set defaults
-	viper.SetDefault(service.EnabledProperty(), true)
-
 	// Test deserializing the user defined plans and service definition
 	if _, err := service.CatalogEntry(); err != nil {
 		log.Fatalf("Error registering service %q, %s", name, err)
@@ -77,7 +75,7 @@ func (brokerRegistry *BrokerRegistry) GetEnabledServices() ([]*ServiceDefinition
 	var out []*ServiceDefinition
 
 	for _, svc := range brokerRegistry.GetAllServices() {
-		isEnabled := svc.IsEnabled()
+		isEnabled := true
 
 		if entry, err := svc.CatalogEntry(); err != nil {
 			return nil, err

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -35,8 +35,9 @@ var (
 		"beta":         toggles.Compatibility.Toggle("enable-gcp-beta-services", true, "Enable services that are in GCP Beta. These have no SLA or support policy."),
 		"deprecated":   toggles.Compatibility.Toggle("enable-gcp-deprecated-services", false, "Enable services that use deprecated GCP components."),
 		"terraform":    toggles.Compatibility.Toggle("enable-terraform-services", false, "Enable services that use the experimental, unstable, Terraform back-end."),
-		"builtin":      toggles.Compatibility.Toggle("enable-builtin-services", true, "Enable services that are built in to the broker i.e. not brokerpaks."),
 	}
+
+	enableBuiltinServices = toggles.Compatibility.Toggle("enable-builtin-services", true, `Enable services that are built in to the broker i.e. not brokerpaks.`)
 )
 
 // BrokerRegistry holds the list of ServiceDefinitions that can be provisioned
@@ -76,6 +77,10 @@ func (brokerRegistry *BrokerRegistry) GetEnabledServices() ([]*ServiceDefinition
 
 	for _, svc := range brokerRegistry.GetAllServices() {
 		isEnabled := true
+
+		if svc.IsBuiltin {
+			isEnabled = enableBuiltinServices.IsActive()
+		}
 
 		if entry, err := svc.CatalogEntry(); err != nil {
 			return nil, err

--- a/pkg/broker/registry_test.go
+++ b/pkg/broker/registry_test.go
@@ -67,12 +67,14 @@ func TestRegistry_GetEnabledServices(t *testing.T) {
                 }
               ]
             }`,
+				IsBuiltin: true,
 			}
 
 			registry := BrokerRegistry{}
 			registry.Register(&sd)
 
-			// shouldn't show up when property is false
+			// shouldn't show up when property is false even if builtins are enabled
+			viper.Set("compatibility.enable-builtin-services", true)
 			viper.Set(tc.Property, false)
 			if defns, err := registry.GetEnabledServices(); err != nil {
 				t.Fatal(err)
@@ -86,6 +88,14 @@ func TestRegistry_GetEnabledServices(t *testing.T) {
 				t.Fatal(err)
 			} else if len(defns) != 1 {
 				t.Fatalf("Expected 1 definition with %s enabled, but got %d", tc.Property, len(defns))
+			}
+
+			// should not show up if the service is explicitly disabled
+			viper.Set("compatibility.enable-builtin-services", false)
+			if defns, err := registry.GetEnabledServices(); err != nil {
+				t.Fatal(err)
+			} else if len(defns) != 0 {
+				t.Fatalf("Expected no definition with builtins disabled, but got %d", len(defns))
 			}
 		})
 	}

--- a/pkg/broker/registry_test.go
+++ b/pkg/broker/registry_test.go
@@ -72,8 +72,7 @@ func TestRegistry_GetEnabledServices(t *testing.T) {
 			registry := BrokerRegistry{}
 			registry.Register(&sd)
 
-			// shouldn't show up when property is false even if the service is enabled
-			viper.Set(sd.EnabledProperty(), true)
+			// shouldn't show up when property is false
 			viper.Set(tc.Property, false)
 			if defns, err := registry.GetEnabledServices(); err != nil {
 				t.Fatal(err)
@@ -87,14 +86,6 @@ func TestRegistry_GetEnabledServices(t *testing.T) {
 				t.Fatal(err)
 			} else if len(defns) != 1 {
 				t.Fatalf("Expected 1 definition with %s enabled, but got %d", tc.Property, len(defns))
-			}
-
-			// should not show up if the service is explicitly disabled
-			viper.Set(sd.EnabledProperty(), false)
-			if defns, err := registry.GetEnabledServices(); err != nil {
-				t.Fatal(err)
-			} else if len(defns) != 0 {
-				t.Fatalf("Expected o definition with %s disabled, but got %d", sd.EnabledProperty(), len(defns))
 			}
 		})
 	}

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -47,6 +47,9 @@ type ServiceDefinition struct {
 
 	// ProviderBuilder creates a new provider given the project, auth, and logger.
 	ProviderBuilder func(projectId string, auth *jwt.Config, logger lager.Logger) ServiceProvider
+
+	// IsBuiltin is true if the service is built-in to the platform.
+	IsBuiltin bool
 }
 
 // DefinitionProperty computes the Viper property name for the JSON service

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -49,12 +49,6 @@ type ServiceDefinition struct {
 	ProviderBuilder func(projectId string, auth *jwt.Config, logger lager.Logger) ServiceProvider
 }
 
-// EnabledProperty computes the Viper property name for the boolean the user
-// can set to disable or enable this service.
-func (svc *ServiceDefinition) EnabledProperty() string {
-	return fmt.Sprintf("service.%s.enabled", svc.Name)
-}
-
 // DefinitionProperty computes the Viper property name for the JSON service
 // definition.
 func (svc *ServiceDefinition) DefinitionProperty() string {
@@ -108,12 +102,6 @@ func (svc *ServiceDefinition) TileUserDefinedPlansVariable() string {
 	}
 
 	return v + "_CUSTOM_PLANS"
-}
-
-// IsEnabled returns false if the operator has explicitly disabled this service
-// or true otherwise.
-func (svc *ServiceDefinition) IsEnabled() bool {
-	return viper.GetBool(svc.EnabledProperty())
 }
 
 // CatalogEntry returns the service broker catalog entry for this service, it

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -86,41 +86,12 @@ func GenerateForms() TileFormsSections {
 			generateServiceAccountForm(),
 			generateDatabaseForm(),
 			generateBrokerpakForm(),
-			generateEnableDisableForm(),
 			generateRoleWhitelistForm(),
 			generateCompatibilityForm(),
 			generateDefaultOverrideForm(),
 		},
 
 		ServicePlanForms: append(generateServicePlanForms(), brokerpakConfigurationForm()),
-	}
-}
-
-// generateEnableDisableForm generates the form to enable and disable services.
-func generateEnableDisableForm() Form {
-	enablers := []FormProperty{}
-	for _, svc := range builtin.BuiltinBrokerRegistry() {
-		entry, err := svc.CatalogEntry()
-		if err != nil {
-			log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
-		}
-
-		enableForm := FormProperty{
-			Name:         strings.ToLower(utils.PropertyToEnv(svc.EnabledProperty())),
-			Label:        fmt.Sprintf("Let the broker create and bind %s instances.", entry.Metadata.DisplayName),
-			Type:         "boolean",
-			Default:      true,
-			Configurable: true,
-		}
-
-		enablers = append(enablers, enableForm)
-	}
-
-	return Form{
-		Name:        "enable_disable",
-		Label:       "Enable Services",
-		Description: "Enable or disable services.",
-		Properties:  enablers,
 	}
 }
 

--- a/pkg/providers/builtin/registry_test.go
+++ b/pkg/providers/builtin/registry_test.go
@@ -62,4 +62,23 @@ func TestBuiltinBrokerRegistry(t *testing.T) {
 			t.Errorf("Expected service names: %v, got: %v", builtinServiceNames, actual)
 		}
 	})
+
+	t.Run("has-builtin-tag", func(t *testing.T) {
+		registry := BuiltinBrokerRegistry()
+		for _, svc := range registry {
+			defn, err := svc.ServiceDefinition()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			found := false
+			for _, tag := range defn.Tags {
+				found = found || tag == "builtin"
+			}
+
+			if !found {
+				t.Errorf("Expected tag 'builtin' in list for %s, but list was: %v", defn.Name, defn.Tags)
+			}
+		}
+	})
 }

--- a/pkg/providers/builtin/registry_test.go
+++ b/pkg/providers/builtin/registry_test.go
@@ -63,21 +63,11 @@ func TestBuiltinBrokerRegistry(t *testing.T) {
 		}
 	})
 
-	t.Run("has-builtin-tag", func(t *testing.T) {
+	t.Run("has-builtin-flag", func(t *testing.T) {
 		registry := BuiltinBrokerRegistry()
 		for _, svc := range registry {
-			defn, err := svc.ServiceDefinition()
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			found := false
-			for _, tag := range defn.Tags {
-				found = found || tag == "builtin"
-			}
-
-			if !found {
-				t.Errorf("Expected tag 'builtin' in list for %s, but list was: %v", defn.Name, defn.Tags)
+			if !svc.IsBuiltin {
+				t.Errorf("Expected flag 'builtin' to be set for %s, but it was: %t", svc.Name, svc.IsBuiltin)
 			}
 		}
 	})

--- a/tile.yml
+++ b/tile.yml
@@ -120,90 +120,6 @@ forms:
       a variable isn't found in the specific brokerpak's configuration it's looked
       up here.
     configurable: true
-- name: enable_disable
-  label: Enable Services
-  description: Enable or disable services.
-  properties:
-  - name: gsb_service_google_bigquery_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google BigQuery instances.
-    configurable: true
-  - name: gsb_service_google_bigtable_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google Bigtable instances.
-    configurable: true
-  - name: gsb_service_google_cloudsql_mysql_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google CloudSQL MySQL instances.
-    configurable: true
-  - name: gsb_service_google_cloudsql_postgres_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google CloudSQL PostgreSQL instances.
-    configurable: true
-  - name: gsb_service_google_dataflow_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google Cloud Dataflow instances.
-    configurable: true
-  - name: gsb_service_google_datastore_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google Cloud Datastore instances.
-    configurable: true
-  - name: gsb_service_google_dialogflow_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google Cloud Dialogflow instances.
-    configurable: true
-  - name: gsb_service_google_firestore_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google Cloud Firestore instances.
-    configurable: true
-  - name: gsb_service_google_ml_apis_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google Machine Learning APIs instances.
-    configurable: true
-  - name: gsb_service_google_pubsub_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google PubSub instances.
-    configurable: true
-  - name: gsb_service_google_spanner_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google Spanner instances.
-    configurable: true
-  - name: gsb_service_google_stackdriver_debugger_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Stackdriver Debugger instances.
-    configurable: true
-  - name: gsb_service_google_stackdriver_monitoring_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Stackdriver Monitoring instances.
-    configurable: true
-  - name: gsb_service_google_stackdriver_profiler_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Stackdriver Profiler instances.
-    configurable: true
-  - name: gsb_service_google_stackdriver_trace_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Stackdriver Trace instances.
-    configurable: true
-  - name: gsb_service_google_storage_enabled
-    type: boolean
-    default: true
-    label: Let the broker create and bind Google Cloud Storage instances.
-    configurable: true
 - name: role_whitelists
   label: Role Whitelisting
   description: Enable or disable role whitelisting.
@@ -268,6 +184,12 @@ forms:
   label: Compatibility
   description: Legacy Compatibility Options
   properties:
+  - name: gsb_compatibility_enable_builtin_services
+    type: boolean
+    default: "true"
+    label: enable-builtin-services
+    description: Enable services that are built in to the broker i.e. not brokerpaks.
+    configurable: true
   - name: gsb_compatibility_enable_cf_sharing
     type: boolean
     default: "false"


### PR DESCRIPTION
Removing the functionality to enable/disable specific services. This was a vestigial artifact from the way services were originally defined in the tile as environment variable JSON blobs.

Builtin services now have a tag and can be enabled/disabled using the tag just like all the other tags.