### PR TITLE
updated deps for CVE-2019-15759

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -342,15 +342,24 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:0ddb907d581670c05eb84f02ac1cb39e9666fbb7ca767a144d0d018aab80665c"
+  digest = "1:b5f4b4abdc0a9927dad7d4f50b4355ee6647b832077fe588190929c8fa88f1f3"
   name = "github.com/pivotal-cf/brokerapi"
   packages = [
     ".",
     "auth",
+    "middlewares/originating_identity_header",
   ]
   pruneopts = ""
-  revision = "d1fcddd951a6776bc01659143dda6aca057e98b7"
-  version = "v2.0.4"
+  revision = "644cda48aed126142816ea9fdf0c676e7d66032e"
+  version = "v4.2.1"
+
+[[projects]]
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,7 +17,7 @@ ignored = ["github.com/GoogleCloudPlatform/gcp-service-broker/tools/osdfgen*"]
 
 [[constraint]]
   name = "github.com/pivotal-cf/brokerapi"
-  version = "2.0.4"
+  version = "4.2.1"
 
 [[constraint]]
   name = "github.com/spf13/cobra"

--- a/vendor/github.com/pivotal-cf/brokerapi/.travis.yml
+++ b/vendor/github.com/pivotal-cf/brokerapi/.travis.yml
@@ -1,10 +1,9 @@
 language: go
 
 go:
-  - 1.7.x
-  - 1.8.x
   - 1.9.x
   - 1.10.x
+  - 1.11.x
 
 install:
   - go get -v -t ./...

--- a/vendor/github.com/pivotal-cf/brokerapi/Gopkg.lock
+++ b/vendor/github.com/pivotal-cf/brokerapi/Gopkg.lock
@@ -3,34 +3,52 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:9b6ce688faa0b6a4d495eadc4984327b91c70be9e6bb1b8dd452c7739af6d937"
   name = "code.cloudfoundry.org/lager"
   packages = [
     ".",
+    "internal/truncate",
     "lagerctx",
-    "lagertest"
+    "lagertest",
   ]
-  revision = "a77e1033ba8d8e36597be5c0d384ee6054105bc2"
+  pruneopts = ""
+  revision = "baf208c4c56b0a06ddec4a03c0348d072261d43a"
 
 [[projects]]
+  digest = "1:029f604c64cb13a3e2facee76fd1ae446d343df36fbb280b536bf36f9864ef1f"
   name = "github.com/drewolson/testflight"
   packages = ["."]
+  pruneopts = ""
   revision = "ab2d9a74b97eda058004c8deef80ac624432f408"
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/gorilla/context"
+  digest = "1:a25a2c5ae694b01713fb6cd03c3b1ac1ccc1902b9f0a922680a88ec254f968e1"
+  name = "github.com/google/uuid"
   packages = ["."]
-  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
-  version = "v1.1"
+  pruneopts = ""
+  revision = "9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8"
+  version = "v1.1.0"
 
 [[projects]]
+  digest = "1:dbbeb8ddb0be949954c8157ee8439c2adfd8dc1c9510eb44a6e58cb68c3dce28"
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  pruneopts = ""
+  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:c2c8666b4836c81a1d247bdf21c6a6fc1ab586538ab56f74437c2e0df5c375e1"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
-  version = "v1.6.1"
+  pruneopts = ""
+  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
+  version = "v1.6.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:8df8625c851c00c5c55a8cde64323d203fd1221a8ea3e137ad2d05d01945ca55"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -50,12 +68,14 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types"
+    "types",
   ]
+  pruneopts = ""
   revision = "9008c7b79f9636c46a0a945141020124702f0ecf"
 
 [[projects]]
   branch = "master"
+  digest = "1:44c1e18198c748e250810263a25205168c1cb452bdd8b850c40ef93b92ab4c7d"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -70,32 +90,48 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types"
+    "types",
   ]
+  pruneopts = ""
   revision = "49e4233a3b46c26dddd43cf84547cf31c92d0f2b"
 
 [[projects]]
   branch = "master"
+  digest = "1:a2692649163142c4dbe4ab102f8b012031e30a29021d523cb7b57f8d4e40913a"
   name = "github.com/pborman/uuid"
   packages = ["."]
