### PR TITLE
mark built-in services as not-free

### DIFF
--- a/brokerapi/brokers/api_service/definition.go
+++ b/brokerapi/brokers/api_service/definition.go
@@ -58,7 +58,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
          "name": "default",
          "display_name": "Default",
          "description": "Machine Learning API default plan.",
-         "service_properties": {}
+         "service_properties": {},
+         "free": false
         }
       ]
     }

--- a/brokerapi/brokers/bigquery/definition.go
+++ b/brokerapi/brokers/bigquery/definition.go
@@ -58,7 +58,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
             "name": "default",
             "display_name": "Default",
             "description": "BigQuery default plan.",
-            "service_properties": {}
+            "service_properties": {},
+            "free": false
           }
         ]
       }`,

--- a/brokerapi/brokers/bigtable/definition.go
+++ b/brokerapi/brokers/bigtable/definition.go
@@ -58,7 +58,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
             "num_nodes": "3"
           },
           "display_name": "3 Node HDD",
-          "service_id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe"
+          "service_id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe",
+          "free": false
         },
         {
           "id": "38aa0e65-624b-4998-9c06-f9194b56d252",
@@ -69,7 +70,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
             "num_nodes": "3"
           },
           "display_name": "3 Node SSD",
-          "service_id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe"
+          "service_id": "b8e19880-ac58-42ef-b033-f7cd9c94d1fe",
+          "free": false
         }
       ]
     }`,

--- a/brokerapi/brokers/cloudsql/mysql-definition.go
+++ b/brokerapi/brokers/cloudsql/mysql-definition.go
@@ -52,7 +52,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-f1-micro (Shared CPUs, 0.6 GB/RAM, 3062 GB/disk, 250 Connections)",
 				        "id": "7d8f9ade-30c1-4c96-b622-ea0205cc5f0b",
-				        "name": "mysql-db-f1-micro"
+				        "name": "mysql-db-f1-micro",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -61,7 +62,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-g1-small (Shared CPUs, 1.7 GB/RAM, 3062 GB/disk, 1,000 Connections)",
 				        "id": "b68bf4d8-1636-4121-af2f-087e46189929",
