### PR TITLE
Service Configuration Changeup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+ - Removed the `GSB_SERVICE_*_ENABLED` environment variables.
+ - Merged the environment variables `GSB_SERVICE_*_WHITELIST`, `GSB_SERVICE_*_PROVISION_DEFAULTS`, `GSB_SERVICE_*_BIND_DEFAULTS` and `*_CUSTOM_PLANS` into `GSB_SERVICE_CONFIG`.
+
 ## [4.2.0] - 2019-01-04
 
 ### Security

--- a/brokerapi/brokers/broker_config.go
+++ b/brokerapi/brokers/broker_config.go
@@ -27,7 +27,7 @@ import (
 type BrokerConfig struct {
 	HttpConfig *jwt.Config
 	ProjectId  string
-	Registry   broker.BrokerRegistry
+	Registry   *broker.ServiceRegistry
 }
 
 func NewBrokerConfigFromEnv() (*BrokerConfig, error) {
@@ -41,7 +41,12 @@ func NewBrokerConfigFromEnv() (*BrokerConfig, error) {
 		return nil, err
 	}
 
-	registry := builtin.BuiltinBrokerRegistry()
+	serviceRegistryConfig, err := broker.NewServiceConfigMapFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	registry := builtin.BuiltinBrokerRegistry(serviceRegistryConfig)
 	if err := brokerpak.RegisterAll(registry); err != nil {
 		return nil, fmt.Errorf("Error loading brokerpaks: %v", err)
 	}

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -248,10 +248,9 @@ func TestGCPServiceBroker_Services(t *testing.T) {
 	broker, closer := newStubbedBroker(t, registry)
 	defer closer()
 
-	registryServices := registry.GetAllServices()
 	services, err := broker.Services(context.Background())
 	failIfErr(t, "getting services", err)
-	assertEqual(t, "service count should be the same", len(registryServices), len(services))
+	assertEqual(t, "service count should be the same", registry.ServiceCount(), len(services))
 }
 
 func TestGCPServiceBroker_Provision(t *testing.T) {

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 
 	. "github.com/GoogleCloudPlatform/gcp-service-broker/brokerapi/brokers"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker/brokerfakes"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
@@ -106,10 +106,7 @@ func (s *serviceStub) UnbindDetails() brokerapi.UnbindDetails {
 // references to some important properties.
 func fakeService(t *testing.T, isAsync bool) *serviceStub {
 	defn := storage.ServiceDefinition()
-	svc, err := defn.CatalogEntry()
-	if err != nil {
-		t.Fatal(err)
-	}
+	svc := defn.CatalogEntry()
 
 	stub := serviceStub{
 		ServiceId:         svc.ID,
@@ -137,7 +134,7 @@ func fakeService(t *testing.T, isAsync bool) *serviceStub {
 
 // newStubbedBroker creates a new GCPServiceBroker with a dummy database for the given registry.
 // It returns the broker and a callback used to clean up the database when done with it.
-func newStubbedBroker(t *testing.T, registry broker.BrokerRegistry) (broker *GCPServiceBroker, closer func()) {
+func newStubbedBroker(t *testing.T, registry *broker.ServiceRegistry) (broker *GCPServiceBroker, closer func()) {
 	// Set up database
 	db, err := gorm.Open("sqlite3", "test.db")
 	if err != nil {
@@ -208,7 +205,7 @@ func (cases BrokerEndpointTestSuite) Run(t *testing.T) {
 			stub := fakeService(t, tc.AsyncService)
 
 			t.Log("Creating broker")
-			registry := broker.BrokerRegistry{}
+			registry := broker.NewServiceRegistry(broker.ServiceConfigMap{})
 			registry.Register(stub.ServiceDefinition)
 
 			broker, closer := newStubbedBroker(t, registry)
@@ -247,13 +244,14 @@ func initService(t *testing.T, state InstanceState, broker *GCPServiceBroker, st
 }
 
 func TestGCPServiceBroker_Services(t *testing.T) {
-	registry := builtin.BuiltinBrokerRegistry()
+	registry := builtin.BuiltinBrokerRegistry(broker.ServiceConfigMap{})
 	broker, closer := newStubbedBroker(t, registry)
 	defer closer()
 
+	registryServices := registry.GetAllServices()
 	services, err := broker.Services(context.Background())
 	failIfErr(t, "getting services", err)
-	assertEqual(t, "service count should be the same", len(registry), len(services))
+	assertEqual(t, "service count should be the same", len(registryServices), len(services))
 }
 
 func TestGCPServiceBroker_Provision(t *testing.T) {

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -27,8 +27,8 @@ import (
 
 	"encoding/json"
 
-	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service/models"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
@@ -41,7 +41,7 @@ var (
 
 // GCPServiceBroker is a brokerapi.ServiceBroker that can be used to generate an OSB compatible service broker.
 type GCPServiceBroker struct {
-	registry  broker.BrokerRegistry
+	registry  *broker.ServiceRegistry
 	jwtConfig *jwt.Config
 	projectId string
 
@@ -64,17 +64,10 @@ func New(cfg *BrokerConfig, logger lager.Logger) (*GCPServiceBroker, error) {
 func (gcpBroker *GCPServiceBroker) Services(ctx context.Context) ([]brokerapi.Service, error) {
 	svcs := []brokerapi.Service{}
 
-	enabledServices, err := gcpBroker.registry.GetEnabledServices()
-	if err != nil {
-		return nil, err
-	}
+	enabledServices := gcpBroker.registry.GetEnabledServices()
 
 	for _, service := range enabledServices {
-		entry, err := service.CatalogEntry()
-		if err != nil {
-			return svcs, err
-		}
-		svcs = append(svcs, entry.ToPlain())
+		svcs = append(svcs, service.CatalogEntry().ToPlain())
 	}
 
 	return svcs, nil

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -122,7 +122,7 @@ user-defined plans.
 				log.Fatalf("Error creating client: %v", err)
 			}
 
-			// for tests we dnon't load custom plans or overrides because it may
+			// for tests we don't load custom plans or overrides because it may
 			// cause conflicts in the object equality tests if the user overrides
 			// something.
 			emptyConfig := broker.ServiceConfigMap{}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -125,8 +125,7 @@ user-defined plans.
 			// for tests we don't load custom plans or overrides because it may
 			// cause conflicts in the object equality tests if the user overrides
 			// something.
-			emptyConfig := broker.ServiceConfigMap{}
-			if err := client.RunExamplesForService(builtin.BuiltinBrokerRegistry(emptyConfig), apiClient, serviceName); err != nil {
+			if err := client.RunExamplesForService(builtin.BuiltinBrokerRegistry(broker.ServiceConfigMap{}), apiClient, serviceName); err != nil {
 				log.Fatalf("Error executing examples: %v", err)
 			}
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"log"
 
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/client"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
@@ -121,7 +122,11 @@ user-defined plans.
 				log.Fatalf("Error creating client: %v", err)
 			}
 
-			if err := client.RunExamplesForService(builtin.BuiltinBrokerRegistry(), apiClient, serviceName); err != nil {
+			// for tests we dnon't load custom plans or overrides because it may
+			// cause conflicts in the object equality tests if the user overrides
+			// something
+			emptyConfig := broker.ServiceConfigMap{}
+			if err := client.RunExamplesForService(builtin.BuiltinBrokerRegistry(emptyConfig), apiClient, serviceName); err != nil {
 				log.Fatalf("Error executing examples: %v", err)
 			}
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -124,7 +124,7 @@ user-defined plans.
 
 			// for tests we dnon't load custom plans or overrides because it may
 			// cause conflicts in the object equality tests if the user overrides
-			// something
+			// something.
 			emptyConfig := broker.ServiceConfigMap{}
 			if err := client.RunExamplesForService(builtin.BuiltinBrokerRegistry(emptyConfig), apiClient, serviceName); err != nil {
 				log.Fatalf("Error executing examples: %v", err)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -46,8 +46,7 @@ func init() {
 			// by default, don't include overrides in generated documentation.
 			// this will be available under the docs endpoint for a running
 			// installation.
-			emptyConfig := broker.ServiceConfigMap{}
-			registry := builtin.BuiltinBrokerRegistry(emptyConfig)
+			registry := builtin.BuiltinBrokerRegistry(broker.ServiceConfigMap{})
 			fmt.Println(generator.CatalogDocumentation(registry))
 		},
 	})

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -43,7 +43,7 @@ func init() {
 	 * available parameters
 	`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// by default, don't include overrides in generated documentation
+			// by default, don't include overrides in generated documentation.
 			// this will be available under the docs endpoint for a running
 			// installation.
 			emptyConfig := broker.ServiceConfigMap{}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/generator"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/spf13/cobra"
@@ -40,10 +41,14 @@ func init() {
 
 	 * details about what each service is
 	 * available parameters
-
 	`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(generator.CatalogDocumentation(builtin.BuiltinBrokerRegistry()))
+			// by default, don't include overrides in generated documentation
+			// this will be available under the docs endpoint for a running
+			// installation.
+			emptyConfig := broker.ServiceConfigMap{}
+			registry := builtin.BuiltinBrokerRegistry(emptyConfig)
+			fmt.Println(generator.CatalogDocumentation(registry))
 		},
 	})
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,5 +1,32 @@
 ## Upgrading
 
+### v4.X to 5.0
+
+Version 5 of the broker changes the environment variables the broker uses for configuration.
+
+The following fields have been combined into a single new field `GSB_SERVICE_CONFIG`:
+
+ * `GSB_SERVICE_*_WHITELIST`
+ * `GSB_SERVICE_*_PROVISION_DEFAULTS`
+ * `GSB_SERVICE_*_BIND_DEFAULTS`
+ * `GSB_SERVICE_*_ENABLED`
+ * `*_CUSTOM_PLANS`
+
+Version 5 of the broker provides an automatic upgrade if you're using the tile.
+If you are running the broker in another way, you can use the `migrate-env`
+command to show the changes you'll need to make to upgrade your environment.
+
+```
+$ GSB_SERVICE_GOOGLE_STORAGE_WHITELIST=foo,bar,bazz ./gcp-service-broker config migrate-env
+GSB_SERVICE_GOOGLE_STORAGE_WHITELIST:
+  old: foo,bar,bazz
+  new: ""
+```
+
+### v3.X to 5.0
+
+You MUST upgrade your 3.X version to 4.x before upgrading to 5.x.
+
 ### v3.X to 4.0
 
 Version 4.0 of the broker contains significant improvements to security, ability to self-service, and documentation.
@@ -30,7 +57,3 @@ If you:
   * You can now set it in the database form of the PCF tile.
 * Use a BigQuery billing export for chargebacks:
   * Read the [billing docs](https://github.com/GoogleCloudPlatform/gcp-service-broker/blob/master/docs/billing.md) to understand how labels are automatically applied to services now.
-
-### v3.X to 5.0
-
-You MUST upgrade your 3.X version to 4.x before upgrading to 5.x.

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -133,30 +133,19 @@ func TestServiceDefinition_SetConfig(t *testing.T) {
 
 func TestServiceDefinition_CatalogEntry(t *testing.T) {
 	cases := map[string]struct {
-		UserPlans   []CustomPlan
-		PlanIds     map[string]bool
-		ExpectError bool
+		UserPlans []CustomPlan
+		PlanIds   map[string]bool
 	}{
 		"no-customization": {
-			UserPlans:   nil,
-			PlanIds:     map[string]bool{},
-			ExpectError: false,
+			UserPlans: nil,
+			PlanIds:   map[string]bool{},
 		},
 		"custom-plans": {
 			UserPlans: []CustomPlan{
-				{
-					GUID:       "aaa",
-					Name:       "aaa",
-					Properties: map[string]string{"instances": "3"},
-				},
-				{
-					GUID:       "bbb",
-					Name:       "bbb",
-					Properties: map[string]string{"instances": "3"},
-				},
+				{GUID: "aaa", Name: "aaa", Properties: map[string]string{"instances": "3"}},
+				{GUID: "bbb", Name: "bbb", Properties: map[string]string{"instances": "3"}},
 			},
-			PlanIds:     map[string]bool{"aaa": true, "bbb": true},
-			ExpectError: false,
+			PlanIds: map[string]bool{"aaa": true, "bbb": true},
 		},
 	}
 
@@ -167,23 +156,18 @@ func TestServiceDefinition_CatalogEntry(t *testing.T) {
 
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			err := service.SetConfig(ServiceConfig{
-				CustomPlans: tc.UserPlans,
-			})
-
-			hasErr := err != nil
-			if hasErr != tc.ExpectError {
-				t.Errorf("Expected Error? %v, got error: %v", tc.ExpectError, err)
+			if err := service.SetConfig(ServiceConfig{CustomPlans: tc.UserPlans}); err != nil {
+				t.Fatal(err)
 			}
 
 			srvc := service.CatalogEntry()
-			if err == nil && len(srvc.Plans) != len(tc.PlanIds) {
-				t.Errorf("Expected %d plans, but got %d (%+v)", len(tc.PlanIds), len(srvc.Plans), srvc.Plans)
+			if len(srvc.Plans) != len(tc.PlanIds) {
+				t.Fatalf("Expected %d plans, but got %d (%+v)", len(tc.PlanIds), len(srvc.Plans), srvc.Plans)
+			}
 
-				for _, plan := range srvc.Plans {
-					if _, ok := tc.PlanIds[plan.ID]; !ok {
-						t.Errorf("Got unexpected plan id %s, expected %+v", plan.ID, tc.PlanIds)
-					}
+			for _, plan := range srvc.Plans {
+				if _, ok := tc.PlanIds[plan.ID]; !ok {
+					t.Errorf("Got unexpected plan id %s, expected %+v", plan.ID, tc.PlanIds)
 				}
 			}
 		})

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -120,8 +120,7 @@ func TestServiceDefinition_SetConfig(t *testing.T) {
 
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			config := ServiceConfig{CustomPlans: tc.Value}
-			err := service.SetConfig(config)
+			err := service.SetConfig(ServiceConfig{CustomPlans: tc.Value})
 			defer service.SetConfig(ServiceConfig{})
 
 			if !reflect.DeepEqual(err, tc.ExpectError) {
@@ -133,15 +132,15 @@ func TestServiceDefinition_SetConfig(t *testing.T) {
 
 func TestServiceDefinition_CatalogEntry(t *testing.T) {
 	cases := map[string]struct {
-		UserPlans []CustomPlan
-		PlanIds   map[string]bool
+		CustomPlans []CustomPlan
+		PlanIds     map[string]bool
 	}{
 		"no-customization": {
-			UserPlans: nil,
-			PlanIds:   map[string]bool{},
+			CustomPlans: nil,
+			PlanIds:     map[string]bool{},
 		},
 		"custom-plans": {
-			UserPlans: []CustomPlan{
+			CustomPlans: []CustomPlan{
 				{GUID: "aaa", Name: "aaa", Properties: map[string]string{"instances": "3"}},
 				{GUID: "bbb", Name: "bbb", Properties: map[string]string{"instances": "3"}},
 			},
@@ -156,7 +155,7 @@ func TestServiceDefinition_CatalogEntry(t *testing.T) {
 
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			if err := service.SetConfig(ServiceConfig{CustomPlans: tc.UserPlans}); err != nil {
+			if err := service.SetConfig(ServiceConfig{CustomPlans: tc.CustomPlans}); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/broker/registry_test.go
+++ b/pkg/broker/registry_test.go
@@ -68,31 +68,28 @@ func TestRegistry_GetEnabledServices(t *testing.T) {
 				IsBuiltin: true,
 			}
 
-			registry := BrokerRegistry{}
+			registry := NewServiceRegistry(ServiceConfigMap{})
 			registry.Register(&sd)
 
 			// shouldn't show up when property is false even if builtins are enabled
 			viper.Set("compatibility.enable-builtin-services", true)
 			viper.Set(tc.Property, false)
-			if defns, err := registry.GetEnabledServices(); err != nil {
-				t.Fatal(err)
-			} else if len(defns) != 0 {
+			defns := registry.GetEnabledServices()
+			if len(defns) != 0 {
 				t.Fatalf("Expected 0 definitions with %s disabled, but got %d", tc.Property, len(defns))
 			}
 
 			// should show up when property is true
 			viper.Set(tc.Property, true)
-			if defns, err := registry.GetEnabledServices(); err != nil {
-				t.Fatal(err)
-			} else if len(defns) != 1 {
+			defns = registry.GetEnabledServices()
+			if len(defns) != 1 {
 				t.Fatalf("Expected 1 definition with %s enabled, but got %d", tc.Property, len(defns))
 			}
 
 			// should not show up if the service is explicitly disabled
 			viper.Set("compatibility.enable-builtin-services", false)
-			if defns, err := registry.GetEnabledServices(); err != nil {
-				t.Fatal(err)
-			} else if len(defns) != 0 {
+			defns = registry.GetEnabledServices()
+			if len(defns) != 0 {
 				t.Fatalf("Expected no definition with builtins disabled, but got %d", len(defns))
 			}
 		})

--- a/pkg/broker/service_config.go
+++ b/pkg/broker/service_config.go
@@ -1,0 +1,76 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pivotal-cf/brokerapi"
+	"github.com/spf13/viper"
+)
+
+// ServiceConfigProperty holds the Viper property for the service config map.
+const ServiceConfigProperty = "service-config"
+
+// ServiceConfigMap is a mapping of Service GUID -> ServiceConfig objects.
+type ServiceConfigMap map[string]ServiceConfig
+
+// ServiceConfig holds user-defined configuration for a specific service.
+type ServiceConfig struct {
+	ProvisionDefaults map[string]interface{} `json:"provision_defaults"`
+	BindDefaults      map[string]interface{} `json:"bind_defaults"`
+	CustomPlans       []CustomPlan           `json:"custom_plans"`
+}
+
+// CustomPlan holds operator defined variables for each service.
+type CustomPlan struct {
+	GUID        string            `json:"guid" validate:"required,uuid"`
+	Name        string            `json:"name" validate:"required"`
+	DisplayName string            `json:"display_name" validate:"required"`
+	Description string            `json:"description" validate:"required"`
+	Properties  map[string]string `json:"properties"`
+}
+
+// ToServicePlan converts the CustomPlan to a ServicePlan.
+func (c *CustomPlan) ToServicePlan() ServicePlan {
+	return ServicePlan{
+		ServicePlan: brokerapi.ServicePlan{
+			Description: c.Description,
+			Name:        c.Name,
+			ID:          c.GUID,
+			Metadata: &brokerapi.ServicePlanMetadata{
+				DisplayName: c.DisplayName,
+			},
+		},
+		ServiceProperties: c.Properties,
+	}
+}
+
+// NewServiceConfigMapFromEnv reads viper for the value at ServiceConfigProperty
+// and deserializes it into a ServiceConfigMap.
+func NewServiceConfigMapFromEnv() (ServiceConfigMap, error) {
+	out := ServiceConfigMap{}
+	sources := viper.GetString(ServiceConfigProperty)
+	if len(sources) == 0 {
+		return out, nil
+	}
+
+	if err := json.Unmarshal([]byte(sources), &out); err != nil {
+		return nil, fmt.Errorf("couldn't deserialize ServiceConfigMap: %v", err)
+	}
+
+	return out, nil
+}

--- a/pkg/broker/service_config_test.go
+++ b/pkg/broker/service_config_test.go
@@ -1,0 +1,132 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/pivotal-cf/brokerapi"
+	"github.com/spf13/viper"
+)
+
+func TestServiceConfig_ToServicePlan(t *testing.T) {
+	cases := map[string]struct {
+		Plan     CustomPlan
+		Expected ServicePlan
+	}{
+		"nominal": {
+			Plan: CustomPlan{
+				GUID:        "00000000-0000-0000-0000-000000000000",
+				Name:        "my-normal-plan",
+				DisplayName: "My Normal Plan",
+				Description: "Some normal plan",
+				Properties:  map[string]string{"a": "b"},
+			},
+			Expected: ServicePlan{
+				ServicePlan: brokerapi.ServicePlan{
+					Description: "Some normal plan",
+					Name:        "my-normal-plan",
+					ID:          "00000000-0000-0000-0000-000000000000",
+					Metadata: &brokerapi.ServicePlanMetadata{
+						DisplayName: "My Normal Plan",
+					},
+				},
+				ServiceProperties: map[string]string{"a": "b"},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual := tc.Plan.ToServicePlan()
+
+			if !reflect.DeepEqual(tc.Expected, actual) {
+				t.Errorf("Expected: %v, Actual: %v", tc.Expected, actual)
+			}
+		})
+	}
+}
+
+func TestNewServiceConfigMapFromEnv(t *testing.T) {
+	cases := map[string]struct {
+		Env         string
+		ExpectedErr error
+		Expected    ServiceConfigMap
+	}{
+		"blank": {
+			Expected: ServiceConfigMap{},
+		},
+		"invalid-json": {
+			Env:         "{",
+			ExpectedErr: errors.New("couldn't deserialize ServiceConfigMap: unexpected end of JSON input"),
+		},
+		"multiple-objects": {
+			Env: `{"00000000-0000-0000-0000-000000000000":{}, "00000000-0000-0000-0000-000000000001":{}}`,
+			Expected: ServiceConfigMap{
+				"00000000-0000-0000-0000-000000000000": ServiceConfig{},
+				"00000000-0000-0000-0000-000000000001": ServiceConfig{},
+			},
+		},
+		"populated-object": {
+			Env: `{"00000000-0000-0000-0000-000000000000":{
+        "provision_defaults":{"pd1":"pdv1", "pd2":"pdv2"},
+        "bind_defaults":{"bd1":"bdv1", "bd2":"bdv2"},
+        "custom_plans":[
+          {
+            "guid":"00000000-0000-0000-0000-000000000001",
+            "name":"my-service-name",
+            "display_name":"my-service-display-name",
+            "description":"my-service-description",
+            "properties":{"pk1":"pv1"}
+          }
+        ]
+        }
+      }`,
+			Expected: ServiceConfigMap{
+				"00000000-0000-0000-0000-000000000000": ServiceConfig{
+					ProvisionDefaults: map[string]interface{}{"pd1": "pdv1", "pd2": "pdv2"},
+					BindDefaults:      map[string]interface{}{"bd1": "bdv1", "bd2": "bdv2"},
+					CustomPlans: []CustomPlan{
+						{
+							GUID:        "00000000-0000-0000-0000-000000000001",
+							Name:        "my-service-name",
+							DisplayName: "my-service-display-name",
+							Description: "my-service-description",
+							Properties:  map[string]string{"pk1": "pv1"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			viper.Set(ServiceConfigProperty, tc.Env)
+			defer viper.Reset()
+
+			actual, actualErr := NewServiceConfigMapFromEnv()
+			if !reflect.DeepEqual(tc.ExpectedErr, actualErr) {
+				t.Errorf("Expected: %v, Actual: %v", tc.ExpectedErr, actualErr)
+			}
+
+			if !reflect.DeepEqual(tc.Expected, actual) {
+				t.Errorf("Expected: %v, Actual: %v", tc.Expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -81,9 +81,9 @@ func (svc *ServiceDefinition) SetConfig(cfg ServiceConfig) error {
 // has metadata about the service so operators and programmers know which
 // service and plan will work best for their purposes.
 func (svc *ServiceDefinition) CatalogEntry() *Service {
-	userPlans := []ServicePlan{}
+	customPlans := []ServicePlan{}
 	for _, customPlan := range svc.config.CustomPlans {
-		userPlans = append(userPlans, customPlan.ToServicePlan())
+		customPlans = append(customPlans, customPlan.ToServicePlan())
 	}
 
 	sd := &Service{
@@ -103,7 +103,7 @@ func (svc *ServiceDefinition) CatalogEntry() *Service {
 			Bindable:      svc.Bindable,
 			PlanUpdatable: svc.PlanUpdateable,
 		},
-		Plans: append(svc.Plans, userPlans...),
+		Plans: append(svc.Plans, customPlans...),
 	}
 
 	if enableCatalogSchemas.IsActive() {

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -15,9 +15,7 @@
 package broker
 
 import (
-	"encoding/json"
 	"fmt"
-	"strings"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service/models"
@@ -25,7 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 	"github.com/pivotal-cf/brokerapi"
-	"github.com/spf13/viper"
 	"golang.org/x/oauth2/jwt"
 )
 
@@ -60,65 +57,31 @@ type ServiceDefinition struct {
 
 	// IsBuiltin is true if the service is built-in to the platform.
 	IsBuiltin bool
+
+	// config is set by the owning registry and is used to augment the data in the
+	// definition.
+	config ServiceConfig
 }
 
-// UserDefinedPlansProperty computes the Viper property name for the JSON list
-// of user-defined service plans.
-func (svc *ServiceDefinition) UserDefinedPlansProperty() string {
-	return fmt.Sprintf("service.%s.plans", svc.Name)
-}
-
-// ProvisionDefaultOverrideProperty returns the Viper property name for the
-// object users can set to override the default values on provision.
-func (svc *ServiceDefinition) ProvisionDefaultOverrideProperty() string {
-	return fmt.Sprintf("service.%s.provision.defaults", svc.Name)
-}
-
-// ProvisionDefaultOverrides returns the deserialized JSON object for the
-// operator-provided property overrides.
-func (svc *ServiceDefinition) ProvisionDefaultOverrides() map[string]interface{} {
-	return viper.GetStringMap(svc.ProvisionDefaultOverrideProperty())
-}
-
-// IsRoleWhitelistEnabled returns false if the service has no default whitelist
-// meaning it does not allow any roles.
-func (svc *ServiceDefinition) IsRoleWhitelistEnabled() bool {
-	return len(svc.DefaultRoleWhitelist) > 0
-}
-
-// BindDefaultOverrideProperty returns the Viper property name for the
-// object users can set to override the default values on bind.
-func (svc *ServiceDefinition) BindDefaultOverrideProperty() string {
-	return fmt.Sprintf("service.%s.bind.defaults", svc.Name)
-}
-
-// BindDefaultOverrides returns the deserialized JSON object for the
-// operator-provided property overrides.
-func (svc *ServiceDefinition) BindDefaultOverrides() map[string]interface{} {
-	return viper.GetStringMap(svc.BindDefaultOverrideProperty())
-}
-
-// TileUserDefinedPlansVariable returns the name of the user defined plans
-// variable for the broker tile.
-func (svc *ServiceDefinition) TileUserDefinedPlansVariable() string {
-	prefix := "GOOGLE_"
-
-	v := utils.PropertyToEnvUnprefixed(svc.Name)
-	if strings.HasPrefix(v, prefix) {
-		v = v[len(prefix):]
+// SetConfig sets user-defined overrides for the ServiceDefinition.
+// It returns an error if the config is invalid for the service.
+func (svc *ServiceDefinition) SetConfig(cfg ServiceConfig) error {
+	// all plans should have valid values
+	for _, plan := range cfg.CustomPlans {
+		if err := svc.validatePlan(plan); err != nil {
+			return err
+		}
 	}
 
-	return v + "_CUSTOM_PLANS"
+	svc.config = cfg
+	return nil
 }
 
 // CatalogEntry returns the service broker catalog entry for this service, it
 // has metadata about the service so operators and programmers know which
 // service and plan will work best for their purposes.
-func (svc *ServiceDefinition) CatalogEntry() (*Service, error) {
-	userPlans, err := svc.UserDefinedPlans()
-	if err != nil {
-		return nil, err
-	}
+func (svc *ServiceDefinition) CatalogEntry() *Service {
+	userPlans := svc.UserDefinedPlans()
 
 	sd := &Service{
 		Service: brokerapi.Service{
@@ -141,12 +104,12 @@ func (svc *ServiceDefinition) CatalogEntry() (*Service, error) {
 	}
 
 	if enableCatalogSchemas.IsActive() {
-		for i, _ := range sd.Plans {
+		for i := range sd.Plans {
 			sd.Plans[i].Schemas = svc.createSchemas()
 		}
 	}
 
-	return sd, nil
+	return sd
 }
 
 // createSchemas creates JSONSchemas compatible with the OSB spec for provision and bind.
@@ -168,10 +131,7 @@ func (svc *ServiceDefinition) createSchemas() *brokerapi.ServiceSchemas {
 
 // GetPlanById finds a plan in this service by its UUID.
 func (svc *ServiceDefinition) GetPlanById(planId string) (*ServicePlan, error) {
-	catalogEntry, err := svc.CatalogEntry()
-	if err != nil {
-		return nil, err
-	}
+	catalogEntry := svc.CatalogEntry()
 
 	for _, plan := range catalogEntry.Plans {
 		if plan.ID == planId {
@@ -184,49 +144,21 @@ func (svc *ServiceDefinition) GetPlanById(planId string) (*ServicePlan, error) {
 
 // UserDefinedPlans extracts user defined plans from the environment, failing if
 // the plans were not valid JSON or were missing required properties/variables.
-func (svc *ServiceDefinition) UserDefinedPlans() ([]ServicePlan, error) {
+func (svc *ServiceDefinition) UserDefinedPlans() []ServicePlan {
+	// TODO refactor this to work with custom plans
 	plans := []ServicePlan{}
 
-	userPlanJson := viper.GetString(svc.UserDefinedPlansProperty())
-	if userPlanJson == "" {
-		return plans, nil
-	}
-
-	// There's a mismatch between how plans are used internally and defined by
-	// the user and the tile. In the environment variables we parse an array of
-	// flat maps, but internally extra variables need to be put into a sub-map.
-	// e.g. they come in as [{"id":"1234", "name":"foo", "A": 1, "B": 2}]
-	// but we need [{"id":"1234", "name":"foo", "service_properties":{"A": 1, "B": 2}}]
-	// Go doesn't support this natively so we do it manually here.
-	rawPlans := []json.RawMessage{}
-	if err := json.Unmarshal([]byte(userPlanJson), &rawPlans); err != nil {
-		return plans, err
-	}
-
-	for _, rawPlan := range rawPlans {
-		plan := ServicePlan{}
-		remainder, err := utils.UnmarshalObjectRemainder(rawPlan, &plan)
-		if err != nil {
-			return []ServicePlan{}, err
-		}
-
-		plan.ServiceProperties = make(map[string]string)
-		if err := json.Unmarshal(remainder, &plan.ServiceProperties); err != nil {
-			return []ServicePlan{}, err
-		}
-
-		if err := svc.validatePlan(plan); err != nil {
-			return []ServicePlan{}, err
-		}
+	for _, customPlan := range svc.config.CustomPlans {
+		plan := customPlan.ToServicePlan()
 
 		plans = append(plans, plan)
 	}
 
-	return plans, nil
+	return plans
 }
 
-func (svc *ServiceDefinition) validatePlan(plan ServicePlan) error {
-	if plan.ID == "" {
+func (svc *ServiceDefinition) validatePlan(plan CustomPlan) error {
+	if plan.GUID == "" {
 		return fmt.Errorf("%s custom plan %+v is missing an id", svc.Name, plan)
 	}
 
@@ -243,7 +175,7 @@ func (svc *ServiceDefinition) validatePlan(plan ServicePlan) error {
 			continue
 		}
 
-		if _, ok := plan.ServiceProperties[customVar.FieldName]; !ok {
+		if _, ok := plan.Properties[customVar.FieldName]; !ok {
 			return fmt.Errorf("%s custom plan %+v is missing required property %s", svc.Name, plan, customVar.FieldName)
 		}
 	}
@@ -295,7 +227,7 @@ func (svc *ServiceDefinition) ProvisionVariables(instanceId string, details brok
 
 	builder := varcontext.Builder().
 		SetEvalConstants(constants).
-		MergeMap(svc.ProvisionDefaultOverrides()).
+		MergeMap(svc.config.ProvisionDefaults).
 		MergeJsonObject(details.GetRawParameters()).
 		MergeDefaults(svc.provisionDefaults()).
 		MergeMap(plan.GetServiceProperties()).
@@ -345,7 +277,7 @@ func (svc *ServiceDefinition) BindVariables(instance models.ServiceInstanceDetai
 
 	builder := varcontext.Builder().
 		SetEvalConstants(constants).
-		MergeMap(svc.BindDefaultOverrides()).
+		MergeMap(svc.config.BindDefaults).
 		MergeJsonObject(details.GetRawParameters()).
 		MergeDefaults(svc.bindDefaults()).
 		MergeDefaults(svc.BindComputedVariables)

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -145,13 +145,10 @@ func (svc *ServiceDefinition) GetPlanById(planId string) (*ServicePlan, error) {
 // UserDefinedPlans extracts user defined plans from the environment, failing if
 // the plans were not valid JSON or were missing required properties/variables.
 func (svc *ServiceDefinition) UserDefinedPlans() []ServicePlan {
-	// TODO refactor this to work with custom plans
 	plans := []ServicePlan{}
 
 	for _, customPlan := range svc.config.CustomPlans {
-		plan := customPlan.ToServicePlan()
-
-		plans = append(plans, plan)
+		plans = append(plans, customPlan.ToServicePlan())
 	}
 
 	return plans

--- a/pkg/brokerpak/cmd.go
+++ b/pkg/brokerpak/cmd.go
@@ -161,7 +161,7 @@ func Validate(pack string) error {
 
 // RegisterAll fetches all brokerpaks from the settings file and registers them
 // with the given registry.
-func RegisterAll(registry broker.BrokerRegistry) error {
+func RegisterAll(registry *broker.ServiceRegistry) error {
 	pakConfig, err := NewServerConfigFromEnv()
 	if err != nil {
 		return err
@@ -196,10 +196,15 @@ func Docs(pack string) error {
 	return nil
 }
 
-func registryFromLocalBrokerpak(packPath string) (broker.BrokerRegistry, error) {
+func registryFromLocalBrokerpak(packPath string) (*broker.ServiceRegistry, error) {
 	config := newLocalFileServerConfig(packPath)
 
-	registry := broker.BrokerRegistry{}
+	serviceConfig, err := broker.NewServiceConfigMapFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	registry := broker.NewServiceRegistry(serviceConfig)
+
 	if err := NewRegistrar(config).Register(registry); err != nil {
 		return nil, err
 	}

--- a/pkg/brokerpak/cmd_test.go
+++ b/pkg/brokerpak/cmd_test.go
@@ -166,8 +166,8 @@ func TestRegistryFromLocalBrokerpak(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(registry) != 1 {
-		t.Fatalf("Expected %d services but got %d", 1, len(registry))
+	if registry.ServiceCount() != 1 {
+		t.Fatalf("Expected %d services but got %d", 1, registry.ServiceCount())
 	}
 
 	svc, err := registry.GetServiceById("00000000-0000-0000-0000-000000000000")

--- a/pkg/brokerpak/registrar.go
+++ b/pkg/brokerpak/registrar.go
@@ -39,7 +39,7 @@ type Registrar struct {
 }
 
 // Register fetches the brokerpaks and registers them with the given registry.
-func (r *Registrar) Register(registry broker.BrokerRegistry) error {
+func (r *Registrar) Register(registry *broker.ServiceRegistry) error {
 	registerLogger := utils.NewLogger("brokerpak-registration")
 
 	return r.walk(func(name string, pak BrokerpakSourceConfig, vc *varcontext.VarContext) error {

--- a/pkg/brokerpak/registrar_test.go
+++ b/pkg/brokerpak/registrar_test.go
@@ -41,14 +41,14 @@ func TestNewRegistrar(t *testing.T) {
 	}
 
 	config := newLocalFileServerConfig(abs)
-	registry := broker.BrokerRegistry{}
+	registry := broker.NewServiceRegistry(broker.ServiceConfigMap{})
 	err = NewRegistrar(config).Register(registry)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(registry) != 1 {
-		t.Fatal("Expected length to be 1 got", len(registry))
+	if registry.ServiceCount() != 1 {
+		t.Fatal("Expected service count to be 1 got", registry.ServiceCount())
 	}
 }
 
@@ -77,7 +77,7 @@ func TestRegistrar_toDefinitions(t *testing.T) {
 			},
 			Config: BrokerpakSourceConfig{
 				ExcludedServices: "",
-				ServicePrefix: "",
+				ServicePrefix:    "",
 			},
 			ExpectedNames: []string{"service-foo", "service-bar"},
 		},
@@ -88,7 +88,7 @@ func TestRegistrar_toDefinitions(t *testing.T) {
 			},
 			Config: BrokerpakSourceConfig{
 				ExcludedServices: "",
-				ServicePrefix: "pre-",
+				ServicePrefix:    "pre-",
 			},
 			ExpectedNames: []string{"pre-service-foo", "pre-service-bar"},
 		},
@@ -99,7 +99,7 @@ func TestRegistrar_toDefinitions(t *testing.T) {
 			},
 			Config: BrokerpakSourceConfig{
 				ExcludedServices: "b69a96ad-0c38-4e84-84a3-be9513e3c645",
-				ServicePrefix: "",
+				ServicePrefix:    "",
 			},
 			ExpectedNames: []string{"service-bar"},
 		},

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -29,7 +29,7 @@ import (
 // RunExamplesForService runs all the exmaples for a given service name against
 // the service broker pointed to by client. All examples in the registry get run
 // if serviceName is blank.
-func RunExamplesForService(registry broker.BrokerRegistry, client *Client, serviceName string) error {
+func RunExamplesForService(registry *broker.ServiceRegistry, client *Client, serviceName string) error {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	services := registry.GetAllServices()
@@ -165,11 +165,7 @@ func newExampleExecutor(client *Client, example broker.ServiceExample, service *
 		return nil, err
 	}
 
-	catalog, err := service.CatalogEntry()
-	if err != nil {
-		return nil, err
-	}
-
+	catalog := service.CatalogEntry()
 	testid := rand.Uint32()
 
 	return &exampleExecutor{

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -28,7 +28,7 @@ import (
 
 // CatalogDocumentation generates markdown documentation for the service catalog
 // of the given registry.
-func CatalogDocumentation(registry broker.BrokerRegistry) string {
+func CatalogDocumentation(registry *broker.ServiceRegistry) string {
 	out := ""
 
 	services := registry.GetAllServices()
@@ -42,10 +42,7 @@ func CatalogDocumentation(registry broker.BrokerRegistry) string {
 
 // generateServiceDocumentation creates documentation for a single catalog entry
 func generateServiceDocumentation(svc *broker.ServiceDefinition) string {
-	catalog, err := svc.CatalogEntry()
-	if err != nil {
-		log.Fatalf("Error getting catalog entry for service %s, %v", svc.Name, err)
-	}
+	catalog := svc.CatalogEntry()
 
 	vars := map[string]interface{}{
 		"catalog":            catalog,

--- a/pkg/providers/builtin/registry.go
+++ b/pkg/providers/builtin/registry.go
@@ -36,14 +36,14 @@ import (
 
 // BuiltinBrokerRegistry creates a new registry with all the built-in brokers
 // added to it.
-func BuiltinBrokerRegistry() broker.BrokerRegistry {
-	out := broker.BrokerRegistry{}
+func BuiltinBrokerRegistry(cfg broker.ServiceConfigMap) *broker.ServiceRegistry {
+	out := broker.NewServiceRegistry(cfg)
 	RegisterBuiltinBrokers(out)
 	return out
 }
 
 // RegisterBuiltinBrokers adds the built-in brokers to the given registry.
-func RegisterBuiltinBrokers(registry broker.BrokerRegistry) {
+func RegisterBuiltinBrokers(registry *broker.ServiceRegistry) {
 	registry.Register(ml.ServiceDefinition())
 	registry.Register(bigquery.ServiceDefinition())
 	registry.Register(bigtable.ServiceDefinition())

--- a/pkg/providers/builtin/registry_test.go
+++ b/pkg/providers/builtin/registry_test.go
@@ -46,7 +46,8 @@ func TestBuiltinBrokerRegistry(t *testing.T) {
 
 	t.Run("service-count", func(t *testing.T) {
 		expectedServiceCount := len(builtinServiceNames)
-		actualServiceCount := len(BuiltinBrokerRegistry())
+		builtinRegistry := BuiltinBrokerRegistry(broker.ServiceConfigMap{})
+		actualServiceCount := len(builtinRegistry.GetAllServices())
 		if actualServiceCount != expectedServiceCount {
 			t.Errorf("Expected %d services, registered: %d", expectedServiceCount, actualServiceCount)
 		}
@@ -54,9 +55,9 @@ func TestBuiltinBrokerRegistry(t *testing.T) {
 
 	t.Run("service-names", func(t *testing.T) {
 		var actual []string
-		registry := BuiltinBrokerRegistry()
-		for name, _ := range registry {
-			actual = append(actual, name)
+		registry := BuiltinBrokerRegistry(broker.ServiceConfigMap{})
+		for _, svc := range registry.GetAllServices() {
+			actual = append(actual, svc.Name)
 		}
 
 		sort.Strings(actual)
@@ -65,7 +66,8 @@ func TestBuiltinBrokerRegistry(t *testing.T) {
 		}
 	})
 
-	for _, svc := range BuiltinBrokerRegistry() {
+	builtinRegistry := BuiltinBrokerRegistry(broker.ServiceConfigMap{})
+	for _, svc := range builtinRegistry.GetAllServices() {
 		validateServiceDefinition(t, svc)
 	}
 }
@@ -76,10 +78,7 @@ func validateServiceDefinition(t *testing.T, svc *broker.ServiceDefinition) {
 			t.Errorf("Expected flag 'builtin' to be set, but it was: %t", svc.IsBuiltin)
 		}
 
-		catalog, err := svc.CatalogEntry()
-		if err != nil {
-			t.Fatal(err)
-		}
+		catalog := svc.CatalogEntry()
 
 		if catalog.PlanUpdatable {
 			t.Error("Expected PlanUpdatable to be false")

--- a/pkg/server/docs.go
+++ b/pkg/server/docs.go
@@ -24,7 +24,7 @@ import (
 
 // NewDocsHandler returns a handler func that generates HTML documentation for
 // the given registry.
-func NewDocsHandler(registry broker.BrokerRegistry) http.HandlerFunc {
+func NewDocsHandler(registry *broker.ServiceRegistry) http.HandlerFunc {
 	docsPageMd := generator.CatalogDocumentation(registry)
 
 	params := blackfriday.HTMLRendererParameters{

--- a/pkg/server/docs_test.go
+++ b/pkg/server/docs_test.go
@@ -20,11 +20,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 )
 
 func TestNewDocsHandler(t *testing.T) {
-	registry := builtin.BuiltinBrokerRegistry()
+	registry := builtin.BuiltinBrokerRegistry(broker.ServiceConfigMap{})
 	// Test that the handler sets the correct header and contains some imporant
 	// strings that will indicate (but not prove!) that the rendering was correct.
 	handler := NewDocsHandler(registry)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -118,42 +118,6 @@ func SetParameter(input json.RawMessage, key string, value interface{}) (json.Ra
 	return json.Marshal(params)
 }
 
-// UnmarshalObjectRemaidner unmarshals an object into v and returns the
-// remaining key/value pairs as a JSON string by doing a set difference.
-func UnmarshalObjectRemainder(data []byte, v interface{}) ([]byte, error) {
-	if err := json.Unmarshal(data, v); err != nil {
-		return nil, err
-	}
-
-	encoded, err := json.Marshal(v)
-	if err != nil {
-		return nil, err
-	}
-
-	return jsonDiff(data, encoded)
-}
-
-func jsonDiff(superset, subset json.RawMessage) ([]byte, error) {
-	usedKeys := make(map[string]json.RawMessage)
-	if err := json.Unmarshal(subset, &usedKeys); err != nil {
-		return nil, err
-	}
-
-	allKeys := make(map[string]json.RawMessage)
-	if err := json.Unmarshal(superset, &allKeys); err != nil {
-		return nil, err
-	}
-
-	remainder := make(map[string]json.RawMessage)
-	for key, value := range allKeys {
-		if _, ok := usedKeys[key]; !ok {
-			remainder[key] = value
-		}
-	}
-
-	return json.Marshal(remainder)
-}
-
 // GetDefaultProject gets the default project id for the service broker based
 // on the JSON Service Account key.
 func GetDefaultProjectId() (string, error) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -51,22 +51,6 @@ func ExampleSetParameter() {
 	// {"replace":"new"}, <nil>
 }
 
-func ExampleUnmarshalObjectRemainder() {
-	var obj struct {
-		A string `json:"a_str"`
-		B int
-	}
-
-	remainder, err := UnmarshalObjectRemainder([]byte(`{"a_str":"hello", "B": 33, "C": 123}`), &obj)
-	fmt.Printf("%s, %v\n", string(remainder), err)
-
-	remainder, err = UnmarshalObjectRemainder([]byte(`{"a_str":"hello", "B": 33}`), &obj)
-	fmt.Printf("%s, %v\n", string(remainder), err)
-
-	// Output: {"C":123}, <nil>
-	// {}, <nil>
-}
-
 func ExampleGetDefaultProjectId() {
 	serviceAccountJson := `{
 	  "//": "Dummy account from https://github.com/GoogleCloudPlatform/google-cloud-java/google-cloud-clients/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java",


### PR DESCRIPTION
This is 1/2 of the full work to move the broker into using a general `GSB_SERVICE_CONFIG` environment variable and removes the following variables:

 * `GSB_SERVICE_*_WHITELIST`
 * `GSB_SERVICE_*_PROVISION_DEFAULTS`
 * `GSB_SERVICE_*_BIND_DEFAULTS`
 * `GSB_SERVICE_*_ENABLED`
 * `*_CUSTOM_PLANS`

What's included:

* Created new types: `ServiceConfig`, `ServiceConfigMap` and 
* Refactored BrokerRegistry to be named ServiceRegistry and include the user-customization options.

What will be included in another PR:

* The tile form for the `GSB_SERVICE_CONFIG` field and user-facing documentation for it.
* The migration script that generates `GSB_SERVICE_CONFIG`.

Part of #420 