-  revision = "c65b2f87fee37d1c7854c9164a450713c28d50cd"
+  pruneopts = ""
+  revision = "8b1b92947f46224e3b97bb1a3a5b0382be00d31e"
+
+[[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:b4ba046df563f56fe42b6270b20039107a37e1ab47c97aa47a16f848aa5b6d9a"
   name = "golang.org/x/net"
   packages = [
     "html",
     "html/atom",
-    "html/charset"
+    "html/charset",
   ]
+  pruneopts = ""
   revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
 
 [[projects]]
+  digest = "1:1ed067f6338b4c6496a27a889a53e5c1adcafdcc4442024a01e035e5dcf28698"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "a408501be4d17ee978c04a618e7a1b22af058c0e"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -114,19 +150,32 @@
     "language",
     "runes",
     "transform",
-    "unicode/cldr"
+    "unicode/cldr",
   ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:59925e8b791ee90b60e4dc05099d34fd38d0922a2a8f9b4e700cb61fc421e6b2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "e4d366fc3c7938e2958e662b4258c7a89e1f0e3e"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f5bfe5f275adcd02ff0727a3f378547c393e64ad2de6a2ce7e21f4b617d83456"
+  input-imports = [
+    "code.cloudfoundry.org/lager",
+    "code.cloudfoundry.org/lager/lagertest",
+    "github.com/drewolson/testflight",
+    "github.com/gorilla/mux",
+    "github.com/onsi/ginkgo",
+    "github.com/onsi/gomega",
+    "github.com/onsi/gomega/gbytes",
+    "github.com/pborman/uuid",
+    "github.com/pkg/errors",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/pivotal-cf/brokerapi/Gopkg.toml
+++ b/vendor/github.com/pivotal-cf/brokerapi/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/gorilla/mux"
-  version = "1.6.0"
+  version = "^1.6.1"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"
@@ -44,3 +44,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/pborman/uuid"
+
+[[constraint]]
+  name = "github.com/pkg/errors"
+  version = "^0.8.0"

--- a/vendor/github.com/pivotal-cf/brokerapi/README.md
+++ b/vendor/github.com/pivotal-cf/brokerapi/README.md
@@ -1,8 +1,11 @@
 # brokerapi
 
-[![Build Status](https://travis-ci.org/pivotal-cf/brokerapi.svg?branch=master)](https://travis-ci.org/pivotal-cf/brokerapi)
+[![Build
+Status](https://travis-ci.org/pivotal-cf/brokerapi.svg?branch=master)](https://travis-ci.org/pivotal-cf/brokerapi)
 
-A Go package for building [V2 Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker/) compliant Service Brokers.
+A Go package for building [V2 Open Service Broker
+API](https://github.com/openservicebrokerapi/servicebroker/) compliant Service
+Brokers.
 
 ## [Docs](https://godoc.org/github.com/pivotal-cf/brokerapi)
 
@@ -10,24 +13,53 @@ A Go package for building [V2 Open Service Broker API](https://github.com/opense
 
 - Go 1.7+
 - [lager](https://github.com/cloudfoundry/lager)
-- [gorilla/mux](https://github.com/gorilla/mux)
+- [gorilla/mux v1.6.1+](https://github.com/gorilla/mux)
 
-We use [dep](https://github.com/golang/dep) to manager our dependencies. Use `dep ensure` in order to download the required packages.
+We use [dep](https://github.com/golang/dep) to manager our dependencies. Use
+`dep ensure` in order to download the required packages.
 
 ## Usage
 
-`brokerapi` defines a [`ServiceBroker`](https://godoc.org/github.com/pivotal-cf/brokerapi#ServiceBroker) interface. Pass an implementation of this to [`brokerapi.New`](https://godoc.org/github.com/pivotal-cf/brokerapi#New), which returns an `http.Handler` that you can use to serve handle HTTP requests.
+`brokerapi` defines a
+[`ServiceBroker`](https://godoc.org/github.com/pivotal-cf/brokerapi#ServiceBroker)
+interface. Pass an implementation of this to
+[`brokerapi.New`](https://godoc.org/github.com/pivotal-cf/brokerapi#New), which
+returns an `http.Handler` that you can use to serve handle HTTP requests.
 
-Alternatively, if you already have a `*mux.Router` that you want to attach service broker routes to, you can use [`brokerapi.AttachRoutes`](https://godoc.org/github.com/pivotal-cf/brokerapi#AttachRoutes).
+Alternatively, if you already have a `*mux.Router` that you want to attach
+service broker routes to, you can use
+[`brokerapi.AttachRoutes`](https://godoc.org/github.com/pivotal-cf/brokerapi#AttachRoutes).
+Note in this case, the Basic Authentication and Originating Identity middleware
+will not be set up, so you will have to attach them manually if required.
 
 ## Error types
 
-`brokerapi` defines a handful of error types in `service_broker.go` for some common error cases that your service broker may encounter. Return these from your `ServiceBroker` methods where appropriate, and `brokerapi` will do the "right thing" (™), and give Cloud Foundry an appropriate status code, as per the [Service Broker API specification](https://docs.cloudfoundry.org/services/api.html).
+`brokerapi` defines a handful of error types in `service_broker.go` for some
+common error cases that your service broker may encounter. Return these from
+your `ServiceBroker` methods where appropriate, and `brokerapi` will do the
+"right thing" (™), and give Cloud Foundry an appropriate status code, as per
+the [Service Broker API
+specification](https://docs.cloudfoundry.org/services/api.html).
 
 ### Custom Errors
 
-`NewFailureResponse()` allows you to return a custom error from any of the `ServiceBroker` interface methods which return an error. Within this you must define an error, a HTTP response status code and a logging key. You can also use the `NewFailureResponseBuilder()` to add a custom `Error:` value in the response, or indicate that the broker should return an empty response rather than the error message.
+`NewFailureResponse()` allows you to return a custom error from any of the
+`ServiceBroker` interface methods which return an error. Within this you must
+define an error, a HTTP response status code and a logging key. You can also
+use the `NewFailureResponseBuilder()` to add a custom `Error:` value in the
+response, or indicate that the broker should return an empty response rather
+than the error message.
+
+## Originating Identity
+
+The request context for every request contains the unparsed
+`X-Broker-API-Originating-Identity` header under the key
+`originatingIdentityKey`.  More details on how the Open Service Broker API
+manages request originating identity is available
+[here](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#originating-identity).
 
 ## Example Service Broker
 
-You can see the [cf-redis](https://github.com/pivotal-cf/cf-redis-broker/blob/2f0e9a8ebb1012a9be74bbef2d411b0b3b60352f/broker/broker.go) service broker uses the BrokerAPI package to create a service broker for Redis.
+You can see the
+[cf-redis](https://github.com/pivotal-cf/cf-redis-broker/blob/2f0e9a8ebb1012a9be74bbef2d411b0b3b60352f/broker/broker.go)
+service broker uses the BrokerAPI package to create a service broker for Redis.

--- a/vendor/github.com/pivotal-cf/brokerapi/failure_response.go
+++ b/vendor/github.com/pivotal-cf/brokerapi/failure_response.go
@@ -71,11 +71,11 @@ func (f *FailureResponse) LoggerAction() string {
 // AppendErrorMessage returns an error with the message updated. All other properties are preserved.
 func (f *FailureResponse) AppendErrorMessage(msg string) *FailureResponse {
 	return &FailureResponse{
-		error: errors.New(fmt.Sprintf("%s %s", f.Error(), msg)),
-		statusCode: f.statusCode,
-		loggerAction: f.loggerAction,
+		error:         errors.New(fmt.Sprintf("%s %s", f.Error(), msg)),
+		statusCode:    f.statusCode,
+		loggerAction:  f.loggerAction,
 		emptyResponse: f.emptyResponse,
-		errorKey: f.errorKey,
+		errorKey:      f.errorKey,
 	}
 }
 

--- a/vendor/github.com/pivotal-cf/brokerapi/failure_response_test.go
+++ b/vendor/github.com/pivotal-cf/brokerapi/failure_response_test.go
@@ -65,7 +65,7 @@ var _ = Describe("FailureResponse", func() {
 			Expect(newError.Error()).To(Equal("my error message and some more details"))
 			Expect(newError.ValidatedStatusCode(nil)).To(Equal(http.StatusForbidden))
 			Expect(newError.LoggerAction()).To(Equal(failureResponse.LoggerAction()))
-			
+
 			errorResponse, typeCast := newError.ErrorResponse().(brokerapi.ErrorResponse)
 			Expect(typeCast).To(BeTrue())
 			Expect(errorResponse.Error).To(Equal("some-key"))

--- a/vendor/github.com/pivotal-cf/brokerapi/fakes/auto_fake_service_broker.go
+++ b/vendor/github.com/pivotal-cf/brokerapi/fakes/auto_fake_service_broker.go
@@ -8,7 +8,7 @@ import (
 	brokerapi "github.com/pivotal-cf/brokerapi"
 )
 
-type FakeServiceBroker struct {
+type AutoFakeServiceBroker struct {
 	BindStub        func(context.Context, string, string, brokerapi.BindDetails, bool) (brokerapi.Binding, error)
 	bindMutex       sync.RWMutex
 	bindArgsForCall []struct {
@@ -168,7 +168,7 @@ type FakeServiceBroker struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServiceBroker) Bind(arg1 context.Context, arg2 string, arg3 string, arg4 brokerapi.BindDetails, arg5 bool) (brokerapi.Binding, error) {
+func (fake *AutoFakeServiceBroker) Bind(arg1 context.Context, arg2 string, arg3 string, arg4 brokerapi.BindDetails, arg5 bool) (brokerapi.Binding, error) {
 	fake.bindMutex.Lock()
 	ret, specificReturn := fake.bindReturnsOnCall[len(fake.bindArgsForCall)]
 	fake.bindArgsForCall = append(fake.bindArgsForCall, struct {
@@ -190,26 +190,26 @@ func (fake *FakeServiceBroker) Bind(arg1 context.Context, arg2 string, arg3 stri
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) BindCallCount() int {
+func (fake *AutoFakeServiceBroker) BindCallCount() int {
 	fake.bindMutex.RLock()
 	defer fake.bindMutex.RUnlock()
 	return len(fake.bindArgsForCall)
 }
 
-func (fake *FakeServiceBroker) BindCalls(stub func(context.Context, string, string, brokerapi.BindDetails, bool) (brokerapi.Binding, error)) {
+func (fake *AutoFakeServiceBroker) BindCalls(stub func(context.Context, string, string, brokerapi.BindDetails, bool) (brokerapi.Binding, error)) {
 	fake.bindMutex.Lock()
 	defer fake.bindMutex.Unlock()
 	fake.BindStub = stub
 }
 
-func (fake *FakeServiceBroker) BindArgsForCall(i int) (context.Context, string, string, brokerapi.BindDetails, bool) {
+func (fake *AutoFakeServiceBroker) BindArgsForCall(i int) (context.Context, string, string, brokerapi.BindDetails, bool) {
 	fake.bindMutex.RLock()
 	defer fake.bindMutex.RUnlock()
 	argsForCall := fake.bindArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
-func (fake *FakeServiceBroker) BindReturns(result1 brokerapi.Binding, result2 error) {
+func (fake *AutoFakeServiceBroker) BindReturns(result1 brokerapi.Binding, result2 error) {
 	fake.bindMutex.Lock()
 	defer fake.bindMutex.Unlock()
 	fake.BindStub = nil
@@ -219,7 +219,7 @@ func (fake *FakeServiceBroker) BindReturns(result1 brokerapi.Binding, result2 er
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) BindReturnsOnCall(i int, result1 brokerapi.Binding, result2 error) {
+func (fake *AutoFakeServiceBroker) BindReturnsOnCall(i int, result1 brokerapi.Binding, result2 error) {
 	fake.bindMutex.Lock()
 	defer fake.bindMutex.Unlock()
 	fake.BindStub = nil
@@ -235,7 +235,7 @@ func (fake *FakeServiceBroker) BindReturnsOnCall(i int, result1 brokerapi.Bindin
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) Deprovision(arg1 context.Context, arg2 string, arg3 brokerapi.DeprovisionDetails, arg4 bool) (brokerapi.DeprovisionServiceSpec, error) {
+func (fake *AutoFakeServiceBroker) Deprovision(arg1 context.Context, arg2 string, arg3 brokerapi.DeprovisionDetails, arg4 bool) (brokerapi.DeprovisionServiceSpec, error) {
 	fake.deprovisionMutex.Lock()
 	ret, specificReturn := fake.deprovisionReturnsOnCall[len(fake.deprovisionArgsForCall)]
 	fake.deprovisionArgsForCall = append(fake.deprovisionArgsForCall, struct {
@@ -256,26 +256,26 @@ func (fake *FakeServiceBroker) Deprovision(arg1 context.Context, arg2 string, ar
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) DeprovisionCallCount() int {
+func (fake *AutoFakeServiceBroker) DeprovisionCallCount() int {
 	fake.deprovisionMutex.RLock()
 	defer fake.deprovisionMutex.RUnlock()
 	return len(fake.deprovisionArgsForCall)
 }
 
-func (fake *FakeServiceBroker) DeprovisionCalls(stub func(context.Context, string, brokerapi.DeprovisionDetails, bool) (brokerapi.DeprovisionServiceSpec, error)) {
+func (fake *AutoFakeServiceBroker) DeprovisionCalls(stub func(context.Context, string, brokerapi.DeprovisionDetails, bool) (brokerapi.DeprovisionServiceSpec, error)) {
 	fake.deprovisionMutex.Lock()
 	defer fake.deprovisionMutex.Unlock()
 	fake.DeprovisionStub = stub
 }
 
-func (fake *FakeServiceBroker) DeprovisionArgsForCall(i int) (context.Context, string, brokerapi.DeprovisionDetails, bool) {
+func (fake *AutoFakeServiceBroker) DeprovisionArgsForCall(i int) (context.Context, string, brokerapi.DeprovisionDetails, bool) {
 	fake.deprovisionMutex.RLock()
 	defer fake.deprovisionMutex.RUnlock()
 	argsForCall := fake.deprovisionArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeServiceBroker) DeprovisionReturns(result1 brokerapi.DeprovisionServiceSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) DeprovisionReturns(result1 brokerapi.DeprovisionServiceSpec, result2 error) {
 	fake.deprovisionMutex.Lock()
 	defer fake.deprovisionMutex.Unlock()
 	fake.DeprovisionStub = nil
@@ -285,7 +285,7 @@ func (fake *FakeServiceBroker) DeprovisionReturns(result1 brokerapi.DeprovisionS
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) DeprovisionReturnsOnCall(i int, result1 brokerapi.DeprovisionServiceSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) DeprovisionReturnsOnCall(i int, result1 brokerapi.DeprovisionServiceSpec, result2 error) {
 	fake.deprovisionMutex.Lock()
 	defer fake.deprovisionMutex.Unlock()
 	fake.DeprovisionStub = nil
@@ -301,7 +301,7 @@ func (fake *FakeServiceBroker) DeprovisionReturnsOnCall(i int, result1 brokerapi
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) GetBinding(arg1 context.Context, arg2 string, arg3 string) (brokerapi.GetBindingSpec, error) {
+func (fake *AutoFakeServiceBroker) GetBinding(arg1 context.Context, arg2 string, arg3 string) (brokerapi.GetBindingSpec, error) {
 	fake.getBindingMutex.Lock()
 	ret, specificReturn := fake.getBindingReturnsOnCall[len(fake.getBindingArgsForCall)]
 	fake.getBindingArgsForCall = append(fake.getBindingArgsForCall, struct {
@@ -321,26 +321,26 @@ func (fake *FakeServiceBroker) GetBinding(arg1 context.Context, arg2 string, arg
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) GetBindingCallCount() int {
+func (fake *AutoFakeServiceBroker) GetBindingCallCount() int {
 	fake.getBindingMutex.RLock()
 	defer fake.getBindingMutex.RUnlock()
 	return len(fake.getBindingArgsForCall)
 }
 
-func (fake *FakeServiceBroker) GetBindingCalls(stub func(context.Context, string, string) (brokerapi.GetBindingSpec, error)) {
+func (fake *AutoFakeServiceBroker) GetBindingCalls(stub func(context.Context, string, string) (brokerapi.GetBindingSpec, error)) {
 	fake.getBindingMutex.Lock()
 	defer fake.getBindingMutex.Unlock()
 	fake.GetBindingStub = stub
 }
 
-func (fake *FakeServiceBroker) GetBindingArgsForCall(i int) (context.Context, string, string) {
+func (fake *AutoFakeServiceBroker) GetBindingArgsForCall(i int) (context.Context, string, string) {
 	fake.getBindingMutex.RLock()
 	defer fake.getBindingMutex.RUnlock()
 	argsForCall := fake.getBindingArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeServiceBroker) GetBindingReturns(result1 brokerapi.GetBindingSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) GetBindingReturns(result1 brokerapi.GetBindingSpec, result2 error) {
 	fake.getBindingMutex.Lock()
 	defer fake.getBindingMutex.Unlock()
 	fake.GetBindingStub = nil
@@ -350,7 +350,7 @@ func (fake *FakeServiceBroker) GetBindingReturns(result1 brokerapi.GetBindingSpe
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) GetBindingReturnsOnCall(i int, result1 brokerapi.GetBindingSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) GetBindingReturnsOnCall(i int, result1 brokerapi.GetBindingSpec, result2 error) {
 	fake.getBindingMutex.Lock()
 	defer fake.getBindingMutex.Unlock()
 	fake.GetBindingStub = nil
@@ -366,7 +366,7 @@ func (fake *FakeServiceBroker) GetBindingReturnsOnCall(i int, result1 brokerapi.
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) GetInstance(arg1 context.Context, arg2 string) (brokerapi.GetInstanceDetailsSpec, error) {
+func (fake *AutoFakeServiceBroker) GetInstance(arg1 context.Context, arg2 string) (brokerapi.GetInstanceDetailsSpec, error) {
 	fake.getInstanceMutex.Lock()
 	ret, specificReturn := fake.getInstanceReturnsOnCall[len(fake.getInstanceArgsForCall)]
 	fake.getInstanceArgsForCall = append(fake.getInstanceArgsForCall, struct {
@@ -385,26 +385,26 @@ func (fake *FakeServiceBroker) GetInstance(arg1 context.Context, arg2 string) (b
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) GetInstanceCallCount() int {
+func (fake *AutoFakeServiceBroker) GetInstanceCallCount() int {
 	fake.getInstanceMutex.RLock()
 	defer fake.getInstanceMutex.RUnlock()
 	return len(fake.getInstanceArgsForCall)
 }
 
-func (fake *FakeServiceBroker) GetInstanceCalls(stub func(context.Context, string) (brokerapi.GetInstanceDetailsSpec, error)) {
+func (fake *AutoFakeServiceBroker) GetInstanceCalls(stub func(context.Context, string) (brokerapi.GetInstanceDetailsSpec, error)) {
 	fake.getInstanceMutex.Lock()
 	defer fake.getInstanceMutex.Unlock()
 	fake.GetInstanceStub = stub
 }
 
-func (fake *FakeServiceBroker) GetInstanceArgsForCall(i int) (context.Context, string) {
+func (fake *AutoFakeServiceBroker) GetInstanceArgsForCall(i int) (context.Context, string) {
 	fake.getInstanceMutex.RLock()
 	defer fake.getInstanceMutex.RUnlock()
 	argsForCall := fake.getInstanceArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeServiceBroker) GetInstanceReturns(result1 brokerapi.GetInstanceDetailsSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) GetInstanceReturns(result1 brokerapi.GetInstanceDetailsSpec, result2 error) {
 	fake.getInstanceMutex.Lock()
 	defer fake.getInstanceMutex.Unlock()
 	fake.GetInstanceStub = nil
@@ -414,7 +414,7 @@ func (fake *FakeServiceBroker) GetInstanceReturns(result1 brokerapi.GetInstanceD
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) GetInstanceReturnsOnCall(i int, result1 brokerapi.GetInstanceDetailsSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) GetInstanceReturnsOnCall(i int, result1 brokerapi.GetInstanceDetailsSpec, result2 error) {
 	fake.getInstanceMutex.Lock()
 	defer fake.getInstanceMutex.Unlock()
 	fake.GetInstanceStub = nil
@@ -430,7 +430,7 @@ func (fake *FakeServiceBroker) GetInstanceReturnsOnCall(i int, result1 brokerapi
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) LastBindingOperation(arg1 context.Context, arg2 string, arg3 string, arg4 brokerapi.PollDetails) (brokerapi.LastOperation, error) {
+func (fake *AutoFakeServiceBroker) LastBindingOperation(arg1 context.Context, arg2 string, arg3 string, arg4 brokerapi.PollDetails) (brokerapi.LastOperation, error) {
 	fake.lastBindingOperationMutex.Lock()
 	ret, specificReturn := fake.lastBindingOperationReturnsOnCall[len(fake.lastBindingOperationArgsForCall)]
 	fake.lastBindingOperationArgsForCall = append(fake.lastBindingOperationArgsForCall, struct {
@@ -451,26 +451,26 @@ func (fake *FakeServiceBroker) LastBindingOperation(arg1 context.Context, arg2 s
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) LastBindingOperationCallCount() int {
+func (fake *AutoFakeServiceBroker) LastBindingOperationCallCount() int {
 	fake.lastBindingOperationMutex.RLock()
 	defer fake.lastBindingOperationMutex.RUnlock()
 	return len(fake.lastBindingOperationArgsForCall)
 }
 
-func (fake *FakeServiceBroker) LastBindingOperationCalls(stub func(context.Context, string, string, brokerapi.PollDetails) (brokerapi.LastOperation, error)) {
+func (fake *AutoFakeServiceBroker) LastBindingOperationCalls(stub func(context.Context, string, string, brokerapi.PollDetails) (brokerapi.LastOperation, error)) {
 	fake.lastBindingOperationMutex.Lock()
 	defer fake.lastBindingOperationMutex.Unlock()
 	fake.LastBindingOperationStub = stub
 }
 
-func (fake *FakeServiceBroker) LastBindingOperationArgsForCall(i int) (context.Context, string, string, brokerapi.PollDetails) {
+func (fake *AutoFakeServiceBroker) LastBindingOperationArgsForCall(i int) (context.Context, string, string, brokerapi.PollDetails) {
 	fake.lastBindingOperationMutex.RLock()
 	defer fake.lastBindingOperationMutex.RUnlock()
 	argsForCall := fake.lastBindingOperationArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeServiceBroker) LastBindingOperationReturns(result1 brokerapi.LastOperation, result2 error) {
+func (fake *AutoFakeServiceBroker) LastBindingOperationReturns(result1 brokerapi.LastOperation, result2 error) {
 	fake.lastBindingOperationMutex.Lock()
 	defer fake.lastBindingOperationMutex.Unlock()
 	fake.LastBindingOperationStub = nil
@@ -480,7 +480,7 @@ func (fake *FakeServiceBroker) LastBindingOperationReturns(result1 brokerapi.Las
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) LastBindingOperationReturnsOnCall(i int, result1 brokerapi.LastOperation, result2 error) {
+func (fake *AutoFakeServiceBroker) LastBindingOperationReturnsOnCall(i int, result1 brokerapi.LastOperation, result2 error) {
 	fake.lastBindingOperationMutex.Lock()
 	defer fake.lastBindingOperationMutex.Unlock()
 	fake.LastBindingOperationStub = nil
@@ -496,7 +496,7 @@ func (fake *FakeServiceBroker) LastBindingOperationReturnsOnCall(i int, result1 
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) LastOperation(arg1 context.Context, arg2 string, arg3 brokerapi.PollDetails) (brokerapi.LastOperation, error) {
+func (fake *AutoFakeServiceBroker) LastOperation(arg1 context.Context, arg2 string, arg3 brokerapi.PollDetails) (brokerapi.LastOperation, error) {
 	fake.lastOperationMutex.Lock()
 	ret, specificReturn := fake.lastOperationReturnsOnCall[len(fake.lastOperationArgsForCall)]
 	fake.lastOperationArgsForCall = append(fake.lastOperationArgsForCall, struct {
@@ -516,26 +516,26 @@ func (fake *FakeServiceBroker) LastOperation(arg1 context.Context, arg2 string, 
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) LastOperationCallCount() int {
+func (fake *AutoFakeServiceBroker) LastOperationCallCount() int {
 	fake.lastOperationMutex.RLock()
 	defer fake.lastOperationMutex.RUnlock()
 	return len(fake.lastOperationArgsForCall)
 }
 
-func (fake *FakeServiceBroker) LastOperationCalls(stub func(context.Context, string, brokerapi.PollDetails) (brokerapi.LastOperation, error)) {
+func (fake *AutoFakeServiceBroker) LastOperationCalls(stub func(context.Context, string, brokerapi.PollDetails) (brokerapi.LastOperation, error)) {
 	fake.lastOperationMutex.Lock()
 	defer fake.lastOperationMutex.Unlock()
 	fake.LastOperationStub = stub
 }
 
-func (fake *FakeServiceBroker) LastOperationArgsForCall(i int) (context.Context, string, brokerapi.PollDetails) {
+func (fake *AutoFakeServiceBroker) LastOperationArgsForCall(i int) (context.Context, string, brokerapi.PollDetails) {
 	fake.lastOperationMutex.RLock()
 	defer fake.lastOperationMutex.RUnlock()
 	argsForCall := fake.lastOperationArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeServiceBroker) LastOperationReturns(result1 brokerapi.LastOperation, result2 error) {
+func (fake *AutoFakeServiceBroker) LastOperationReturns(result1 brokerapi.LastOperation, result2 error) {
 	fake.lastOperationMutex.Lock()
 	defer fake.lastOperationMutex.Unlock()
 	fake.LastOperationStub = nil
@@ -545,7 +545,7 @@ func (fake *FakeServiceBroker) LastOperationReturns(result1 brokerapi.LastOperat
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) LastOperationReturnsOnCall(i int, result1 brokerapi.LastOperation, result2 error) {
+func (fake *AutoFakeServiceBroker) LastOperationReturnsOnCall(i int, result1 brokerapi.LastOperation, result2 error) {
 	fake.lastOperationMutex.Lock()
 	defer fake.lastOperationMutex.Unlock()
 	fake.LastOperationStub = nil
@@ -561,7 +561,7 @@ func (fake *FakeServiceBroker) LastOperationReturnsOnCall(i int, result1 brokera
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) Provision(arg1 context.Context, arg2 string, arg3 brokerapi.ProvisionDetails, arg4 bool) (brokerapi.ProvisionedServiceSpec, error) {
+func (fake *AutoFakeServiceBroker) Provision(arg1 context.Context, arg2 string, arg3 brokerapi.ProvisionDetails, arg4 bool) (brokerapi.ProvisionedServiceSpec, error) {
 	fake.provisionMutex.Lock()
 	ret, specificReturn := fake.provisionReturnsOnCall[len(fake.provisionArgsForCall)]
 	fake.provisionArgsForCall = append(fake.provisionArgsForCall, struct {
@@ -582,26 +582,26 @@ func (fake *FakeServiceBroker) Provision(arg1 context.Context, arg2 string, arg3
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) ProvisionCallCount() int {
+func (fake *AutoFakeServiceBroker) ProvisionCallCount() int {
 	fake.provisionMutex.RLock()
 	defer fake.provisionMutex.RUnlock()
 	return len(fake.provisionArgsForCall)
 }
 
-func (fake *FakeServiceBroker) ProvisionCalls(stub func(context.Context, string, brokerapi.ProvisionDetails, bool) (brokerapi.ProvisionedServiceSpec, error)) {
+func (fake *AutoFakeServiceBroker) ProvisionCalls(stub func(context.Context, string, brokerapi.ProvisionDetails, bool) (brokerapi.ProvisionedServiceSpec, error)) {
 	fake.provisionMutex.Lock()
 	defer fake.provisionMutex.Unlock()
 	fake.ProvisionStub = stub
 }
 
-func (fake *FakeServiceBroker) ProvisionArgsForCall(i int) (context.Context, string, brokerapi.ProvisionDetails, bool) {
+func (fake *AutoFakeServiceBroker) ProvisionArgsForCall(i int) (context.Context, string, brokerapi.ProvisionDetails, bool) {
 	fake.provisionMutex.RLock()
 	defer fake.provisionMutex.RUnlock()
 	argsForCall := fake.provisionArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeServiceBroker) ProvisionReturns(result1 brokerapi.ProvisionedServiceSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) ProvisionReturns(result1 brokerapi.ProvisionedServiceSpec, result2 error) {
 	fake.provisionMutex.Lock()
 	defer fake.provisionMutex.Unlock()
 	fake.ProvisionStub = nil
@@ -611,7 +611,7 @@ func (fake *FakeServiceBroker) ProvisionReturns(result1 brokerapi.ProvisionedSer
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) ProvisionReturnsOnCall(i int, result1 brokerapi.ProvisionedServiceSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) ProvisionReturnsOnCall(i int, result1 brokerapi.ProvisionedServiceSpec, result2 error) {
 	fake.provisionMutex.Lock()
 	defer fake.provisionMutex.Unlock()
 	fake.ProvisionStub = nil
@@ -627,7 +627,7 @@ func (fake *FakeServiceBroker) ProvisionReturnsOnCall(i int, result1 brokerapi.P
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) Services(arg1 context.Context) ([]brokerapi.Service, error) {
+func (fake *AutoFakeServiceBroker) Services(arg1 context.Context) ([]brokerapi.Service, error) {
 	fake.servicesMutex.Lock()
 	ret, specificReturn := fake.servicesReturnsOnCall[len(fake.servicesArgsForCall)]
 	fake.servicesArgsForCall = append(fake.servicesArgsForCall, struct {
@@ -645,26 +645,26 @@ func (fake *FakeServiceBroker) Services(arg1 context.Context) ([]brokerapi.Servi
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) ServicesCallCount() int {
+func (fake *AutoFakeServiceBroker) ServicesCallCount() int {
 	fake.servicesMutex.RLock()
 	defer fake.servicesMutex.RUnlock()
 	return len(fake.servicesArgsForCall)
 }
 
-func (fake *FakeServiceBroker) ServicesCalls(stub func(context.Context) ([]brokerapi.Service, error)) {
+func (fake *AutoFakeServiceBroker) ServicesCalls(stub func(context.Context) ([]brokerapi.Service, error)) {
 	fake.servicesMutex.Lock()
 	defer fake.servicesMutex.Unlock()
 	fake.ServicesStub = stub
 }
 
-func (fake *FakeServiceBroker) ServicesArgsForCall(i int) context.Context {
+func (fake *AutoFakeServiceBroker) ServicesArgsForCall(i int) context.Context {
 	fake.servicesMutex.RLock()
 	defer fake.servicesMutex.RUnlock()
 	argsForCall := fake.servicesArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeServiceBroker) ServicesReturns(result1 []brokerapi.Service, result2 error) {
+func (fake *AutoFakeServiceBroker) ServicesReturns(result1 []brokerapi.Service, result2 error) {
 	fake.servicesMutex.Lock()
 	defer fake.servicesMutex.Unlock()
 	fake.ServicesStub = nil
@@ -674,7 +674,7 @@ func (fake *FakeServiceBroker) ServicesReturns(result1 []brokerapi.Service, resu
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) ServicesReturnsOnCall(i int, result1 []brokerapi.Service, result2 error) {
+func (fake *AutoFakeServiceBroker) ServicesReturnsOnCall(i int, result1 []brokerapi.Service, result2 error) {
 	fake.servicesMutex.Lock()
 	defer fake.servicesMutex.Unlock()
 	fake.ServicesStub = nil
@@ -690,7 +690,7 @@ func (fake *FakeServiceBroker) ServicesReturnsOnCall(i int, result1 []brokerapi.
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) Unbind(arg1 context.Context, arg2 string, arg3 string, arg4 brokerapi.UnbindDetails, arg5 bool) (brokerapi.UnbindSpec, error) {
+func (fake *AutoFakeServiceBroker) Unbind(arg1 context.Context, arg2 string, arg3 string, arg4 brokerapi.UnbindDetails, arg5 bool) (brokerapi.UnbindSpec, error) {
 	fake.unbindMutex.Lock()
 	ret, specificReturn := fake.unbindReturnsOnCall[len(fake.unbindArgsForCall)]
 	fake.unbindArgsForCall = append(fake.unbindArgsForCall, struct {
@@ -712,26 +712,26 @@ func (fake *FakeServiceBroker) Unbind(arg1 context.Context, arg2 string, arg3 st
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) UnbindCallCount() int {
+func (fake *AutoFakeServiceBroker) UnbindCallCount() int {
 	fake.unbindMutex.RLock()
 	defer fake.unbindMutex.RUnlock()
 	return len(fake.unbindArgsForCall)
 }
 
-func (fake *FakeServiceBroker) UnbindCalls(stub func(context.Context, string, string, brokerapi.UnbindDetails, bool) (brokerapi.UnbindSpec, error)) {
+func (fake *AutoFakeServiceBroker) UnbindCalls(stub func(context.Context, string, string, brokerapi.UnbindDetails, bool) (brokerapi.UnbindSpec, error)) {
 	fake.unbindMutex.Lock()
 	defer fake.unbindMutex.Unlock()
 	fake.UnbindStub = stub
 }
 
-func (fake *FakeServiceBroker) UnbindArgsForCall(i int) (context.Context, string, string, brokerapi.UnbindDetails, bool) {
+func (fake *AutoFakeServiceBroker) UnbindArgsForCall(i int) (context.Context, string, string, brokerapi.UnbindDetails, bool) {
 	fake.unbindMutex.RLock()
 	defer fake.unbindMutex.RUnlock()
 	argsForCall := fake.unbindArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
-func (fake *FakeServiceBroker) UnbindReturns(result1 brokerapi.UnbindSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) UnbindReturns(result1 brokerapi.UnbindSpec, result2 error) {
 	fake.unbindMutex.Lock()
 	defer fake.unbindMutex.Unlock()
 	fake.UnbindStub = nil
@@ -741,7 +741,7 @@ func (fake *FakeServiceBroker) UnbindReturns(result1 brokerapi.UnbindSpec, resul
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) UnbindReturnsOnCall(i int, result1 brokerapi.UnbindSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) UnbindReturnsOnCall(i int, result1 brokerapi.UnbindSpec, result2 error) {
 	fake.unbindMutex.Lock()
 	defer fake.unbindMutex.Unlock()
 	fake.UnbindStub = nil
@@ -757,7 +757,7 @@ func (fake *FakeServiceBroker) UnbindReturnsOnCall(i int, result1 brokerapi.Unbi
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) Update(arg1 context.Context, arg2 string, arg3 brokerapi.UpdateDetails, arg4 bool) (brokerapi.UpdateServiceSpec, error) {
+func (fake *AutoFakeServiceBroker) Update(arg1 context.Context, arg2 string, arg3 brokerapi.UpdateDetails, arg4 bool) (brokerapi.UpdateServiceSpec, error) {
 	fake.updateMutex.Lock()
 	ret, specificReturn := fake.updateReturnsOnCall[len(fake.updateArgsForCall)]
 	fake.updateArgsForCall = append(fake.updateArgsForCall, struct {
@@ -778,26 +778,26 @@ func (fake *FakeServiceBroker) Update(arg1 context.Context, arg2 string, arg3 br
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceBroker) UpdateCallCount() int {
+func (fake *AutoFakeServiceBroker) UpdateCallCount() int {
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	return len(fake.updateArgsForCall)
 }
 
-func (fake *FakeServiceBroker) UpdateCalls(stub func(context.Context, string, brokerapi.UpdateDetails, bool) (brokerapi.UpdateServiceSpec, error)) {
+func (fake *AutoFakeServiceBroker) UpdateCalls(stub func(context.Context, string, brokerapi.UpdateDetails, bool) (brokerapi.UpdateServiceSpec, error)) {
 	fake.updateMutex.Lock()
 	defer fake.updateMutex.Unlock()
 	fake.UpdateStub = stub
 }
 
-func (fake *FakeServiceBroker) UpdateArgsForCall(i int) (context.Context, string, brokerapi.UpdateDetails, bool) {
+func (fake *AutoFakeServiceBroker) UpdateArgsForCall(i int) (context.Context, string, brokerapi.UpdateDetails, bool) {
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	argsForCall := fake.updateArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeServiceBroker) UpdateReturns(result1 brokerapi.UpdateServiceSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) UpdateReturns(result1 brokerapi.UpdateServiceSpec, result2 error) {
 	fake.updateMutex.Lock()
 	defer fake.updateMutex.Unlock()
 	fake.UpdateStub = nil
@@ -807,7 +807,7 @@ func (fake *FakeServiceBroker) UpdateReturns(result1 brokerapi.UpdateServiceSpec
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) UpdateReturnsOnCall(i int, result1 brokerapi.UpdateServiceSpec, result2 error) {
+func (fake *AutoFakeServiceBroker) UpdateReturnsOnCall(i int, result1 brokerapi.UpdateServiceSpec, result2 error) {
 	fake.updateMutex.Lock()
 	defer fake.updateMutex.Unlock()
 	fake.UpdateStub = nil
@@ -823,7 +823,7 @@ func (fake *FakeServiceBroker) UpdateReturnsOnCall(i int, result1 brokerapi.Upda
 	}{result1, result2}
 }
 
-func (fake *FakeServiceBroker) Invocations() map[string][][]interface{} {
+func (fake *AutoFakeServiceBroker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.bindMutex.RLock()
@@ -853,7 +853,7 @@ func (fake *FakeServiceBroker) Invocations() map[string][][]interface{} {
 	return copiedInvocations
 }
 
-func (fake *FakeServiceBroker) recordInvocation(key string, args []interface{}) {
+func (fake *AutoFakeServiceBroker) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
@@ -865,4 +865,4 @@ func (fake *FakeServiceBroker) recordInvocation(key string, args []interface{}) 
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ brokerapi.ServiceBroker = new(FakeServiceBroker)
+var _ brokerapi.ServiceBroker = new(AutoFakeServiceBroker)

--- a/vendor/github.com/pivotal-cf/brokerapi/fixtures/async_bind_response.json
+++ b/vendor/github.com/pivotal-cf/brokerapi/fixtures/async_bind_response.json
@@ -1,0 +1,3 @@
+{
+  "operation":"0xDEADBEEF"
+}

--- a/vendor/github.com/pivotal-cf/brokerapi/fixtures/catalog.json
+++ b/vendor/github.com/pivotal-cf/brokerapi/fixtures/catalog.json
@@ -12,6 +12,11 @@
       "metadata": {
         "displayName": "Cassandra"
       },
+      "maintenance_info": {
+        "public": {
+          "name": "foo"
+        }
+      },
       "schemas": {
         "service_instance": {
           "create": {

--- a/vendor/github.com/pivotal-cf/brokerapi/fixtures/get_instance.json
+++ b/vendor/github.com/pivotal-cf/brokerapi/fixtures/get_instance.json
@@ -1,0 +1,8 @@
+{
+    "service_id" : "0A789746-596F-4CEA-BFAC-A0795DA056E3",
+    "plan_id" : "plan-id",
+    "dashboard_url" : "https://example.com/dashboard/some-instance",
+    "parameters": {
+			"param1" : "value1"
+    }
+}

--- a/vendor/github.com/pivotal-cf/brokerapi/fixtures/updating_with_dashboard.json
+++ b/vendor/github.com/pivotal-cf/brokerapi/fixtures/updating_with_dashboard.json
@@ -1,0 +1,3 @@
+{
+  "dashboard_url": "some-dashboard-url"
+}

--- a/vendor/github.com/pivotal-cf/brokerapi/middlewares/originating_identity_header/originating_identity_header.go
+++ b/vendor/github.com/pivotal-cf/brokerapi/middlewares/originating_identity_header/originating_identity_header.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2015-Present Pivotal Software, Inc. All rights reserved.
+
+// This program and the accompanying materials are made available under
+// the terms of the under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package originating_identity_header
+
+import (
+	"context"
+	"net/http"
+)
+
+const (
+	originatingIdentityKey = "originatingIdentity"
+)
+
+func AddToContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		originatingIdentity := req.Header.Get("X-Broker-API-Originating-Identity")
+		newCtx := context.WithValue(req.Context(), originatingIdentityKey, originatingIdentity)
+		next.ServeHTTP(w, req.WithContext(newCtx))
+	})
+}
+

--- a/vendor/github.com/pivotal-cf/brokerapi/response.go
+++ b/vendor/github.com/pivotal-cf/brokerapi/response.go
@@ -31,7 +31,15 @@ type ProvisioningResponse struct {
 	OperationData string `json:"operation,omitempty"`
 }
 
+type GetInstanceResponse struct {
+	ServiceID    string      `json:"service_id"`
+	PlanID       string      `json:"plan_id"`
+	DashboardURL string      `json:"dashboard_url,omitempty"`
+	Parameters   interface{} `json:"parameters,omitempty"`
+}
+
 type UpdateResponse struct {
+	DashboardURL  string `json:"dashboard_url,omitempty"`
 	OperationData string `json:"operation,omitempty"`
 }
 
@@ -42,6 +50,26 @@ type DeprovisionResponse struct {
 type LastOperationResponse struct {
 	State       LastOperationState `json:"state"`
 	Description string             `json:"description,omitempty"`
+}
+
+type AsyncBindResponse struct {
+	OperationData string `json:"operation,omitempty"`
+}
+
+type BindingResponse struct {
+	Credentials     interface{}   `json:"credentials"`
+	SyslogDrainURL  string        `json:"syslog_drain_url,omitempty"`
+	RouteServiceURL string        `json:"route_service_url,omitempty"`
+	VolumeMounts    []VolumeMount `json:"volume_mounts,omitempty"`
+}
+
+type GetBindingResponse struct {
+	BindingResponse
+	Parameters interface{} `json:"parameters,omitempty"`
+}
+
+type UnbindResponse struct {
+	OperationData string `json:"operation,omitempty"`
 }
 
 type ExperimentalVolumeMountBindingResponse struct {

--- a/vendor/github.com/pivotal-cf/brokerapi/response_test.go
+++ b/vendor/github.com/pivotal-cf/brokerapi/response_test.go
@@ -60,10 +60,34 @@ var _ = Describe("Provisioning Response", func() {
 	})
 })
 
+var _ = Describe("Update Response", func() {
+	Describe("JSON encoding", func() {
+		Context("when the dashboard URL is not present", func() {
+			It("does not return it in the JSON", func() {
+				updateResponse := brokerapi.UpdateResponse{}
+				jsonString := `{}`
+
+				Expect(json.Marshal(updateResponse)).To(MatchJSON(jsonString))
+			})
+		})
+
+		Context("when the dashboard URL is present", func() {
+			It("returns it in the JSON", func() {
+				updateResponse := brokerapi.UpdateResponse{
+					DashboardURL: "http://example.com/broker_updated",
+				}
+				jsonString := `{"dashboard_url":"http://example.com/broker_updated"}`
+
+				Expect(json.Marshal(updateResponse)).To(MatchJSON(jsonString))
+			})
+		})
+	})
+})
+
 var _ = Describe("Binding Response", func() {
 	Describe("JSON encoding", func() {
 		It("has a credentials object", func() {
-			binding := brokerapi.Binding{}
+			binding := brokerapi.BindingResponse{}
 			jsonString := `{"credentials":null}`
 
 			Expect(json.Marshal(binding)).To(MatchJSON(jsonString))

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.x
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## License
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/bench_test.go
+++ b/vendor/github.com/pkg/errors/bench_test.go
@@ -1,0 +1,63 @@
+// +build go1.7
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	stderrors "errors"
+)
+
+func noErrors(at, depth int) error {
+	if at >= depth {
+		return stderrors.New("no error")
+	}
+	return noErrors(at+1, depth)
+}
+
+func yesErrors(at, depth int) error {
+	if at >= depth {
+		return New("ye error")
+	}
+	return yesErrors(at+1, depth)
+}
+
+// GlobalE is an exported global to store the result of benchmark results,
+// preventing the compiler from optimising the benchmark functions away.
+var GlobalE error
+
+func BenchmarkErrors(b *testing.B) {
+	type run struct {
+		stack int
+		std   bool
+	}
+	runs := []run{
+		{10, false},
+		{10, true},
+		{100, false},
+		{100, true},
+		{1000, false},
+		{1000, true},
+	}
+	for _, r := range runs {
+		part := "pkg/errors"
+		if r.std {
+			part = "errors"
+		}
+		name := fmt.Sprintf("%s-stack-%d", part, r.stack)
+		b.Run(name, func(b *testing.B) {
+			var err error
+			f := yesErrors
+			if r.std {
+				f = noErrors
+			}
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				err = f(0, r.stack)
+			}
+			b.StopTimer()
+			GlobalE = err
+		})
+	}
+}

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,282 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/errors_test.go
+++ b/vendor/github.com/pkg/errors/errors_test.go
@@ -1,0 +1,251 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		err  string
+		want error
+	}{
+		{"", fmt.Errorf("")},
+		{"foo", fmt.Errorf("foo")},
+		{"foo", New("foo")},
+		{"string with format specifiers: %v", errors.New("string with format specifiers: %v")},
+	}
+
+	for _, tt := range tests {
+		got := New(tt.err)
+		if got.Error() != tt.want.Error() {
+			t.Errorf("New.Error(): got: %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestWrapNil(t *testing.T) {
+	got := Wrap(nil, "no error")
+	if got != nil {
+		t.Errorf("Wrap(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWrap(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{Wrap(io.EOF, "read error"), "client error", "client error: read error: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := Wrap(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("Wrap(%v, %q): got: %v, want %v", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+type nilError struct{}
+
+func (nilError) Error() string { return "nil error" }
+
+func TestCause(t *testing.T) {
+	x := New("error")
+	tests := []struct {
+		err  error
+		want error
+	}{{
+		// nil error is nil
+		err:  nil,
+		want: nil,
+	}, {
+		// explicit nil error is nil
+		err:  (error)(nil),
+		want: nil,
+	}, {
+		// typed nil is nil
+		err:  (*nilError)(nil),
+		want: (*nilError)(nil),
+	}, {
+		// uncaused error is unaffected
+		err:  io.EOF,
+		want: io.EOF,
+	}, {
+		// caused error returns cause
+		err:  Wrap(io.EOF, "ignored"),
+		want: io.EOF,
+	}, {
+		err:  x, // return from errors.New
+		want: x,
+	}, {
+		WithMessage(nil, "whoops"),
+		nil,
+	}, {
+		WithMessage(io.EOF, "whoops"),
+		io.EOF,
+	}, {
+		WithStack(nil),
+		nil,
+	}, {
+		WithStack(io.EOF),
+		io.EOF,
+	}}
+
+	for i, tt := range tests {
+		got := Cause(tt.err)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("test %d: got %#v, want %#v", i+1, got, tt.want)
+		}
+	}
+}
+
+func TestWrapfNil(t *testing.T) {
+	got := Wrapf(nil, "no error")
+	if got != nil {
+		t.Errorf("Wrapf(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWrapf(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{Wrapf(io.EOF, "read error without format specifiers"), "client error", "client error: read error without format specifiers: EOF"},
+		{Wrapf(io.EOF, "read error with %d format specifier", 1), "client error", "client error: read error with 1 format specifier: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := Wrapf(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("Wrapf(%v, %q): got: %v, want %v", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{Errorf("read error without format specifiers"), "read error without format specifiers"},
+		{Errorf("read error with %d format specifier", 1), "read error with 1 format specifier"},
+	}
+
+	for _, tt := range tests {
+		got := tt.err.Error()
+		if got != tt.want {
+			t.Errorf("Errorf(%v): got: %q, want %q", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestWithStackNil(t *testing.T) {
+	got := WithStack(nil)
+	if got != nil {
+		t.Errorf("WithStack(nil): got %#v, expected nil", got)
+	}
+}
+
+func TestWithStack(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{io.EOF, "EOF"},
+		{WithStack(io.EOF), "EOF"},
+	}
+
+	for _, tt := range tests {
+		got := WithStack(tt.err).Error()
+		if got != tt.want {
+			t.Errorf("WithStack(%v): got: %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestWithMessageNil(t *testing.T) {
+	got := WithMessage(nil, "no error")
+	if got != nil {
+		t.Errorf("WithMessage(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWithMessage(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{WithMessage(io.EOF, "read error"), "client error", "client error: read error: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := WithMessage(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("WithMessage(%v, %q): got: %q, want %q", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+func TestWithMessagefNil(t *testing.T) {
+	got := WithMessagef(nil, "no error")
+	if got != nil {
+		t.Errorf("WithMessage(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWithMessagef(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{WithMessagef(io.EOF, "read error without format specifier"), "client error", "client error: read error without format specifier: EOF"},
+		{WithMessagef(io.EOF, "read error with %d format specifier", 1), "client error", "client error: read error with 1 format specifier: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := WithMessagef(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("WithMessage(%v, %q): got: %q, want %q", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+// errors.New, etc values are not expected to be compared by value
+// but the change in errors#27 made them incomparable. Assert that
+// various kinds of errors have a functional equality operator, even
+// if the result of that equality is always false.
+func TestErrorEquality(t *testing.T) {
+	vals := []error{
+		nil,
+		io.EOF,
+		errors.New("EOF"),
+		New("EOF"),
+		Errorf("EOF"),
+		Wrap(io.EOF, "EOF"),
+		Wrapf(io.EOF, "EOF%d", 2),
+		WithMessage(nil, "whoops"),
+		WithMessage(io.EOF, "whoops"),
+		WithStack(io.EOF),
+		WithStack(nil),
+	}
+
+	for i := range vals {
+		for j := range vals {
+			_ = vals[i] == vals[j] // mustn't panic
+		}
+	}
+}

--- a/vendor/github.com/pkg/errors/example_test.go
+++ b/vendor/github.com/pkg/errors/example_test.go
@@ -1,0 +1,205 @@
+package errors_test
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+func ExampleNew() {
+	err := errors.New("whoops")
+	fmt.Println(err)
+
+	// Output: whoops
+}
+
+func ExampleNew_printf() {
+	err := errors.New("whoops")
+	fmt.Printf("%+v", err)
+
+	// Example output:
+	// whoops
+	// github.com/pkg/errors_test.ExampleNew_printf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:17
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+}
+
+func ExampleWithMessage() {
+	cause := errors.New("whoops")
+	err := errors.WithMessage(cause, "oh noes")
+	fmt.Println(err)
+
+	// Output: oh noes: whoops
+}
+
+func ExampleWithStack() {
+	cause := errors.New("whoops")
+	err := errors.WithStack(cause)
+	fmt.Println(err)
+
+	// Output: whoops
+}
+
+func ExampleWithStack_printf() {
+	cause := errors.New("whoops")
+	err := errors.WithStack(cause)
+	fmt.Printf("%+v", err)
+
+	// Example Output:
+	// whoops
+	// github.com/pkg/errors_test.ExampleWithStack_printf
+	//         /home/fabstu/go/src/github.com/pkg/errors/example_test.go:55
+	// testing.runExample
+	//         /usr/lib/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /usr/lib/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /usr/lib/go/src/testing/testing.go:744
+	// main.main
+	//         github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /usr/lib/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /usr/lib/go/src/runtime/asm_amd64.s:2086
+	// github.com/pkg/errors_test.ExampleWithStack_printf
+	//         /home/fabstu/go/src/github.com/pkg/errors/example_test.go:56
+	// testing.runExample
+	//         /usr/lib/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /usr/lib/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /usr/lib/go/src/testing/testing.go:744
+	// main.main
+	//         github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /usr/lib/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /usr/lib/go/src/runtime/asm_amd64.s:2086
+}
+
+func ExampleWrap() {
+	cause := errors.New("whoops")
+	err := errors.Wrap(cause, "oh noes")
+	fmt.Println(err)
+
+	// Output: oh noes: whoops
+}
+
+func fn() error {
+	e1 := errors.New("error")
+	e2 := errors.Wrap(e1, "inner")
+	e3 := errors.Wrap(e2, "middle")
+	return errors.Wrap(e3, "outer")
+}
+
+func ExampleCause() {
+	err := fn()
+	fmt.Println(err)
+	fmt.Println(errors.Cause(err))
+
+	// Output: outer: middle: inner: error
+	// error
+}
+
+func ExampleWrap_extended() {
+	err := fn()
+	fmt.Printf("%+v\n", err)
+
+	// Example output:
+	// error
+	// github.com/pkg/errors_test.fn
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:47
+	// github.com/pkg/errors_test.ExampleCause_printf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:63
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:104
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+	// github.com/pkg/errors_test.fn
+	// 	  /home/dfc/src/github.com/pkg/errors/example_test.go:48: inner
+	// github.com/pkg/errors_test.fn
+	//        /home/dfc/src/github.com/pkg/errors/example_test.go:49: middle
+	// github.com/pkg/errors_test.fn
+	//      /home/dfc/src/github.com/pkg/errors/example_test.go:50: outer
+}
+
+func ExampleWrapf() {
+	cause := errors.New("whoops")
+	err := errors.Wrapf(cause, "oh noes #%d", 2)
+	fmt.Println(err)
+
+	// Output: oh noes #2: whoops
+}
+
+func ExampleErrorf_extended() {
+	err := errors.Errorf("whoops: %s", "foo")
+	fmt.Printf("%+v", err)
+
+	// Example output:
+	// whoops: foo
+	// github.com/pkg/errors_test.ExampleErrorf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:101
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:102
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+}
+
+func Example_stackTrace() {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+
+	err, ok := errors.Cause(fn()).(stackTracer)
+	if !ok {
+		panic("oops, err does not implement stackTracer")
+	}
+
+	st := err.StackTrace()
+	fmt.Printf("%+v", st[0:2]) // top two frames
+
+	// Example output:
+	// github.com/pkg/errors_test.fn
+	//	/home/dfc/src/github.com/pkg/errors/example_test.go:47
+	// github.com/pkg/errors_test.Example_stackTrace
+	//	/home/dfc/src/github.com/pkg/errors/example_test.go:127
+}
+
+func ExampleCause_printf() {
+	err := errors.Wrap(func() error {
+		return func() error {
+			return errors.Errorf("hello %s", fmt.Sprintf("world"))
+		}()
+	}(), "failed")
+
+	fmt.Printf("%v", err)
+
+	// Output: failed: hello world
+}

--- a/vendor/github.com/pkg/errors/format_test.go
+++ b/vendor/github.com/pkg/errors/format_test.go
@@ -1,0 +1,535 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestFormatNew(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		New("error"),
+		"%s",
+		"error",
+	}, {
+		New("error"),
+		"%v",
+		"error",
+	}, {
+		New("error"),
+		"%+v",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatNew\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:26",
+	}, {
+		New("error"),
+		"%q",
+		`"error"`,
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatErrorf(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		Errorf("%s", "error"),
+		"%s",
+		"error",
+	}, {
+		Errorf("%s", "error"),
+		"%v",
+		"error",
+	}, {
+		Errorf("%s", "error"),
+		"%+v",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatErrorf\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:56",
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWrap(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		Wrap(New("error"), "error2"),
+		"%s",
+		"error2: error",
+	}, {
+		Wrap(New("error"), "error2"),
+		"%v",
+		"error2: error",
+	}, {
+		Wrap(New("error"), "error2"),
+		"%+v",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:82",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%s",
+		"error: EOF",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%v",
+		"error: EOF",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%+v",
+		"EOF\n" +
+			"error\n" +
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:96",
+	}, {
+		Wrap(Wrap(io.EOF, "error1"), "error2"),
+		"%+v",
+		"EOF\n" +
+			"error1\n" +
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:103\n",
+	}, {
+		Wrap(New("error with space"), "context"),
+		"%q",
+		`"context: error with space"`,
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWrapf(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		Wrapf(io.EOF, "error%d", 2),
+		"%s",
+		"error2: EOF",
+	}, {
+		Wrapf(io.EOF, "error%d", 2),
+		"%v",
+		"error2: EOF",
+	}, {
+		Wrapf(io.EOF, "error%d", 2),
+		"%+v",
+		"EOF\n" +
+			"error2\n" +
+			"github.com/pkg/errors.TestFormatWrapf\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:134",
+	}, {
+		Wrapf(New("error"), "error%d", 2),
+		"%s",
+		"error2: error",
+	}, {
+		Wrapf(New("error"), "error%d", 2),
+		"%v",
+		"error2: error",
+	}, {
+		Wrapf(New("error"), "error%d", 2),
+		"%+v",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatWrapf\n" +
+			"\t.+/github.com/pkg/errors/format_test.go:149",
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWithStack(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   []string
+	}{{
+		WithStack(io.EOF),
+		"%s",
+		[]string{"EOF"},
+	}, {
+		WithStack(io.EOF),
+		"%v",
+		[]string{"EOF"},
+	}, {
+		WithStack(io.EOF),
+		"%+v",
+		[]string{"EOF",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:175"},
+	}, {
+		WithStack(New("error")),
+		"%s",
+		[]string{"error"},
+	}, {
+		WithStack(New("error")),
+		"%v",
+		[]string{"error"},
+	}, {
+		WithStack(New("error")),
+		"%+v",
+		[]string{"error",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:189",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:189"},
+	}, {
+		WithStack(WithStack(io.EOF)),
+		"%+v",
+		[]string{"EOF",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:197",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:197"},
+	}, {
+		WithStack(WithStack(Wrapf(io.EOF, "message"))),
+		"%+v",
+		[]string{"EOF",
+			"message",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:205",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:205",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:205"},
+	}, {
+		WithStack(Errorf("error%d", 1)),
+		"%+v",
+		[]string{"error1",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:216",
+			"github.com/pkg/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:216"},
+	}}
+
+	for i, tt := range tests {
+		testFormatCompleteCompare(t, i, tt.error, tt.format, tt.want, true)
+	}
+}
+
+func TestFormatWithMessage(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   []string
+	}{{
+		WithMessage(New("error"), "error2"),
+		"%s",
+		[]string{"error2: error"},
+	}, {
+		WithMessage(New("error"), "error2"),
+		"%v",
+		[]string{"error2: error"},
+	}, {
+		WithMessage(New("error"), "error2"),
+		"%+v",
+		[]string{
+			"error",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:244",
+			"error2"},
+	}, {
+		WithMessage(io.EOF, "addition1"),
+		"%s",
+		[]string{"addition1: EOF"},
+	}, {
+		WithMessage(io.EOF, "addition1"),
+		"%v",
+		[]string{"addition1: EOF"},
+	}, {
+		WithMessage(io.EOF, "addition1"),
+		"%+v",
+		[]string{"EOF", "addition1"},
+	}, {
+		WithMessage(WithMessage(io.EOF, "addition1"), "addition2"),
+		"%v",
+		[]string{"addition2: addition1: EOF"},
+	}, {
+		WithMessage(WithMessage(io.EOF, "addition1"), "addition2"),
+		"%+v",
+		[]string{"EOF", "addition1", "addition2"},
+	}, {
+		Wrap(WithMessage(io.EOF, "error1"), "error2"),
+		"%+v",
+		[]string{"EOF", "error1", "error2",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:272"},
+	}, {
+		WithMessage(Errorf("error%d", 1), "error2"),
+		"%+v",
+		[]string{"error1",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:278",
+			"error2"},
+	}, {
+		WithMessage(WithStack(io.EOF), "error"),
+		"%+v",
+		[]string{
+			"EOF",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:285",
+			"error"},
+	}, {
+		WithMessage(Wrap(WithStack(io.EOF), "inside-error"), "outside-error"),
+		"%+v",
+		[]string{
+			"EOF",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:293",
+			"inside-error",
+			"github.com/pkg/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:293",
+			"outside-error"},
+	}}
+
+	for i, tt := range tests {
+		testFormatCompleteCompare(t, i, tt.error, tt.format, tt.want, true)
+	}
+}
+
+func TestFormatGeneric(t *testing.T) {
+	starts := []struct {
+		err  error
+		want []string
+	}{
+		{New("new-error"), []string{
+			"new-error",
+			"github.com/pkg/errors.TestFormatGeneric\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:315"},
+		}, {Errorf("errorf-error"), []string{
+			"errorf-error",
+			"github.com/pkg/errors.TestFormatGeneric\n" +
+				"\t.+/github.com/pkg/errors/format_test.go:319"},
+		}, {errors.New("errors-new-error"), []string{
+			"errors-new-error"},
+		},
+	}
+
+	wrappers := []wrapper{
+		{
+			func(err error) error { return WithMessage(err, "with-message") },
+			[]string{"with-message"},
+		}, {
+			func(err error) error { return WithStack(err) },
+			[]string{
+				"github.com/pkg/errors.(func·002|TestFormatGeneric.func2)\n\t" +
+					".+/github.com/pkg/errors/format_test.go:333",
+			},
+		}, {
+			func(err error) error { return Wrap(err, "wrap-error") },
+			[]string{
+				"wrap-error",
+				"github.com/pkg/errors.(func·003|TestFormatGeneric.func3)\n\t" +
+					".+/github.com/pkg/errors/format_test.go:339",
+			},
+		}, {
+			func(err error) error { return Wrapf(err, "wrapf-error%d", 1) },
+			[]string{
+				"wrapf-error1",
+				"github.com/pkg/errors.(func·004|TestFormatGeneric.func4)\n\t" +
+					".+/github.com/pkg/errors/format_test.go:346",
+			},
+		},
+	}
+
+	for s := range starts {
+		err := starts[s].err
+		want := starts[s].want
+		testFormatCompleteCompare(t, s, err, "%+v", want, false)
+		testGenericRecursive(t, err, want, wrappers, 3)
+	}
+}
+
+func testFormatRegexp(t *testing.T, n int, arg interface{}, format, want string) {
+	got := fmt.Sprintf(format, arg)
+	gotLines := strings.SplitN(got, "\n", -1)
+	wantLines := strings.SplitN(want, "\n", -1)
+
+	if len(wantLines) > len(gotLines) {
+		t.Errorf("test %d: wantLines(%d) > gotLines(%d):\n got: %q\nwant: %q", n+1, len(wantLines), len(gotLines), got, want)
+		return
+	}
+
+	for i, w := range wantLines {
+		match, err := regexp.MatchString(w, gotLines[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("test %d: line %d: fmt.Sprintf(%q, err):\n got: %q\nwant: %q", n+1, i+1, format, got, want)
+		}
+	}
+}
+
+var stackLineR = regexp.MustCompile(`\.`)
+
+// parseBlocks parses input into a slice, where:
+//  - incase entry contains a newline, its a stacktrace
+//  - incase entry contains no newline, its a solo line.
+//
+// Detecting stack boundaries only works incase the WithStack-calls are
+// to be found on the same line, thats why it is optionally here.
+//
+// Example use:
+//
+// for _, e := range blocks {
+//   if strings.ContainsAny(e, "\n") {
+//     // Match as stack
+//   } else {
+//     // Match as line
+//   }
+// }
+//
+func parseBlocks(input string, detectStackboundaries bool) ([]string, error) {
+	var blocks []string
+
+	stack := ""
+	wasStack := false
+	lines := map[string]bool{} // already found lines
+
+	for _, l := range strings.Split(input, "\n") {
+		isStackLine := stackLineR.MatchString(l)
+
+		switch {
+		case !isStackLine && wasStack:
+			blocks = append(blocks, stack, l)
+			stack = ""
+			lines = map[string]bool{}
+		case isStackLine:
+			if wasStack {
+				// Detecting two stacks after another, possible cause lines match in
+				// our tests due to WithStack(WithStack(io.EOF)) on same line.
+				if detectStackboundaries {
+					if lines[l] {
+						if len(stack) == 0 {
+							return nil, errors.New("len of block must not be zero here")
+						}
+
+						blocks = append(blocks, stack)
+						stack = l
+						lines = map[string]bool{l: true}
+						continue
+					}
+				}
+
+				stack = stack + "\n" + l
+			} else {
+				stack = l
+			}
+			lines[l] = true
+		case !isStackLine && !wasStack:
+			blocks = append(blocks, l)
+		default:
+			return nil, errors.New("must not happen")
+		}
+
+		wasStack = isStackLine
+	}
+
+	// Use up stack
+	if stack != "" {
+		blocks = append(blocks, stack)
+	}
+	return blocks, nil
+}
+
+func testFormatCompleteCompare(t *testing.T, n int, arg interface{}, format string, want []string, detectStackBoundaries bool) {
+	gotStr := fmt.Sprintf(format, arg)
+
+	got, err := parseBlocks(gotStr, detectStackBoundaries)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("test %d: fmt.Sprintf(%s, err) -> wrong number of blocks: got(%d) want(%d)\n got: %s\nwant: %s\ngotStr: %q",
+			n+1, format, len(got), len(want), prettyBlocks(got), prettyBlocks(want), gotStr)
+	}
+
+	for i := range got {
+		if strings.ContainsAny(want[i], "\n") {
+			// Match as stack
+			match, err := regexp.MatchString(want[i], got[i])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !match {
+				t.Fatalf("test %d: block %d: fmt.Sprintf(%q, err):\ngot:\n%q\nwant:\n%q\nall-got:\n%s\nall-want:\n%s\n",
+					n+1, i+1, format, got[i], want[i], prettyBlocks(got), prettyBlocks(want))
+			}
+		} else {
+			// Match as message
+			if got[i] != want[i] {
+				t.Fatalf("test %d: fmt.Sprintf(%s, err) at block %d got != want:\n got: %q\nwant: %q", n+1, format, i+1, got[i], want[i])
+			}
+		}
+	}
+}
+
+type wrapper struct {
+	wrap func(err error) error
+	want []string
+}
+
+func prettyBlocks(blocks []string) string {
+	var out []string
+
+	for _, b := range blocks {
+		out = append(out, fmt.Sprintf("%v", b))
+	}
+
+	return "   " + strings.Join(out, "\n   ")
+}
+
+func testGenericRecursive(t *testing.T, beforeErr error, beforeWant []string, list []wrapper, maxDepth int) {
+	if len(beforeWant) == 0 {
+		panic("beforeWant must not be empty")
+	}
+	for _, w := range list {
+		if len(w.want) == 0 {
+			panic("want must not be empty")
+		}
+
+		err := w.wrap(beforeErr)
+
+		// Copy required cause append(beforeWant, ..) modified beforeWant subtly.
+		beforeCopy := make([]string, len(beforeWant))
+		copy(beforeCopy, beforeWant)
+
+		beforeWant := beforeCopy
+		last := len(beforeWant) - 1
+		var want []string
+
+		// Merge two stacks behind each other.
+		if strings.ContainsAny(beforeWant[last], "\n") && strings.ContainsAny(w.want[0], "\n") {
+			want = append(beforeWant[:last], append([]string{beforeWant[last] + "((?s).*)" + w.want[0]}, w.want[1:]...)...)
+		} else {
+			want = append(beforeWant, w.want...)
+		}
+
+		testFormatCompleteCompare(t, maxDepth, err, "%+v", want, false)
+		if maxDepth > 0 {
+			testGenericRecursive(t, err, want, list, maxDepth-1)
+		}
+	}
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/vendor/github.com/pkg/errors/stack_test.go
+++ b/vendor/github.com/pkg/errors/stack_test.go
@@ -1,0 +1,274 @@
+package errors
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+var initpc, _, _, _ = runtime.Caller(0)
+
+func TestFrameLine(t *testing.T) {
+	var tests = []struct {
+		Frame
+		want int
+	}{{
+		Frame(initpc),
+		9,
+	}, {
+		func() Frame {
+			var pc, _, _, _ = runtime.Caller(0)
+			return Frame(pc)
+		}(),
+		20,
+	}, {
+		func() Frame {
+			var pc, _, _, _ = runtime.Caller(1)
+			return Frame(pc)
+		}(),
+		28,
+	}, {
+		Frame(0), // invalid PC
+		0,
+	}}
+
+	for _, tt := range tests {
+		got := tt.Frame.line()
+		want := tt.want
+		if want != got {
+			t.Errorf("Frame(%v): want: %v, got: %v", uintptr(tt.Frame), want, got)
+		}
+	}
+}
+
+type X struct{}
+
+func (x X) val() Frame {
+	var pc, _, _, _ = runtime.Caller(0)
+	return Frame(pc)
+}
+
+func (x *X) ptr() Frame {
+	var pc, _, _, _ = runtime.Caller(0)
+	return Frame(pc)
+}
+
+func TestFrameFormat(t *testing.T) {
+	var tests = []struct {
+		Frame
+		format string
+		want   string
+	}{{
+		Frame(initpc),
+		"%s",
+		"stack_test.go",
+	}, {
+		Frame(initpc),
+		"%+s",
+		"github.com/pkg/errors.init\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go",
+	}, {
+		Frame(0),
+		"%s",
+		"unknown",
+	}, {
+		Frame(0),
+		"%+s",
+		"unknown",
+	}, {
+		Frame(initpc),
+		"%d",
+		"9",
+	}, {
+		Frame(0),
+		"%d",
+		"0",
+	}, {
+		Frame(initpc),
+		"%n",
+		"init",
+	}, {
+		func() Frame {
+			var x X
+			return x.ptr()
+		}(),
+		"%n",
+		`\(\*X\).ptr`,
+	}, {
+		func() Frame {
+			var x X
+			return x.val()
+		}(),
+		"%n",
+		"X.val",
+	}, {
+		Frame(0),
+		"%n",
+		"",
+	}, {
+		Frame(initpc),
+		"%v",
+		"stack_test.go:9",
+	}, {
+		Frame(initpc),
+		"%+v",
+		"github.com/pkg/errors.init\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:9",
+	}, {
+		Frame(0),
+		"%v",
+		"unknown:0",
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.Frame, tt.format, tt.want)
+	}
+}
+
+func TestFuncname(t *testing.T) {
+	tests := []struct {
+		name, want string
+	}{
+		{"", ""},
+		{"runtime.main", "main"},
+		{"github.com/pkg/errors.funcname", "funcname"},
+		{"funcname", "funcname"},
+		{"io.copyBuffer", "copyBuffer"},
+		{"main.(*R).Write", "(*R).Write"},
+	}
+
+	for _, tt := range tests {
+		got := funcname(tt.name)
+		want := tt.want
+		if got != want {
+			t.Errorf("funcname(%q): want: %q, got %q", tt.name, want, got)
+		}
+	}
+}
+
+func TestStackTrace(t *testing.T) {
+	tests := []struct {
+		err  error
+		want []string
+	}{{
+		New("ooh"), []string{
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:154",
+		},
+	}, {
+		Wrap(New("ooh"), "ahh"), []string{
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:159", // this is the stack of Wrap, not New
+		},
+	}, {
+		Cause(Wrap(New("ooh"), "ahh")), []string{
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:164", // this is the stack of New
+		},
+	}, {
+		func() error { return New("ooh") }(), []string{
+			`github.com/pkg/errors.(func·009|TestStackTrace.func1)` +
+				"\n\t.+/github.com/pkg/errors/stack_test.go:169", // this is the stack of New
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:169", // this is the stack of New's caller
+		},
+	}, {
+		Cause(func() error {
+			return func() error {
+				return Errorf("hello %s", fmt.Sprintf("world"))
+			}()
+		}()), []string{
+			`github.com/pkg/errors.(func·010|TestStackTrace.func2.1)` +
+				"\n\t.+/github.com/pkg/errors/stack_test.go:178", // this is the stack of Errorf
+			`github.com/pkg/errors.(func·011|TestStackTrace.func2)` +
+				"\n\t.+/github.com/pkg/errors/stack_test.go:179", // this is the stack of Errorf's caller
+			"github.com/pkg/errors.TestStackTrace\n" +
+				"\t.+/github.com/pkg/errors/stack_test.go:180", // this is the stack of Errorf's caller's caller
+		},
+	}}
+	for i, tt := range tests {
+		x, ok := tt.err.(interface {
+			StackTrace() StackTrace
+		})
+		if !ok {
+			t.Errorf("expected %#v to implement StackTrace() StackTrace", tt.err)
+			continue
+		}
+		st := x.StackTrace()
+		for j, want := range tt.want {
+			testFormatRegexp(t, i, st[j], "%+v", want)
+		}
+	}
+}
+
+func stackTrace() StackTrace {
+	const depth = 8
+	var pcs [depth]uintptr
+	n := runtime.Callers(1, pcs[:])
+	var st stack = pcs[0:n]
+	return st.StackTrace()
+}
+
+func TestStackTraceFormat(t *testing.T) {
+	tests := []struct {
+		StackTrace
+		format string
+		want   string
+	}{{
+		nil,
+		"%s",
+		`\[\]`,
+	}, {
+		nil,
+		"%v",
+		`\[\]`,
+	}, {
+		nil,
+		"%+v",
+		"",
+	}, {
+		nil,
+		"%#v",
+		`\[\]errors.Frame\(nil\)`,
+	}, {
+		make(StackTrace, 0),
+		"%s",
+		`\[\]`,
+	}, {
+		make(StackTrace, 0),
+		"%v",
+		`\[\]`,
+	}, {
+		make(StackTrace, 0),
+		"%+v",
+		"",
+	}, {
+		make(StackTrace, 0),
+		"%#v",
+		`\[\]errors.Frame{}`,
+	}, {
+		stackTrace()[:2],
+		"%s",
+		`\[stack_test.go stack_test.go\]`,
+	}, {
+		stackTrace()[:2],
+		"%v",
+		`\[stack_test.go:207 stack_test.go:254\]`,
+	}, {
+		stackTrace()[:2],
+		"%+v",
+		"\n" +
+			"github.com/pkg/errors.stackTrace\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:207\n" +
+			"github.com/pkg/errors.TestStackTraceFormat\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:258",
+	}, {
+		stackTrace()[:2],
+		"%#v",
+		`\[\]errors.Frame{stack_test.go:207, stack_test.go:266}`,
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.StackTrace, tt.format, tt.want)
+	}
+}


### PR DESCRIPTION
Fixes #361 by updating the berokerapi dependency.

This dependency requires us to be compatible with an upgraded version of the broker interface. New functionality was introduced in the 2.14 version of the OSB spec, but we can leave it unimplemented because the features are enabled via flags which we don't set.