-				        "name": "mysql-db-g1-small"
+				        "name": "mysql-db-g1-small",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -70,7 +72,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-standard-1 (1 CPUs, 3.75 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "bdfd8033-c2b9-46e9-9b37-1f3a5889eef4",
-				        "name": "mysql-db-n1-standard-1"
+				        "name": "mysql-db-n1-standard-1",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -79,7 +82,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-standard-2 (2 CPUs, 7.5 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "2c99e938-4c1e-4da7-810a-94c9f5b71b57",
-				        "name": "mysql-db-n1-standard-2"
+				        "name": "mysql-db-n1-standard-2",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -88,7 +92,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-standard-4 (4 CPUs, 15 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "d520a5f5-7485-4a83-849b-5439f911fe26",
-				        "name": "mysql-db-n1-standard-4"
+				        "name": "mysql-db-n1-standard-4",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -97,7 +102,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-standard-8 (8 CPUs, 30 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "7ef42bb4-87e3-4ead-8118-4e88c98ed2e6",
-				        "name": "mysql-db-n1-standard-8"
+				        "name": "mysql-db-n1-standard-8",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -106,7 +112,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-standard-16 (16 CPUs, 60 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "200bd90a-4323-46d8-8aa5-afd4601498d0",
-				        "name": "mysql-db-n1-standard-16"
+				        "name": "mysql-db-n1-standard-16",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -115,7 +122,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-standard-32 (32 CPUs, 120 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "52305df2-1e64-4cdb-a4c9-bb5dddb33c3e",
-				        "name": "mysql-db-n1-standard-32"
+				        "name": "mysql-db-n1-standard-32",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -124,7 +132,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-standard-64 (64 CPUs, 240 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "e45d7c44-4990-4dac-a14d-c5127e9ae0c5",
-				        "name": "mysql-db-n1-standard-64"
+				        "name": "mysql-db-n1-standard-64",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -133,7 +142,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-highmem-2 (2 CPUs, 13 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "07b8a04c-0efe-42d3-8b2c-2c23f7c79583",
-				        "name": "mysql-db-n1-highmem-2"
+				        "name": "mysql-db-n1-highmem-2",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -142,7 +152,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-highmem-4 (4 CPUs, 26 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "50fa4baa-e36f-41c3-bbe9-c986d9fbe3c8",
-				        "name": "mysql-db-n1-highmem-4"
+				        "name": "mysql-db-n1-highmem-4",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -151,7 +162,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-highmem-8 (8 CPUs, 52 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "6e8e5bc3-bf68-4e57-bda1-d9c9a67faee0",
-				        "name": "mysql-db-n1-highmem-8"
+				        "name": "mysql-db-n1-highmem-8",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -160,7 +172,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-highmem-16 (16 CPUs, 104 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "3c83ff6b-165e-47bf-9bba-f4801390d0ff",
-				        "name": "mysql-db-n1-highmem-16"
+				        "name": "mysql-db-n1-highmem-16",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -169,7 +182,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-highmem-32 (32 CPUs, 208 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "cbc6d376-8fd3-4a34-9ab5-324311f038f6",
-				        "name": "mysql-db-n1-highmem-32"
+				        "name": "mysql-db-n1-highmem-32",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {
@@ -178,7 +192,8 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				        },
 				        "description": "MySQL on a db-n1-highmem-64 (64 CPUs, 416 GB/RAM, 10230 GB/disk, 4,000 Connections)",
 				        "id": "b0742cc5-caba-4b8d-98e0-03380ae9522b",
-				        "name": "mysql-db-n1-highmem-64"
+				        "name": "mysql-db-n1-highmem-64",
+				        "free": false
 				    }
 				]
 		}`,

--- a/brokerapi/brokers/cloudsql/postgres-definition.go
+++ b/brokerapi/brokers/cloudsql/postgres-definition.go
@@ -49,91 +49,106 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 				        "service_properties": { "tier": "db-f1-micro", "max_disk_size": "3062" },
 				        "description": "PostgreSQL on a db-f1-micro (Shared CPUs, 0.6 GB/RAM, 3062 GB/disk, 250 Connections)",
 				        "id": "2513d4d9-684b-4c3c-add4-6404969006de",
-				        "name": "postgres-db-f1-micro"
+				        "name": "postgres-db-f1-micro",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-g1-small", "max_disk_size": "3062" },
 				        "description": "PostgreSQL on a db-g1-small (Shared CPUs, 1.7 GB/RAM, 3062 GB/disk, 1,000 Connections)",
 				        "id": "6c1174d8-243c-44d1-b7a8-e94a779f67f5",
-				        "name": "postgres-db-g1-small"
+				        "name": "postgres-db-g1-small",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-1-3840", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 1 CPU, 3.75 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "c4e68ab5-34ca-4d02-857d-3e6b3ab079a7",
-				        "name": "postgres-db-n1-standard-1"
+				        "name": "postgres-db-n1-standard-1",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-2-7680", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 2 CPUs, 7.5 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "3f578ecf-885c-4b60-b38b-60272f34e00f",
-				        "name": "postgres-db-n1-standard-2"
+				        "name": "postgres-db-n1-standard-2",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-4-15360", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 4 CPUs, 15 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "b7fcab5d-d66d-4e82-af16-565e84cef7f9",
-				        "name": "postgres-db-n1-standard-4"
+				        "name": "postgres-db-n1-standard-4",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-8-30720", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 8 CPUs, 30 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "4b2fa14a-caf1-42e0-bd8c-3342502008a8",
-				        "name": "postgres-db-n1-standard-8"
+				        "name": "postgres-db-n1-standard-8",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-16-61440", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 16 CPUs, 60 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "ca2e770f-bfa5-4fb7-a249-8b943c3474ca",
-				        "name": "postgres-db-n1-standard-16"
+				        "name": "postgres-db-n1-standard-16",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-32-122880", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 32 CPUs, 120 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "b44f8294-b003-4a50-80c2-706858073f44",
-				        "name": "postgres-db-n1-standard-32"
+				        "name": "postgres-db-n1-standard-32",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-64-245760", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 64 CPUs, 240 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "d97326e0-5af2-4da5-b970-b4772d59cded",
-				        "name": "postgres-db-n1-standard-64"
+				        "name": "postgres-db-n1-standard-64",
+				        "free": false
 				    },
 				    {
 				        "service_properties": {"tier": "db-custom-2-13312", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 2 CPUs, 13 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "c10f8691-02f5-44eb-989f-7217393012ca",
-				        "name": "postgres-db-n1-highmem-2"
+				        "name": "postgres-db-n1-highmem-2",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-4-26624", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 4 CPUs, 26 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "610cc78d-d26a-41a9-90b7-547a44517f03",
-				        "name": "postgres-db-n1-highmem-4"
+				        "name": "postgres-db-n1-highmem-4",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-8-53248",  "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 8 CPUs, 52 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "2a351e8d-958d-4c4f-ae46-c984fec18740",
-				        "name": "postgres-db-n1-highmem-8"
+				        "name": "postgres-db-n1-highmem-8",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-16-106496", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 16 CPUs, 104 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "51d3ca0c-9d21-447d-a395-3e0dc0659775",
-				        "name": "postgres-db-n1-highmem-16"
+				        "name": "postgres-db-n1-highmem-16",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-32-212992", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 32 CPUs, 208 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "2e72b386-f7ce-4f0d-a149-9f9a851337d4",
-				        "name": "postgres-db-n1-highmem-32"
+				        "name": "postgres-db-n1-highmem-32",
+				        "free": false
 				    },
 				    {
 				        "service_properties": { "tier": "db-custom-64-425984", "max_disk_size": "10230" },
 				        "description": "PostgreSQL with 64 CPUs, 416 GB/RAM, 10230 GB/disk, supporting 4,000 connections.",
 				        "id": "82602649-e4ac-4a2f-b80d-dacd745aed6a",
-				        "name": "postgres-db-n1-highmem-64"
+				        "name": "postgres-db-n1-highmem-64",
+				        "free": false
 				    }
 				]
     }`,

--- a/brokerapi/brokers/dataflow/definition.go
+++ b/brokerapi/brokers/dataflow/definition.go
@@ -48,7 +48,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
          "name": "default",
          "display_name": "Default",
          "description": "Dataflow default plan.",
-         "service_properties": {}
+         "service_properties": {},
+         "free": false
         }
       ]
     }`,

--- a/brokerapi/brokers/datastore/definition.go
+++ b/brokerapi/brokers/datastore/definition.go
@@ -48,7 +48,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
          "name": "default",
          "display_name": "Default",
          "description": "Datastore default plan.",
-         "service_properties": {}
+         "service_properties": {},
+         "free": false
         }
       ]
     }`,

--- a/brokerapi/brokers/dialogflow/definition.go
+++ b/brokerapi/brokers/dialogflow/definition.go
@@ -46,7 +46,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
          "name": "default",
          "display_name": "Default",
          "description": "Dialogflow default plan.",
-         "service_properties": {}
+         "service_properties": {},
+         "free": false
         }
       ]
     }`,

--- a/brokerapi/brokers/firestore/definition.go
+++ b/brokerapi/brokers/firestore/definition.go
@@ -49,7 +49,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
          "name": "default",
          "display_name": "Default",
          "description": "Firestore default plan.",
-         "service_properties": {}
+         "service_properties": {},
+         "free": false
         }
       ]
     }`,

--- a/brokerapi/brokers/pubsub/definition.go
+++ b/brokerapi/brokers/pubsub/definition.go
@@ -57,7 +57,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
           "name": "default",
           "display_name": "Default",
           "description": "PubSub Default plan.",
-          "service_properties": {}
+          "service_properties": {},
+          "free": false
         }
       ]
 	  }`,

--- a/brokerapi/brokers/spanner/definition.go
+++ b/brokerapi/brokers/spanner/definition.go
@@ -57,14 +57,16 @@ func ServiceDefinition() *broker.ServiceDefinition {
 					"name": "sandbox",
 					"description": "Useful for testing, not eligible for SLA.",
 					"free": false,
-					"service_properties": {"num_nodes": "1"}
+					"service_properties": {"num_nodes": "1"},
+					"free": false
 				},
 				{
 					"id": "0752b1ad-a784-4dcc-96eb-64149089a1c9",
 					"name": "minimal-production",
 					"description": "A minimal production level Spanner setup eligible for 99.99% SLA. Each node can provide up to 10,000 QPS of reads or 2,000 QPS of writes (writing single rows at 1KB data per row), and 2 TiB storage.",
 					"free": false,
-					"service_properties": {"num_nodes": "3"}
+					"service_properties": {"num_nodes": "3"},
+					"free": false
 				}
 			]
 		}`,

