### PR TITLE
rename compatibility form to features

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -35,7 +35,7 @@ const (
 	apiPortProp     = "api.port"
 )
 
-var cfCompatibilityToggle = toggles.Compatibility.Toggle("enable-cf-sharing", false, `Set all services to have the Sharable flag so they can be shared
+var cfCompatibilityToggle = toggles.Features.Toggle("enable-cf-sharing", false, `Set all services to have the Sharable flag so they can be shared
 	across spaces in PCF.`)
 
 func init() {

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -28,15 +28,15 @@ var (
 	// The following flags enable and disable services based on their tags.
 	// The guiding philosophy for defaults is optimistic about new technology and pessimistic about old.
 	lifecycleTagToggles = map[string]toggles.Toggle{
-		"preview":      toggles.Compatibility.Toggle("enable-preview-services", true, `Enable services that are new to the broker this release.`),
-		"unmaintained": toggles.Compatibility.Toggle("enable-unmaintained-services", false, `Enable broker services that are unmaintained.`),
-		"eol":          toggles.Compatibility.Toggle("enable-eol-services", false, `Enable broker services that are end of life.`),
-		"beta":         toggles.Compatibility.Toggle("enable-gcp-beta-services", true, "Enable services that are in GCP Beta. These have no SLA or support policy."),
-		"deprecated":   toggles.Compatibility.Toggle("enable-gcp-deprecated-services", false, "Enable services that use deprecated GCP components."),
-		"terraform":    toggles.Compatibility.Toggle("enable-terraform-services", false, "Enable services that use the experimental, unstable, Terraform back-end."),
+		"preview":      toggles.Features.Toggle("enable-preview-services", true, `Enable services that are new to the broker this release.`),
+		"unmaintained": toggles.Features.Toggle("enable-unmaintained-services", false, `Enable broker services that are unmaintained.`),
+		"eol":          toggles.Features.Toggle("enable-eol-services", false, `Enable broker services that are end of life.`),
+		"beta":         toggles.Features.Toggle("enable-gcp-beta-services", true, "Enable services that are in GCP Beta. These have no SLA or support policy."),
+		"deprecated":   toggles.Features.Toggle("enable-gcp-deprecated-services", false, "Enable services that use deprecated GCP components."),
+		"terraform":    toggles.Features.Toggle("enable-terraform-services", false, "Enable services that use the experimental, unstable, Terraform back-end."),
 	}
 
-	enableBuiltinServices = toggles.Compatibility.Toggle("enable-builtin-services", true, `Enable services that are built in to the broker i.e. not brokerpaks.`)
+	enableBuiltinServices = toggles.Features.Toggle("enable-builtin-services", true, `Enable services that are built in to the broker i.e. not brokerpaks.`)
 )
 
 // BrokerRegistry holds the list of ServiceDefinitions that can be provisioned

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-var enableCatalogSchemas = toggles.Compatibility.Toggle("enable-catalog-schemas", false, `Enable generating JSONSchema for the service catalog.`)
+var enableCatalogSchemas = toggles.Features.Toggle("enable-catalog-schemas", false, `Enable generating JSONSchema for the service catalog.`)
 
 // ServiceDefinition holds the necessary details to describe an OSB service and
 // provision it.

--- a/pkg/generator/forms.go
+++ b/pkg/generator/forms.go
@@ -85,7 +85,7 @@ func GenerateForms() TileFormsSections {
 			generateServiceAccountForm(),
 			generateDatabaseForm(),
 			generateBrokerpakForm(),
-			generateCompatibilityForm(),
+			generateFeatureFlagForm(),
 			generateDefaultOverrideForm(),
 		},
 
@@ -170,10 +170,10 @@ func generateServiceAccountForm() Form {
 	}
 }
 
-func generateCompatibilityForm() Form {
+func generateFeatureFlagForm() Form {
 	var formEntries []FormProperty
 
-	for _, toggle := range toggles.Compatibility.Toggles() {
+	for _, toggle := range toggles.Features.Toggles() {
 		toggleEntry := FormProperty{
 			Name:         strings.ToLower(toggle.EnvironmentVariable()),
 			Type:         "boolean",
@@ -187,9 +187,9 @@ func generateCompatibilityForm() Form {
 	}
 
 	return Form{
-		Name:        "compatibility",
-		Label:       "Compatibility",
-		Description: "Legacy Compatibility Options",
+		Name:        "features",
+		Label:       "Feature Flags",
+		Description: "Service broker feature flags.",
 		Properties:  formEntries,
 	}
 }

--- a/pkg/toggles/toggle.go
+++ b/pkg/toggles/toggle.go
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 /*
-  Package toggles defines a standard way to define, list, and use feature
-  toggles in the service broker.
+Package toggles defines a standard way to define, list, and use feature
+toggles in the service broker.
 
-  It mimics Go's `flags` package, but uses Viper as a backing store to abstract
-  out how a particular flag is set.
+It mimics Go's `flags` package, but uses Viper as a backing store to abstract
+out how a particular flag is set.
 
 */
 package toggles
@@ -29,11 +29,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Compatibility is the default set of flags for enabling compatibility modes.
-var Compatibility = NewToggleSet("compatibility.")
-
-// Feature is the default set of flags for enabling or disabling features.
-var Feature = NewToggleSet("feature.")
+// Features is the default set of flags for enabling different features.
+// For legacy compatibility reasons the flags are put under the "compatibility"
+// namespace.
+var Features = NewToggleSet("compatibility.")
 
 // Toggle represents a single feature that the user can enable or disable.
 type Toggle struct {


### PR DESCRIPTION
The form for toggling compatibility settings is now changed to a general purpose feature flags form simplifying it: #421 

@craigatgoogle I jinxed myself when I said: "I better get this right the first time."

