### PR TITLE
fixed brokerpak issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.2.1] - 2019-02-06
+
+### Fixed
+ - The `pak run-examples` sub-command now returns a non-zero status code on failure.
+ - JSONSchema validation no longer fails due to erroneous duplicate required fields.
+ - Brokerpaks no longer use incorrect templates due to an invalid pointer.
+
 ## [4.2.0] - 2019-01-04
 
 ### Security

--- a/cmd/pak.go
+++ b/cmd/pak.go
@@ -141,7 +141,11 @@ dependencies, services it provides, and the contents.
 		Short: "run the examples from a brokerpak",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			brokerpak.RunExamples(args[0])
+			if err := brokerpak.RunExamples(args[0]); err != nil {
+				log.Fatalf("Error executing examples: %v", err)
+			}
+
+			log.Println("Success")
 		},
 	})
 

--- a/pkg/broker/variables.go
+++ b/pkg/broker/variables.go
@@ -162,13 +162,13 @@ func ValidateVariables(parameters map[string]interface{}, variables []BrokerVari
 }
 
 func createJsonSchema(schemaVariables []BrokerVariable) map[string]interface{} {
-	var required []string
+	required := utils.NewStringSet()
 	properties := make(map[string]interface{})
 
 	for _, variable := range schemaVariables {
 		properties[variable.FieldName] = variable.ToSchema()
 		if variable.Required {
-			required = append(required, variable.FieldName)
+			required.Add(variable.FieldName)
 		}
 	}
 
@@ -178,8 +178,8 @@ func createJsonSchema(schemaVariables []BrokerVariable) map[string]interface{} {
 		"properties": properties,
 	}
 
-	if required != nil {
-		schema["required"] = required
+	if !required.IsEmpty() {
+		schema["required"] = required.ToSlice()
 	}
 
 	return schema

--- a/pkg/providers/tf/definition.go
+++ b/pkg/providers/tf/definition.go
@@ -177,6 +177,7 @@ func (tfb *TfServiceDefinitionV1) ToService(executor wrapper.TerraformExecutor) 
 		rawPlans = append(rawPlans, plan.ToPlan())
 	}
 
+	constDefn := *tfb
 	return &broker.ServiceDefinition{
 		Id:               tfb.Id,
 		Name:             tfb.Name,
@@ -208,7 +209,7 @@ func (tfb *TfServiceDefinitionV1) ToService(executor wrapper.TerraformExecutor) 
 		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
 			jobRunner := NewTfJobRunnerForProject(projectId)
 			jobRunner.Executor = executor
-			return NewTerraformProvider(jobRunner, logger, *tfb)
+			return NewTerraformProvider(jobRunner, logger, constDefn)
 		},
 	}, nil
 }

--- a/utils/version.go
+++ b/utils/version.go
@@ -15,7 +15,7 @@
 package utils
 
 // Version sets the version for the whole GCP service broker software.
-const Version = "4.2.0"
+const Version = "4.2.1"
 
 // This custom user agent string is added to provision calls so that Google can track the aggregated use of this tool
 // We can better advocate for devoting resources to supporting cloud foundry and this service broker if we can show


### PR DESCRIPTION
 - The `pak run-examples` sub-command now returns a non-zero status code on failure.
 - JSONSchema validation no longer fails due to erroneous duplicate required fields.
 - Brokerpaks no longer use incorrect templates due to an invalid pointer.


The intent is to merge this into v4.2.1, then release a hotfix from that branch before merging it back into master