--- a/brokerapi/brokers/stackdriver/debugger_definition.go
+++ b/brokerapi/brokers/stackdriver/debugger_definition.go
@@ -45,7 +45,8 @@ func StackdriverDebuggerServiceDefinition() *broker.ServiceDefinition {
 		          "name": "default",
 		          "display_name": "Default",
 		          "description": "Stackdriver Debugger default plan.",
-		          "service_properties": {}
+		          "service_properties": {},
+		          "free": false
 		        }
 		      ]
 				}

--- a/brokerapi/brokers/stackdriver/monitoring_definition.go
+++ b/brokerapi/brokers/stackdriver/monitoring_definition.go
@@ -44,7 +44,8 @@ func StackdriverMonitoringServiceDefinition() *broker.ServiceDefinition {
           "name": "default",
           "display_name": "Default",
           "description": "Stackdriver Monitoring default plan.",
-          "service_properties": {}
+          "service_properties": {},
+          "free": false
         }
       ]
     }

--- a/brokerapi/brokers/stackdriver/profiler_definition.go
+++ b/brokerapi/brokers/stackdriver/profiler_definition.go
@@ -45,7 +45,8 @@ func StackdriverProfilerServiceDefinition() *broker.ServiceDefinition {
 		          "name": "default",
 		          "display_name": "Default",
 		          "description": "Stackdriver Profiler default plan.",
-		          "service_properties": {}
+		          "service_properties": {},
+		          "free": false
 		        }
 		      ]
 				}

