### PR TITLE
removed deprecated migrate step from CI

### DIFF
--- a/ci/tasks/osb-integration-tests.sh
+++ b/ci/tasks/osb-integration-tests.sh
@@ -18,7 +18,6 @@ echo "Running brokerpak tests"
 ./gcp-service-broker pak test
 
 echo "Starting server"
-./gcp-service-broker migrate
 ./gcp-service-broker serve &
 
 sleep 5


### PR DESCRIPTION
Serve does an automatic migration, and the migration command has now been removed.