--- a/brokerapi/brokers/stackdriver/trace_definition.go
+++ b/brokerapi/brokers/stackdriver/trace_definition.go
@@ -45,7 +45,8 @@ func StackdriverTraceServiceDefinition() *broker.ServiceDefinition {
           "name": "default",
           "display_name": "Default",
           "description": "Stackdriver Trace default plan.",
-          "service_properties": {}
+          "service_properties": {},
+          "free": false
         }
       ]
     }

--- a/brokerapi/brokers/storage/definition.go
+++ b/brokerapi/brokers/storage/definition.go
@@ -56,7 +56,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
 	            "name": "standard",
 	            "display_name": "Standard",
 	            "description": "Standard storage class. Auto-selects either regional or multi-regional based on the location.",
-	            "service_properties": {"storage_class": "STANDARD"}
+	            "service_properties": {"storage_class": "STANDARD"},
+	            "free": false
 	          },
 	          {
 	            "id": "a42c1182-d1a0-4d40-82c1-28220518b360",
@@ -64,7 +65,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
 	            "name": "nearline",
 	            "display_name": "Nearline",
 	            "description": "Nearline storage class.",
-	            "service_properties": {"storage_class": "NEARLINE"}
+	            "service_properties": {"storage_class": "NEARLINE"},
+	            "free": false
 	          },
 	          {
 	            "id": "1a1f4fe6-1904-44d0-838c-4c87a9490a6b",
@@ -72,28 +74,32 @@ func ServiceDefinition() *broker.ServiceDefinition {
 	            "name": "reduced-availability",
 	            "display_name": "Durable Reduced Availability",
 	            "description": "Durable Reduced Availability storage class.",
-	            "service_properties": {"storage_class": "DURABLE_REDUCED_AVAILABILITY"}
+	            "service_properties": {"storage_class": "DURABLE_REDUCED_AVAILABILITY"},
+	            "free": false
 	          },
 	          {
 	            "id": "c8538397-8f15-45e3-a229-8bb349c3a98f",
 	            "name": "coldline",
 	            "display_name": "Coldline Storage",
 	            "description": "Google Cloud Storage Coldline is a very-low-cost, highly durable storage service for data archiving, online backup, and disaster recovery.",
-	            "service_properties": {"storage_class": "COLDLINE"}
+	            "service_properties": {"storage_class": "COLDLINE"},
+	            "free": false
 	          },
 	          {
 	            "id": "5e6161d2-0202-48be-80c4-1006cce19b9d",
 	            "name": "regional",
 	            "display_name": "Regional Storage",
 	            "description": "Data is stored in a narrow geographic region, redundant across availability zones with a 99.99% typical monthly availability.",
-	            "service_properties": {"storage_class": "REGIONAL"}
+	            "service_properties": {"storage_class": "REGIONAL"},
+	            "free": false
 	          },
 	          {
 	            "id": "a5e8dfb5-e5ec-472a-8d36-33afcaff2fdb",
 	            "name": "multiregional",
 	            "display_name": "Multi-Regional Storage",
 	            "description": "Data is stored geo-redundantly with >99.99% typical monthly availability.",
-	            "service_properties": {"storage_class": "MULTI_REGIONAL"}
+	            "service_properties": {"storage_class": "MULTI_REGIONAL"},
+	            "free": false
 	          }
 	        ]
 	      }`,


### PR DESCRIPTION
Fixes #49. This PR marks all built-in services as non-free. It doesn't attempt to fetch pricing information, but we can at least indicate that services will incur cost.

An additional test is added for plan updating to be false for built-ins because we have no intention of opening that can of worms and risking data loss.