### PR TITLE
4-to-5 migration

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -109,7 +109,10 @@ The original environment variables will not be changed.
 		`,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			diff := migration.MigrateEnv()
+			diff, err := migration.MigrateEnv()
+			if err != nil {
+				log.Fatalf("Error migrating environment: %s", err)
+			}
 
 			response, err := yaml.Marshal(diff)
 			if err != nil {

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -79,6 +79,10 @@ func (registry *ServiceRegistry) GetEnabledServices() []*ServiceDefinition {
 			isEnabled = enableBuiltinServices.IsActive()
 		}
 
+		if svc.config.Disabled {
+			isEnabled = false
+		}
+
 		tags := utils.NewStringSet(svc.Tags...)
 		for tag, toggle := range lifecycleTagToggles {
 			if !toggle.IsActive() && tags.Contains(tag) {

--- a/pkg/broker/registry_test.go
+++ b/pkg/broker/registry_test.go
@@ -86,12 +86,25 @@ func TestRegistry_GetEnabledServices(t *testing.T) {
 				t.Fatalf("Expected 1 definition with %s enabled, but got %d", tc.Property, len(defns))
 			}
 
-			// should not show up if the service is explicitly disabled
-			viper.Set("compatibility.enable-builtin-services", false)
-			defns = registry.GetEnabledServices()
-			if len(defns) != 0 {
-				t.Fatalf("Expected no definition with builtins disabled, but got %d", len(defns))
-			}
+			// should not show up if builtin services are explicitly disabled
+			t.Run("disable-builtins", func(t *testing.T) {
+				viper.Set("compatibility.enable-builtin-services", false)
+				defer viper.Set("compatibility.enable-builtin-services", true)
+				defns = registry.GetEnabledServices()
+				if len(defns) != 0 {
+					t.Fatalf("Expected no definition with builtins disabled, but got %d", len(defns))
+				}
+			})
+
+			// should not show up if builtin services are explicitly disabled
+			t.Run("config-disabled", func(t *testing.T) {
+				sd.config.Disabled = true
+				defer func() { sd.config.Disabled = false }()
+				defns = registry.GetEnabledServices()
+				if len(defns) != 0 {
+					t.Fatalf("Expected no definition with builtins disabled, but got %d", len(defns))
+				}
+			})
 		})
 	}
 }

--- a/pkg/broker/service_config.go
+++ b/pkg/broker/service_config.go
@@ -30,6 +30,9 @@ type ServiceConfigMap map[string]ServiceConfig
 
 // ServiceConfig holds user-defined configuration for a specific service.
 type ServiceConfig struct {
+	// Notes contains user-defined notes about this config.
+	Notes             string                 `json:"//,omitempty"`
+	Disabled          bool                   `json:"disabled"`
 	ProvisionDefaults map[string]interface{} `json:"provision_defaults"`
 	BindDefaults      map[string]interface{} `json:"bind_defaults"`
 	CustomPlans       []CustomPlan           `json:"custom_plans"`

--- a/pkg/config/migration/four-to-five.go
+++ b/pkg/config/migration/four-to-five.go
@@ -70,9 +70,15 @@ func MergeToServiceConfig() Migration {
 				return null;
 			}
 
+			// explicitly check for boolean enabled false and turn it into a string.
+			var enabled = lookupProp(enabledVar);
+			if (enabled === false) {
+				enabled = 'false';
+			}
+
       var context = {
         "custom_plans": lookupProp(customPlanVar) || '[]',
-        "enabled": lookupProp(enabledVar) || 'true',
+        "enabled": enabled || 'true',
         "bind_defaults": lookupProp(bindDefaultsVar) || '{}',
         "provision_defaults": lookupProp(provisionDefaultsVar) || '{}',
       }

--- a/pkg/config/migration/four-to-five.go
+++ b/pkg/config/migration/four-to-five.go
@@ -1,0 +1,213 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+func serviceNames() []string {
+	return []string{
+		"BIGQUERY",
+		"BIGTABLE",
+		"CLOUDSQL_MYSQL",
+		"CLOUDSQL_POSTGRES",
+		"DATAFLOW",
+		"DATASTORE",
+		"DIALOGFLOW",
+		"FIRESTORE",
+		"ML_APIS",
+		"PUBSUB",
+		"SPANNER",
+		"STACKDRIVER_DEBUGGER",
+		"STACKDRIVER_MONITORING",
+		"STACKDRIVER_PROFILER",
+		"STACKDRIVER_TRACE",
+		"STORAGE",
+	}
+}
+
+func customPlanKeys() (out []string) {
+	for _, s := range serviceNames() {
+		out = append(out, s+"_CUSTOM_PLANS")
+	}
+
+	return
+}
+
+func MergeToServiceConfig() Migration {
+	jst := JsTransform{
+		EnvironmentVariables: []string{"GSB_SERVICE_CONFIG"},
+		MigrationJs: `
+
+    function mergeService(svcName) {
+      var customPlanVar = svcName+"_CUSTOM_PLANS";
+      var enabledVar = "GSB_SERVICE_GOOGLE_"+svcName+"_ENABLED";
+      var bindDefaultsVar = "GSB_SERVICE_GOOGLE_"+svcName+"_BIND_DEFAULTS";
+      var provisionDefaultsVar = "GSB_SERVICE_GOOGLE_"+svcName+"_PROVISION_DEFAULTS";
+
+      var context = {
+        "custom_plans": lookupProp(customPlanVar) || '[]',
+        "enabled": lookupProp(enabledVar) || 'true',
+        "bind_defaults": lookupProp(bindDefaultsVar) || '{}',
+        "provision_defaults": lookupProp(provisionDefaultsVar) || '{}',
+      }
+
+      deleteProp(customPlanVar);
+      deleteProp(enabledVar);
+      deleteProp(bindDefaultsVar);
+      deleteProp(provisionDefaultsVar);
+
+      // convert to plain object
+      for (var key in context) {
+        context[key] = JSON.parse(context[key]);
+      }
+
+			context["disabled"] = !context["enabled"];
+			delete context["enabled"];
+
+      context["//"] = "Builtin " + svcName;
+      return context;
+    }
+
+    function mergeServices(envVar) {
+      var out = {
+        "f80c0a3e-bd4d-4809-a900-b4e33a6450f1": mergeService("BIGQUERY"),
+        "b8e19880-ac58-42ef-b033-f7cd9c94d1fe": mergeService("BIGTABLE"),
+        "4bc59b9a-8520-409f-85da-1c7552315863": mergeService("CLOUDSQL_MYSQL"),
+        "cbad6d78-a73c-432d-b8ff-b219a17a803a": mergeService("CLOUDSQL_POSTGRES"),
+        "3e897eb3-9062-4966-bd4f-85bda0f73b3d": mergeService("DATAFLOW"),
+        "76d4abb2-fee7-4c8f-aee1-bcea2837f02b": mergeService("DATASTORE"),
+        "e84b69db-3de9-4688-8f5c-26b9d5b1f129": mergeService("DIALOGFLOW"),
+        "a2b7b873-1e34-4530-8a42-902ff7d66b43": mergeService("FIRESTORE"),
+        "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4": mergeService("ML_APIS"),
+        "628629e3-79f5-4255-b981-d14c6c7856be": mergeService("PUBSUB"),
+        "51b3e27e-d323-49ce-8c5f-1211e6409e82": mergeService("SPANNER"),
+        "83837945-1547-41e0-b661-ea31d76eed11": mergeService("STACKDRIVER_DEBUGGER"),
+        "2bc0d9ed-3f68-4056-b842-4a85cfbc727f": mergeService("STACKDRIVER_MONITORING"),
+        "00b9ca4a-7cd6-406a-a5b7-2f43f41ade75": mergeService("STACKDRIVER_PROFILER"),
+        "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a": mergeService("STACKDRIVER_TRACE"),
+        "b9e4332e-b42b-4680-bda5-ea1506797474": mergeService("STORAGE")
+      };
+
+      setProp(envVar, JSON.stringify(out, null, "  "));
+    }`,
+		TransformFuncName: "mergeServices",
+	}
+
+	return Migration{
+		Name:       "Merge Service Config",
+		TileScript: jst.ToJs(),
+		GoFunc:     jst.RunGo,
+	}
+}
+
+// DeleteWhitelistKeys removes the whitelist keys used prior to 4.0
+func DeleteWhitelistKeys() Migration {
+	whitelistKeys := []string{
+		"GSB_SERVICE_GOOGLE_BIGQUERY_WHITELIST",
+		"GSB_SERVICE_GOOGLE_BIGTABLE_WHITELIST",
+		"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_WHITELIST",
+		"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_WHITELIST",
+		"GSB_SERVICE_GOOGLE_ML_APIS_WHITELIST",
+		"GSB_SERVICE_GOOGLE_PUBSUB_WHITELIST",
+		"GSB_SERVICE_GOOGLE_SPANNER_WHITELIST",
+		"GSB_SERVICE_GOOGLE_STORAGE_WHITELIST",
+	}
+
+	return deleteMigration("Delete whitelist keys from 4.x", whitelistKeys)
+}
+
+// CollapseCustomPlans converts the Tile object based custom plan structure to
+// a JSON flattened structure suitable for passing in an environment variable.
+func CollapseCustomPlans() Migration {
+	jst := JsTransform{
+		EnvironmentVariables: customPlanKeys(),
+		MigrationJs: `
+    function replaceCustomPlans(envVar) {
+      var planList = lookupProp(envVar);
+
+      // do nothing if the planList doesn't exist or if it's already a string
+      if (planList == null || typeof (planList) === 'string') {
+        return;
+      }
+
+      var out = [];
+      for (var i in planList) {
+        var plan = planList[i];
+        var converted = {};
+        for (var k in plan) {
+          converted[k] = plan[k].value;
+        }
+
+        out.push(converted);
+      }
+
+      setProp(envVar, JSON.stringify(out, null, "  "));
+    }
+
+`,
+		TransformFuncName: "replaceCustomPlans",
+	}
+
+	return Migration{
+		Name:       "Collapse custom plans",
+		TileScript: jst.ToJs(),
+		GoFunc:     NoOp().GoFunc,
+	}
+}
+
+// FormatCustomPlans converts a flat variable map that the tile used to produce
+// into a structure the CustomPlan can parse where plan variables get put
+// under a properties map.
+func FormatCustomPlans() Migration {
+	jst := JsTransform{
+		EnvironmentVariables: customPlanKeys(),
+		MigrationJs: `
+    function formatPlans(envVar) {
+      var plansListJson = lookupProp(envVar);
+      if (plansListJson == null) {
+        return;
+      }
+
+      var planList = JSON.parse(plansListJson);
+
+      var out = [];
+      for (var i in planList) {
+        var plan = planList[i];
+        var converted = {};
+        var properties = {};
+        for (var k in plan) {
+          var value = plan[k];
+          if (k === 'service') { continue; }  // skip service key, it's no longer needed
+
+          if (['guid', 'description', 'name', 'display_name'].indexOf(k) >= 0) {
+            converted[k] = value;
+          } else {
+            properties[k] = value;
+          }
+        }
+        converted.properties = properties;
+        out.push(converted);
+      }
+
+      setProp(envVar, JSON.stringify(out));
+    }
+`,
+		TransformFuncName: "formatPlans",
+	}
+
+	return Migration{
+		Name:       "Format custom plans",
+		TileScript: jst.ToJs(),
+		GoFunc:     jst.RunGo,
+	}
+}

--- a/pkg/config/migration/four-to-five.go
+++ b/pkg/config/migration/four-to-five.go
@@ -136,27 +136,26 @@ func MergeToServiceConfig() Migration {
 		TransformFuncName: "mergeServices",
 	}
 
-	return Migration{
-		Name:       "Merge Service Config",
-		TileScript: jst.ToJs(),
-		GoFunc:     jst.RunGo,
-	}
+	return jst.ToMigration("Merge Service Config")
 }
 
 // DeleteWhitelistKeys removes the whitelist keys used prior to 4.0
 func DeleteWhitelistKeys() Migration {
-	whitelistKeys := []string{
-		"GSB_SERVICE_GOOGLE_BIGQUERY_WHITELIST",
-		"GSB_SERVICE_GOOGLE_BIGTABLE_WHITELIST",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_WHITELIST",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_WHITELIST",
-		"GSB_SERVICE_GOOGLE_ML_APIS_WHITELIST",
-		"GSB_SERVICE_GOOGLE_PUBSUB_WHITELIST",
-		"GSB_SERVICE_GOOGLE_SPANNER_WHITELIST",
-		"GSB_SERVICE_GOOGLE_STORAGE_WHITELIST",
+	jst := JsTransform{
+		TransformFuncName: "deleteProp",
+		EnvironmentVariables: []string{
+			"GSB_SERVICE_GOOGLE_BIGQUERY_WHITELIST",
+			"GSB_SERVICE_GOOGLE_BIGTABLE_WHITELIST",
+			"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_WHITELIST",
+			"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_WHITELIST",
+			"GSB_SERVICE_GOOGLE_ML_APIS_WHITELIST",
+			"GSB_SERVICE_GOOGLE_PUBSUB_WHITELIST",
+			"GSB_SERVICE_GOOGLE_SPANNER_WHITELIST",
+			"GSB_SERVICE_GOOGLE_STORAGE_WHITELIST",
+		},
 	}
 
-	return deleteMigration("Delete whitelist keys from 4.x", whitelistKeys)
+	return jst.ToMigration("Delete whitelist keys from 4.x")
 }
 
 // CollapseCustomPlans converts the Tile object based custom plan structure to
@@ -191,11 +190,7 @@ func CollapseCustomPlans() Migration {
 		TransformFuncName: "replaceCustomPlans",
 	}
 
-	return Migration{
-		Name:       "Collapse custom plans",
-		TileScript: jst.ToJs(),
-		GoFunc:     NoOp().GoFunc,
-	}
+	return jst.ToMigration("Collapse custom plans")
 }
 
 // FormatCustomPlans converts a flat variable map that the tile used to produce
@@ -238,9 +233,5 @@ func FormatCustomPlans() Migration {
 		TransformFuncName: "formatPlans",
 	}
 
-	return Migration{
-		Name:       "Format custom plans",
-		TileScript: jst.ToJs(),
-		GoFunc:     jst.RunGo,
-	}
+	return jst.ToMigration("Format custom plans")
 }

--- a/pkg/config/migration/four-to-five_test.go
+++ b/pkg/config/migration/four-to-five_test.go
@@ -1,0 +1,418 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import "testing"
+
+const defaultEmptyGsbServiceConfig = `{
+  "00b9ca4a-7cd6-406a-a5b7-2f43f41ade75": {
+    "//": "Builtin STACKDRIVER_PROFILER",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "2bc0d9ed-3f68-4056-b842-4a85cfbc727f": {
+    "//": "Builtin STACKDRIVER_MONITORING",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "3e897eb3-9062-4966-bd4f-85bda0f73b3d": {
+    "//": "Builtin DATAFLOW",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "4bc59b9a-8520-409f-85da-1c7552315863": {
+    "//": "Builtin CLOUDSQL_MYSQL",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "51b3e27e-d323-49ce-8c5f-1211e6409e82": {
+    "//": "Builtin SPANNER",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4": {
+    "//": "Builtin ML_APIS",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "628629e3-79f5-4255-b981-d14c6c7856be": {
+    "//": "Builtin PUBSUB",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "76d4abb2-fee7-4c8f-aee1-bcea2837f02b": {
+    "//": "Builtin DATASTORE",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "83837945-1547-41e0-b661-ea31d76eed11": {
+    "//": "Builtin STACKDRIVER_DEBUGGER",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "a2b7b873-1e34-4530-8a42-902ff7d66b43": {
+    "//": "Builtin FIRESTORE",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "b8e19880-ac58-42ef-b033-f7cd9c94d1fe": {
+    "//": "Builtin BIGTABLE",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "b9e4332e-b42b-4680-bda5-ea1506797474": {
+    "//": "Builtin STORAGE",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a": {
+    "//": "Builtin STACKDRIVER_TRACE",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "cbad6d78-a73c-432d-b8ff-b219a17a803a": {
+    "//": "Builtin CLOUDSQL_POSTGRES",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "e84b69db-3de9-4688-8f5c-26b9d5b1f129": {
+    "//": "Builtin DIALOGFLOW",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  },
+  "f80c0a3e-bd4d-4809-a900-b4e33a6450f1": {
+    "//": "Builtin BIGQUERY",
+    "bind_defaults": {},
+    "custom_plans": [],
+    "disabled": false,
+    "provision_defaults": {}
+  }
+}`
+
+func TestDeleteWhitelistKeys(t *testing.T) {
+	cases := map[string]MigrationTest{
+		"no-overlap": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.org": {
+              "type": "string",
+              "configurable": true,
+              "credential": false,
+              "value": "system",
+              "optional": false
+            }
+          }
+        }`,
+			Migration:   DeleteWhitelistKeys(),
+			ExpectedEnv: map[string]string{"ORG": "system"},
+		},
+		"one-key": {
+			TileProperties: `
+      {
+        "properties": {
+          ".properties.org": {"type": "string", "value": "system"},
+          ".properties.gsb_service_google_bigquery_whitelist": { "value": 1 }
+        }
+      }`,
+			Migration:   DeleteWhitelistKeys(),
+			ExpectedEnv: map[string]string{"ORG": "system"},
+		},
+		"all-keys": {
+			TileProperties: `
+      {
+        "properties": {
+          ".properties.gsb_service_google_bigquery_whitelist": { "value": 1 },
+          ".properties.gsb_service_google_bigtable_whitelist": { "value": 1 },
+          ".properties.gsb_service_google_cloudsql_mysql_whitelist": { "value": 1 },
+          ".properties.gsb_service_google_cloudsql_postgres_whitelist": { "value": 1 },
+          ".properties.gsb_service_google_ml_apis_whitelist": { "value": 1 },
+          ".properties.gsb_service_google_pubsub_whitelist": { "value": 1 },
+          ".properties.gsb_service_google_spanner_whitelist": { "value": 1 },
+          ".properties.gsb_service_google_storage_whitelist": { "value": 1 }
+        }
+      }`,
+			Migration:   DeleteWhitelistKeys(),
+			ExpectedEnv: map[string]string{},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, tc.Run)
+	}
+}
+
+func TestCollapseCustomPlans(t *testing.T) {
+	cases := map[string]MigrationTest{
+		"no-overlap": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.org": {"type": "string","value": "system"}
+          }
+        }`,
+			Migration:   CollapseCustomPlans(),
+			ExpectedEnv: map[string]string{"ORG": "system"},
+		},
+		"multiple-plans": {
+			TileProperties: `
+      {
+        "properties": {
+          ".properties.cloudsql_mysql_custom_plans": {
+            "type": "collection",
+            "value": [{"name": {"type": "string", "value": "plan1"}},{"name": {"type": "string", "value": "plan2"}}]
+          }
+        }
+      }
+`,
+			Migration: CollapseCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[
+  {
+    "name": "plan1"
+  },
+  {
+    "name": "plan2"
+  }
+]`,
+			},
+		},
+
+		"real-example": {
+			TileProperties: `{
+      	"properties": {
+      		".properties.cloudsql_mysql_custom_plans": {
+      			"type": "collection",
+      			"value": [
+      				{
+      					"guid": {"type": "uuid", "value": "69b4b7c9-2175-4d00-a298-81ebf11de59f"},
+      					"name": {"type": "string", "value": "custom-mysql-plan"},
+      					"display_name": {"type": "string", "value": "custom mysql plan"},
+      					"description": {"type": "string", "value": "custom mysql plan description"},
+      					"service": {"type": "dropdown_select", "value": "4bc59b9a-8520-409f-85da-1c7552315863"},
+      					"tier": {"type": "string", "value": "db-n1-standard-1"},
+      					"pricing_plan": {"type": "dropdown_select", "value": "PER_USE"},
+      					"max_disk_size": {"type": "string", "value": "10"}
+      				}
+      			]
+      		}
+      	}
+      }
+`,
+			Migration: CollapseCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[
+  {
+    "description": "custom mysql plan description",
+    "display_name": "custom mysql plan",
+    "guid": "69b4b7c9-2175-4d00-a298-81ebf11de59f",
+    "max_disk_size": "10",
+    "name": "custom-mysql-plan",
+    "pricing_plan": "PER_USE",
+    "service": "4bc59b9a-8520-409f-85da-1c7552315863",
+    "tier": "db-n1-standard-1"
+  }
+]`,
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, tc.Run)
+	}
+}
+
+func TestFormatCustomPlans(t *testing.T) {
+	cases := map[string]MigrationTest{
+		"no-overlap": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.org": {"type": "string","value": "system"}
+          }
+        }`,
+			Migration:   FormatCustomPlans(),
+			ExpectedEnv: map[string]string{"ORG": "system"},
+		},
+		"service-gets-deleted": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"service\":\"4bc59b9a-8520-409f-85da-1c7552315863\"}]"}
+          }
+        }`,
+			Migration: FormatCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"properties":{}}]`,
+			},
+		},
+		"guid-gets-set": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"guid\":\"4bc59b9a-8520-409f-85da-1c7552315863\"}]"}
+          }
+        }`,
+			Migration: FormatCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"guid":"4bc59b9a-8520-409f-85da-1c7552315863","properties":{}}]`,
+			},
+		},
+		"description-gets-set": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"description\":\"some-value\"}]"}
+          }
+        }`,
+			Migration: FormatCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"description":"some-value","properties":{}}]`,
+			},
+		},
+		"name-gets-set": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"name\":\"some-value\"}]"}
+          }
+        }`,
+			Migration: FormatCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"name":"some-value","properties":{}}]`,
+			},
+		},
+		"display-name-gets-set": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"display_name\":\"some-value\"}]"}
+          }
+        }`,
+			Migration: FormatCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"display_name":"some-value","properties":{}}]`,
+			},
+		},
+		"multiple-plans": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"name\":\"plan1\"},{\"name\":\"plan2\"}]"}
+          }
+        }`,
+			Migration: FormatCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"name":"plan1","properties":{}},{"name":"plan2","properties":{}}]`,
+			},
+		},
+		"unknown-props-go-to-properties": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"prop1\":\"some-value1\",\"prop2\":\"some-value2\"}]"}
+          }
+        }`,
+			Migration: FormatCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"properties":{"prop1":"some-value1","prop2":"some-value2"}}]`,
+			},
+		},
+		// The v4 tile only supports MySQL, Postgres, BigTable, Spanner, and Storage custom plans
+		"applies-to-v4-tile-values": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"name\":\"mysql\"}]"},
+            ".properties.bigtable_custom_plans": {"value":"[{\"name\":\"bigtable\"}]"},
+            ".properties.cloudsql_postgres_custom_plans": {"value":"[{\"name\":\"postgres\"}]"},
+            ".properties.spanner_custom_plans": {"value":"[{\"name\":\"spanner\"}]"},
+            ".properties.storage_custom_plans": {"value":"[{\"name\":\"storage\"}]"}
+          }
+        }`,
+			Migration: FormatCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS":    `[{"name":"mysql","properties":{}}]`,
+				"BIGTABLE_CUSTOM_PLANS":          `[{"name":"bigtable","properties":{}}]`,
+				"CLOUDSQL_POSTGRES_CUSTOM_PLANS": `[{"name":"postgres","properties":{}}]`,
+				"SPANNER_CUSTOM_PLANS":           `[{"name":"spanner","properties":{}}]`,
+				"STORAGE_CUSTOM_PLANS":           `[{"name":"storage","properties":{}}]`,
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, tc.Run)
+	}
+}
+
+func TestMergeToServiceConfig(t *testing.T) {
+	cases := map[string]MigrationTest{
+		"no-overlap": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.org": {"type": "string","value": "system"}
+          }
+        }`,
+			Migration:   MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"ORG": "system", "GSB_SERVICE_CONFIG": defaultEmptyGsbServiceConfig},
+		},
+		"all-keys": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.org": {"type": "string","value": "system"}
+          }
+        }`,
+			Migration:   MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"ORG": "system", "GSB_SERVICE_CONFIG": defaultEmptyGsbServiceConfig},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, tc.Run)
+	}
+}

--- a/pkg/config/migration/four-to-five_test.go
+++ b/pkg/config/migration/four-to-five_test.go
@@ -209,17 +209,9 @@ func TestCollapseCustomPlans(t *testing.T) {
 `,
 			Migration: CollapseCustomPlans(),
 			ExpectedEnv: map[string]string{
-				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[
-  {
-    "name": "plan1"
-  },
-  {
-    "name": "plan2"
-  }
-]`,
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"name": "plan1"},{"name": "plan2"}]`,
 			},
 		},
-
 		"real-example": {
 			TileProperties: `{
       	"properties": {
@@ -239,22 +231,64 @@ func TestCollapseCustomPlans(t *testing.T) {
       			]
       		}
       	}
+      }`,
+			Migration: CollapseCustomPlans(),
+			ExpectedEnv: map[string]string{
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[
+          {
+            "description": "custom mysql plan description",
+            "display_name": "custom mysql plan",
+            "guid": "69b4b7c9-2175-4d00-a298-81ebf11de59f",
+            "max_disk_size": "10",
+            "name": "custom-mysql-plan",
+            "pricing_plan": "PER_USE",
+            "service": "4bc59b9a-8520-409f-85da-1c7552315863",
+            "tier": "db-n1-standard-1"
+            }
+          ]`,
+			},
+		},
+		"all-4x-services": {
+			TileProperties: `
+      {
+        "properties": {
+          ".properties.bigquery_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.bigtable_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.cloudsql_mysql_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.cloudsql_postgres_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.dataflow_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.datastore_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.dialogflow_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.firestore_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.ml_apis_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.pubsub_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.spanner_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.stackdriver_debugger_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.stackdriver_monitoring_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.stackdriver_profiler_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.stackdriver_trace_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]},
+          ".properties.storage_custom_plans": { "type": "collection", "value": [{"name": {"type": "string", "value": "plan1"}}]}
+        }
       }
 `,
 			Migration: CollapseCustomPlans(),
 			ExpectedEnv: map[string]string{
-				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[
-  {
-    "description": "custom mysql plan description",
-    "display_name": "custom mysql plan",
-    "guid": "69b4b7c9-2175-4d00-a298-81ebf11de59f",
-    "max_disk_size": "10",
-    "name": "custom-mysql-plan",
-    "pricing_plan": "PER_USE",
-    "service": "4bc59b9a-8520-409f-85da-1c7552315863",
-    "tier": "db-n1-standard-1"
-  }
-]`,
+				"BIGQUERY_CUSTOM_PLANS":               `[{"name":"plan1"}]`,
+				"BIGTABLE_CUSTOM_PLANS":               `[{"name":"plan1"}]`,
+				"CLOUDSQL_MYSQL_CUSTOM_PLANS":         `[{"name":"plan1"}]`,
+				"CLOUDSQL_POSTGRES_CUSTOM_PLANS":      `[{"name":"plan1"}]`,
+				"DATAFLOW_CUSTOM_PLANS":               `[{"name":"plan1"}]`,
+				"DATASTORE_CUSTOM_PLANS":              `[{"name":"plan1"}]`,
+				"DIALOGFLOW_CUSTOM_PLANS":             `[{"name":"plan1"}]`,
+				"FIRESTORE_CUSTOM_PLANS":              `[{"name":"plan1"}]`,
+				"ML_APIS_CUSTOM_PLANS":                `[{"name":"plan1"}]`,
+				"PUBSUB_CUSTOM_PLANS":                 `[{"name":"plan1"}]`,
+				"SPANNER_CUSTOM_PLANS":                `[{"name":"plan1"}]`,
+				"STACKDRIVER_DEBUGGER_CUSTOM_PLANS":   `[{"name":"plan1"}]`,
+				"STACKDRIVER_MONITORING_CUSTOM_PLANS": `[{"name":"plan1"}]`,
+				"STACKDRIVER_PROFILER_CUSTOM_PLANS":   `[{"name":"plan1"}]`,
+				"STACKDRIVER_TRACE_CUSTOM_PLANS":      `[{"name":"plan1"}]`,
+				"STORAGE_CUSTOM_PLANS":                `[{"name":"plan1"}]`,
 			},
 		},
 	}

--- a/pkg/config/migration/four-to-five_test.go
+++ b/pkg/config/migration/four-to-five_test.go
@@ -394,7 +394,7 @@ func TestFormatCustomPlans(t *testing.T) {
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"properties":{"prop1":"some-value1","prop2":"some-value2"}}]`,
 			},
 		},
-		// The v4 tile only supports MySQL, Postgres, BigTable, Spanner, and Storage custom plans
+		// The v4 tile only supports MySQL, Postgres, BigTable, Spanner, and Storage custom plans.
 		"applies-to-v4-tile-values": {
 			TileProperties: `
         {
@@ -438,11 +438,22 @@ func TestMergeToServiceConfig(t *testing.T) {
 			TileProperties: `
         {
           "properties": {
-            ".properties.org": {"type": "string","value": "system"}
+            ".properties.bigquery_custom_plans": { "type": "collection", "value": "[{\"name\": \"my-plan\"}]"},
+            ".properties.gsb_service_bigquery_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_bigquery_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_bigquery_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration:   MergeToServiceConfig(),
-			ExpectedEnv: map[string]string{"ORG": "system", "GSB_SERVICE_CONFIG": defaultEmptyGsbServiceConfig},
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "f80c0a3e-bd4d-4809-a900-b4e33a6450f1": {
+          "//": "Builtin BIGQUERY",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [{"name":"my-plan"}],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
 		},
 	}
 

--- a/pkg/config/migration/four-to-five_test.go
+++ b/pkg/config/migration/four-to-five_test.go
@@ -319,6 +319,24 @@ func TestMergeToServiceConfig(t *testing.T) {
 			Migration:   MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"ORG": "system", "GSB_SERVICE_CONFIG": "{}"},
 		},
+		"enabled-to-disabled": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_bigquery_enabled": { "type": "boolean", "value": false }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "f80c0a3e-bd4d-4809-a900-b4e33a6450f1": {
+          "//": "Builtin BIGQUERY",
+          "bind_defaults": {},
+          "custom_plans": [],
+          "disabled": true,
+          "provision_defaults": {}
+        }
+      }`},
+		},
 		"bigquery": {
 			TileProperties: `
         {

--- a/pkg/config/migration/four-to-five_test.go
+++ b/pkg/config/migration/four-to-five_test.go
@@ -31,7 +31,6 @@ func TestDeleteWhitelistKeys(t *testing.T) {
             }
           }
         }`,
-			Migration:   DeleteWhitelistKeys(),
 			ExpectedEnv: map[string]string{"ORG": "system"},
 		},
 		"one-key": {
@@ -42,7 +41,6 @@ func TestDeleteWhitelistKeys(t *testing.T) {
           ".properties.gsb_service_google_bigquery_whitelist": { "value": 1 }
         }
       }`,
-			Migration:   DeleteWhitelistKeys(),
 			ExpectedEnv: map[string]string{"ORG": "system"},
 		},
 		"all-keys": {
@@ -59,12 +57,12 @@ func TestDeleteWhitelistKeys(t *testing.T) {
           ".properties.gsb_service_google_storage_whitelist": { "value": 1 }
         }
       }`,
-			Migration:   DeleteWhitelistKeys(),
 			ExpectedEnv: map[string]string{},
 		},
 	}
 
 	for tn, tc := range cases {
+		tc.Migration = DeleteWhitelistKeys()
 		t.Run(tn, tc.Run)
 	}
 }
@@ -78,7 +76,6 @@ func TestCollapseCustomPlans(t *testing.T) {
             ".properties.org": {"type": "string","value": "system"}
           }
         }`,
-			Migration:   CollapseCustomPlans(),
 			ExpectedEnv: map[string]string{"ORG": "system"},
 		},
 		"multiple-plans": {
@@ -92,7 +89,6 @@ func TestCollapseCustomPlans(t *testing.T) {
         }
       }
 `,
-			Migration: CollapseCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"name": "plan1"},{"name": "plan2"}]`,
 			},
@@ -117,7 +113,6 @@ func TestCollapseCustomPlans(t *testing.T) {
       		}
       	}
       }`,
-			Migration: CollapseCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[
           {
@@ -156,7 +151,6 @@ func TestCollapseCustomPlans(t *testing.T) {
         }
       }
 `,
-			Migration: CollapseCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"BIGQUERY_CUSTOM_PLANS":               `[{"name":"plan1"}]`,
 				"BIGTABLE_CUSTOM_PLANS":               `[{"name":"plan1"}]`,
@@ -179,6 +173,7 @@ func TestCollapseCustomPlans(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
+		tc.Migration = CollapseCustomPlans()
 		t.Run(tn, tc.Run)
 	}
 }
@@ -192,7 +187,6 @@ func TestFormatCustomPlans(t *testing.T) {
             ".properties.org": {"type": "string","value": "system"}
           }
         }`,
-			Migration:   FormatCustomPlans(),
 			ExpectedEnv: map[string]string{"ORG": "system"},
 		},
 		"service-gets-deleted": {
@@ -202,7 +196,6 @@ func TestFormatCustomPlans(t *testing.T) {
             ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"service\":\"4bc59b9a-8520-409f-85da-1c7552315863\"}]"}
           }
         }`,
-			Migration: FormatCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"properties":{}}]`,
 			},
@@ -214,7 +207,6 @@ func TestFormatCustomPlans(t *testing.T) {
             ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"guid\":\"4bc59b9a-8520-409f-85da-1c7552315863\"}]"}
           }
         }`,
-			Migration: FormatCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"guid":"4bc59b9a-8520-409f-85da-1c7552315863","properties":{}}]`,
 			},
@@ -226,7 +218,6 @@ func TestFormatCustomPlans(t *testing.T) {
             ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"description\":\"some-value\"}]"}
           }
         }`,
-			Migration: FormatCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"description":"some-value","properties":{}}]`,
 			},
@@ -238,7 +229,6 @@ func TestFormatCustomPlans(t *testing.T) {
             ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"name\":\"some-value\"}]"}
           }
         }`,
-			Migration: FormatCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"name":"some-value","properties":{}}]`,
 			},
@@ -250,7 +240,6 @@ func TestFormatCustomPlans(t *testing.T) {
             ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"display_name\":\"some-value\"}]"}
           }
         }`,
-			Migration: FormatCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"display_name":"some-value","properties":{}}]`,
 			},
@@ -262,7 +251,6 @@ func TestFormatCustomPlans(t *testing.T) {
             ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"name\":\"plan1\"},{\"name\":\"plan2\"}]"}
           }
         }`,
-			Migration: FormatCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"name":"plan1","properties":{}},{"name":"plan2","properties":{}}]`,
 			},
@@ -274,7 +262,6 @@ func TestFormatCustomPlans(t *testing.T) {
             ".properties.cloudsql_mysql_custom_plans": {"value":"[{\"prop1\":\"some-value1\",\"prop2\":\"some-value2\"}]"}
           }
         }`,
-			Migration: FormatCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS": `[{"properties":{"prop1":"some-value1","prop2":"some-value2"}}]`,
 			},
@@ -291,7 +278,6 @@ func TestFormatCustomPlans(t *testing.T) {
             ".properties.storage_custom_plans": {"value":"[{\"name\":\"storage\"}]"}
           }
         }`,
-			Migration: FormatCustomPlans(),
 			ExpectedEnv: map[string]string{
 				"CLOUDSQL_MYSQL_CUSTOM_PLANS":    `[{"name":"mysql","properties":{}}]`,
 				"BIGTABLE_CUSTOM_PLANS":          `[{"name":"bigtable","properties":{}}]`,
@@ -303,6 +289,7 @@ func TestFormatCustomPlans(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
+		tc.Migration = FormatCustomPlans()
 		t.Run(tn, tc.Run)
 	}
 }
@@ -316,7 +303,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.org": {"type": "string","value": "system"}
           }
         }`,
-			Migration:   MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"ORG": "system", "GSB_SERVICE_CONFIG": "{}"},
 		},
 		"enabled-to-disabled": {
@@ -326,7 +312,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_bigquery_enabled": { "type": "boolean", "value": false }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "f80c0a3e-bd4d-4809-a900-b4e33a6450f1": {
           "//": "Builtin BIGQUERY",
@@ -347,7 +332,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_bigquery_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "f80c0a3e-bd4d-4809-a900-b4e33a6450f1": {
           "//": "Builtin BIGQUERY",
@@ -369,7 +353,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_bigtable_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "b8e19880-ac58-42ef-b033-f7cd9c94d1fe": {
           "//": "Builtin BIGTABLE",
@@ -391,7 +374,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_cloudsql_mysql_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "4bc59b9a-8520-409f-85da-1c7552315863": {
           "//": "Builtin CLOUDSQL_MYSQL",
@@ -412,7 +394,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_cloudsql_postgres_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "cbad6d78-a73c-432d-b8ff-b219a17a803a": {
           "//": "Builtin CLOUDSQL_POSTGRES",
@@ -433,7 +414,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_dataflow_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "3e897eb3-9062-4966-bd4f-85bda0f73b3d": {
           "//": "Builtin DATAFLOW",
@@ -453,7 +433,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_datastore_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "76d4abb2-fee7-4c8f-aee1-bcea2837f02b": {
           "//": "Builtin DATASTORE",
@@ -473,7 +452,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_dialogflow_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "e84b69db-3de9-4688-8f5c-26b9d5b1f129": {
           "//": "Builtin DIALOGFLOW",
@@ -493,7 +471,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_firestore_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "a2b7b873-1e34-4530-8a42-902ff7d66b43": {
           "//": "Builtin FIRESTORE",
@@ -513,7 +490,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_ml_apis_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4": {
           "//": "Builtin ML_APIS",
@@ -533,7 +509,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_pubsub_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "628629e3-79f5-4255-b981-d14c6c7856be": {
           "//": "Builtin PUBSUB",
@@ -554,7 +529,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_spanner_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "51b3e27e-d323-49ce-8c5f-1211e6409e82": {
           "//": "Builtin SPANNER",
@@ -574,7 +548,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_stackdriver_debugger_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "83837945-1547-41e0-b661-ea31d76eed11": {
           "//": "Builtin STACKDRIVER_DEBUGGER",
@@ -594,7 +567,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_stackdriver_monitoring_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "2bc0d9ed-3f68-4056-b842-4a85cfbc727f": {
           "//": "Builtin STACKDRIVER_MONITORING",
@@ -614,7 +586,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_stackdriver_profiler_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "00b9ca4a-7cd6-406a-a5b7-2f43f41ade75": {
           "//": "Builtin STACKDRIVER_PROFILER",
@@ -634,7 +605,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_stackdriver_trace_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a": {
           "//": "Builtin STACKDRIVER_TRACE",
@@ -656,7 +626,6 @@ func TestMergeToServiceConfig(t *testing.T) {
             ".properties.gsb_service_google_storage_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
-			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "b9e4332e-b42b-4680-bda5-ea1506797474": {
           "//": "Builtin STORAGE",
@@ -670,6 +639,7 @@ func TestMergeToServiceConfig(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
+		tc.Migration = MergeToServiceConfig()
 		t.Run(tn, tc.Run)
 	}
 }

--- a/pkg/config/migration/four-to-five_test.go
+++ b/pkg/config/migration/four-to-five_test.go
@@ -16,121 +16,6 @@ package migration
 
 import "testing"
 
-const defaultEmptyGsbServiceConfig = `{
-  "00b9ca4a-7cd6-406a-a5b7-2f43f41ade75": {
-    "//": "Builtin STACKDRIVER_PROFILER",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "2bc0d9ed-3f68-4056-b842-4a85cfbc727f": {
-    "//": "Builtin STACKDRIVER_MONITORING",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "3e897eb3-9062-4966-bd4f-85bda0f73b3d": {
-    "//": "Builtin DATAFLOW",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "4bc59b9a-8520-409f-85da-1c7552315863": {
-    "//": "Builtin CLOUDSQL_MYSQL",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "51b3e27e-d323-49ce-8c5f-1211e6409e82": {
-    "//": "Builtin SPANNER",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4": {
-    "//": "Builtin ML_APIS",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "628629e3-79f5-4255-b981-d14c6c7856be": {
-    "//": "Builtin PUBSUB",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "76d4abb2-fee7-4c8f-aee1-bcea2837f02b": {
-    "//": "Builtin DATASTORE",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "83837945-1547-41e0-b661-ea31d76eed11": {
-    "//": "Builtin STACKDRIVER_DEBUGGER",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "a2b7b873-1e34-4530-8a42-902ff7d66b43": {
-    "//": "Builtin FIRESTORE",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "b8e19880-ac58-42ef-b033-f7cd9c94d1fe": {
-    "//": "Builtin BIGTABLE",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "b9e4332e-b42b-4680-bda5-ea1506797474": {
-    "//": "Builtin STORAGE",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a": {
-    "//": "Builtin STACKDRIVER_TRACE",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "cbad6d78-a73c-432d-b8ff-b219a17a803a": {
-    "//": "Builtin CLOUDSQL_POSTGRES",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "e84b69db-3de9-4688-8f5c-26b9d5b1f129": {
-    "//": "Builtin DIALOGFLOW",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  },
-  "f80c0a3e-bd4d-4809-a900-b4e33a6450f1": {
-    "//": "Builtin BIGQUERY",
-    "bind_defaults": {},
-    "custom_plans": [],
-    "disabled": false,
-    "provision_defaults": {}
-  }
-}`
-
 func TestDeleteWhitelistKeys(t *testing.T) {
 	cases := map[string]MigrationTest{
 		"no-overlap": {
@@ -432,22 +317,331 @@ func TestMergeToServiceConfig(t *testing.T) {
           }
         }`,
 			Migration:   MergeToServiceConfig(),
-			ExpectedEnv: map[string]string{"ORG": "system", "GSB_SERVICE_CONFIG": defaultEmptyGsbServiceConfig},
+			ExpectedEnv: map[string]string{"ORG": "system", "GSB_SERVICE_CONFIG": "{}"},
 		},
-		"all-keys": {
+		"bigquery": {
 			TileProperties: `
         {
           "properties": {
             ".properties.bigquery_custom_plans": { "type": "collection", "value": "[{\"name\": \"my-plan\"}]"},
-            ".properties.gsb_service_bigquery_enabled": { "type": "boolean", "value": true },
-            ".properties.gsb_service_bigquery_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
-            ".properties.gsb_service_bigquery_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+            ".properties.gsb_service_google_bigquery_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_bigquery_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_bigquery_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
           }
         }`,
 			Migration: MergeToServiceConfig(),
 			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
         "f80c0a3e-bd4d-4809-a900-b4e33a6450f1": {
           "//": "Builtin BIGQUERY",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [{"name":"my-plan"}],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+
+		"bigtable": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.bigtable_custom_plans": { "type": "collection", "value": "[{\"name\": \"my-plan\"}]"},
+            ".properties.gsb_service_google_bigtable_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_bigtable_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_bigtable_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "b8e19880-ac58-42ef-b033-f7cd9c94d1fe": {
+          "//": "Builtin BIGTABLE",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [{"name":"my-plan"}],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+
+		"cloudsql-mysql": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_mysql_custom_plans": { "type": "collection", "value": "[{\"name\": \"my-plan\"}]"},
+            ".properties.gsb_service_google_cloudsql_mysql_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_cloudsql_mysql_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_cloudsql_mysql_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "4bc59b9a-8520-409f-85da-1c7552315863": {
+          "//": "Builtin CLOUDSQL_MYSQL",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [{"name":"my-plan"}],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"cloudsql-postgres": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.cloudsql_postgres_custom_plans": { "type": "collection", "value": "[{\"name\": \"my-plan\"}]"},
+            ".properties.gsb_service_google_cloudsql_postgres_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_cloudsql_postgres_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_cloudsql_postgres_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "cbad6d78-a73c-432d-b8ff-b219a17a803a": {
+          "//": "Builtin CLOUDSQL_POSTGRES",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [{"name":"my-plan"}],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+
+		"dataflow": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_dataflow_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_dataflow_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_dataflow_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "3e897eb3-9062-4966-bd4f-85bda0f73b3d": {
+          "//": "Builtin DATAFLOW",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"datastore": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_datastore_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_datastore_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_datastore_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "76d4abb2-fee7-4c8f-aee1-bcea2837f02b": {
+          "//": "Builtin DATASTORE",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"dialogflow": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_dialogflow_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_dialogflow_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_dialogflow_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "e84b69db-3de9-4688-8f5c-26b9d5b1f129": {
+          "//": "Builtin DIALOGFLOW",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"firestore": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_firestore_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_firestore_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_firestore_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "a2b7b873-1e34-4530-8a42-902ff7d66b43": {
+          "//": "Builtin FIRESTORE",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"ml-apis": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_ml_apis_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_ml_apis_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_ml_apis_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "5ad2dce0-51f7-4ede-8b46-293d6df1e8d4": {
+          "//": "Builtin ML_APIS",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"pubsub": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_pubsub_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_pubsub_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_pubsub_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "628629e3-79f5-4255-b981-d14c6c7856be": {
+          "//": "Builtin PUBSUB",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"spanner": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.spanner_custom_plans": { "type": "collection", "value": "[{\"name\": \"my-plan\"}]"},
+            ".properties.gsb_service_google_spanner_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_spanner_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_spanner_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "51b3e27e-d323-49ce-8c5f-1211e6409e82": {
+          "//": "Builtin SPANNER",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [{"name":"my-plan"}],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"stackdriver-debugger": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_stackdriver_debugger_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_stackdriver_debugger_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_stackdriver_debugger_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "83837945-1547-41e0-b661-ea31d76eed11": {
+          "//": "Builtin STACKDRIVER_DEBUGGER",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"stackdriver-monitoring": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_stackdriver_monitoring_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_stackdriver_monitoring_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_stackdriver_monitoring_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "2bc0d9ed-3f68-4056-b842-4a85cfbc727f": {
+          "//": "Builtin STACKDRIVER_MONITORING",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"stackdriver-profiler": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_stackdriver_profiler_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_stackdriver_profiler_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_stackdriver_profiler_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "00b9ca4a-7cd6-406a-a5b7-2f43f41ade75": {
+          "//": "Builtin STACKDRIVER_PROFILER",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+		"stackdriver-trace": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.gsb_service_google_stackdriver_trace_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_stackdriver_trace_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_stackdriver_trace_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a": {
+          "//": "Builtin STACKDRIVER_TRACE",
+          "bind_defaults": {"bind":"default"},
+          "custom_plans": [],
+          "disabled": false,
+          "provision_defaults": {"provision":"default"}
+        }
+      }`},
+		},
+
+		"storage": {
+			TileProperties: `
+        {
+          "properties": {
+            ".properties.storage_custom_plans": { "type": "collection", "value": "[{\"name\": \"my-plan\"}]"},
+            ".properties.gsb_service_google_storage_enabled": { "type": "boolean", "value": true },
+            ".properties.gsb_service_google_storage_bind_defaults": { "type": "text", "value": "{\"bind\":\"default\"}" },
+            ".properties.gsb_service_google_storage_provision_defaults": { "type": "text", "value": "{\"provision\":\"default\"}" }
+          }
+        }`,
+			Migration: MergeToServiceConfig(),
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": `{
+        "b9e4332e-b42b-4680-bda5-ea1506797474": {
+          "//": "Builtin STORAGE",
           "bind_defaults": {"bind":"default"},
           "custom_plans": [{"name":"my-plan"}],
           "disabled": false,

--- a/pkg/config/migration/js.go
+++ b/pkg/config/migration/js.go
@@ -1,0 +1,161 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
+	"github.com/robertkrimen/otto"
+)
+
+// JsTransform is a backing tech for building config migrations in JavaScript.
+// It works for tile variables that have string values that can be replaced
+// in-place.
+type JsTransform struct {
+	// EnvironmentVariables holds the environment vars this migratino operates on.
+	EnvironmentVariables []string
+
+	// CreateIfNotExists creates the environment varible or property
+	// if it doesn't exist yet.
+	CreateIfNotExists bool
+
+	// Context returns a map of name->env-vars to look up and call the function
+	// with. It's given the name of the environment variable in case the
+	// other variables are based on that name.
+	Context func(environmentVariable string) map[string]string
+
+	// MigrationJs holds the JavaScript migration function. It MUST follow the
+	// signature func(string) -> string. The param is the value of the environment
+	// variable, and the result is the new value.
+	MigrationJs string
+
+	// TransformFuncName is the name of the JavaScript function defined in
+	// MigrationJs.
+	TransformFuncName string
+}
+
+func (j *JsTransform) lookupContext(variable string, env map[string]string) map[string]string {
+	context := make(map[string]string)
+	if j.Context == nil {
+		return context
+	}
+
+	for k, v := range j.Context(variable) {
+		variable, ok := env[v]
+		if ok {
+			context[k] = variable
+		}
+	}
+
+	return context
+}
+
+func (j *JsTransform) RunGo(env map[string]string) error {
+	for _, varname := range j.EnvironmentVariables {
+		value, exists := env[varname]
+		if !exists && !j.CreateIfNotExists {
+			continue
+		}
+
+		vm := otto.New()
+		if _, err := vm.Run(j.MigrationJs); err != nil {
+			return fmt.Errorf("processing %s loading JS function: %v", varname, err)
+		}
+
+		jsValue, err := vm.ToValue(value)
+		if err != nil {
+			return fmt.Errorf("processing %s converting value to JS value: %v", varname, err)
+		}
+
+		additionalContext, err := vm.ToValue(j.lookupContext(varname, env))
+		if err != nil {
+			return fmt.Errorf("processing %s converting context to JS value: %v", varname, err)
+		}
+
+		result, err := vm.Call(j.TransformFuncName, nil, jsValue, additionalContext)
+		if err != nil {
+			return fmt.Errorf("processing %s calling: %s: %v", varname, j.TransformFuncName, err)
+		}
+
+		str, err := result.ToString()
+		if err != nil {
+			return fmt.Errorf("processing %s couldn't convert result to string: %v", varname, err)
+		}
+
+		env[varname] = str
+	}
+
+	return nil
+}
+
+func (*JsTransform) propName(prop string) string {
+	return fmt.Sprintf("'.properties.%s'", strings.ToLower(prop))
+}
+
+func (j *JsTransform) propValue(prop string) string {
+	propName := j.propName(prop)
+	return fmt.Sprintf("((%s in properties['properties'])? properties['properties'][%s].value : null)", propName, propName)
+}
+
+func (j *JsTransform) jsContext(envVar string) string {
+	if j.Context == nil {
+		return "var context = {}; // no additional context defined"
+	}
+
+	buf := &bytes.Buffer{}
+	fmt.Fprintln(buf, "var context = {")
+
+	context := j.Context(envVar)
+	sortedKeys := utils.NewStringSetFromStringMapKeys(context).ToSlice()
+
+	for _, k := range sortedKeys {
+		fmt.Fprintf(buf, " %q: %s,\n", k, j.propValue(context[k]))
+	}
+	fmt.Fprintln(buf, "};")
+	return buf.String()
+}
+
+// ToJs converts this migration to a JavaScript suitable for running in the
+// tile.
+func (j *JsTransform) ToJs() string {
+	buf := &bytes.Buffer{}
+	fmt.Fprintln(buf, "{")
+	fmt.Fprintln(buf, j.MigrationJs)
+	fmt.Fprintln(buf)
+
+	for _, v := range j.EnvironmentVariables {
+		fmt.Fprintln(buf, "{")
+		fmt.Fprintf(buf, "  // %s\n", v)
+		fmt.Fprintf(buf, "  var prop = %s\n", j.propName(v))
+		fmt.Fprintln(buf, utils.Indent(j.jsContext(v), "  "))
+
+		if j.CreateIfNotExists {
+			fmt.Fprintln(buf, "  if (!(prop in properties['properties'])) {")
+			fmt.Fprintln(buf, "    properties['properties'][prop] = {'value': ''};")
+			fmt.Fprintln(buf, "  }")
+		}
+
+		fmt.Fprintln(buf, "  if (prop in properties['properties']) {")
+		fmt.Fprintf(buf, "    properties['properties'][prop].value = %s(properties['properties'][prop].value, context);\n", j.TransformFuncName)
+		fmt.Fprintln(buf, "  }")
+		fmt.Fprintln(buf, "}")
+	}
+
+	fmt.Fprintln(buf, "}")
+	return buf.String()
+}

--- a/pkg/config/migration/js.go
+++ b/pkg/config/migration/js.go
@@ -122,3 +122,12 @@ func (j *JsTransform) toJs(includeFunctions bool) string {
 	fmt.Fprintln(buf, "}")
 	return buf.String()
 }
+
+// ToMigration converts this transform into a migration with the given name.
+func (j *JsTransform) ToMigration(name string) Migration {
+	return Migration{
+		Name:       name,
+		TileScript: j.ToJs(),
+		GoFunc:     j.RunGo,
+	}
+}

--- a/pkg/config/migration/js_test.go
+++ b/pkg/config/migration/js_test.go
@@ -120,3 +120,85 @@ func TestJsTransform_RunGo(t *testing.T) {
 		})
 	}
 }
+
+func TestJsTransform_lookupProp(t *testing.T) {
+	cases := map[string]MigrationTest{
+		"property-exists": MigrationTest{
+			TileProperties: `{"properties": {".properties.gsb_test":{"value":"example"}}}`,
+			ExpectedEnv:    map[string]string{"GSB_TEST": "found"},
+		},
+		"property-missing": MigrationTest{
+			TileProperties: `{"properties": {}}`,
+			ExpectedEnv:    map[string]string{"GSB_TEST": "not found"},
+		},
+	}
+
+	for tn, tc := range cases {
+		jst := JsTransform{
+			EnvironmentVariables: []string{"GSB_TEST"},
+			MigrationJs: `function gsbTest(varName){
+					if(lookupProp(varName) == null) {
+						setProp(varName, "not found");
+					} else {
+						setProp(varName, "found");
+					}
+				}`,
+			TransformFuncName: "gsbTest",
+		}
+
+		tc.Migration = jst.ToMigration(tn)
+		t.Run(tn, tc.Run)
+	}
+}
+
+func TestJsTransform_deleteProp(t *testing.T) {
+	cases := map[string]MigrationTest{
+		"property-exists": MigrationTest{
+			TileProperties: `{"properties": {".properties.gsb_test":{"value":"example"}}}`,
+			ExpectedEnv:    map[string]string{},
+		},
+		"property-missing": MigrationTest{
+			TileProperties: `{"properties": {}}`,
+			ExpectedEnv:    map[string]string{},
+		},
+	}
+
+	for tn, tc := range cases {
+		jst := JsTransform{
+			EnvironmentVariables: []string{"GSB_TEST"},
+			MigrationJs: `function gsbTest(varName){
+					deleteProp(varName);
+				}`,
+			TransformFuncName: "gsbTest",
+		}
+
+		tc.Migration = jst.ToMigration(tn)
+		t.Run(tn, tc.Run)
+	}
+}
+
+func TestJsTransform_setProp(t *testing.T) {
+	cases := map[string]MigrationTest{
+		"property-exists": MigrationTest{
+			TileProperties: `{"properties": {".properties.gsb_test":{"value":"example"}}}`,
+			ExpectedEnv:    map[string]string{"GSB_TEST": "NEW VALUE"},
+		},
+		"property-missing": MigrationTest{
+			TileProperties: `{"properties": {}}`,
+			ExpectedEnv:    map[string]string{"GSB_TEST": "NEW VALUE"},
+		},
+	}
+
+	for tn, tc := range cases {
+		jst := JsTransform{
+			EnvironmentVariables: []string{"GSB_TEST"},
+			MigrationJs: `function gsbTest(varName){
+					setProp(varName, "NEW VALUE");
+				}`,
+			TransformFuncName: "gsbTest",
+		}
+
+		tc.Migration = jst.ToMigration(tn)
+		t.Run(tn, tc.Run)
+	}
+}

--- a/pkg/config/migration/js_test.go
+++ b/pkg/config/migration/js_test.go
@@ -1,0 +1,135 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func ExampleJsTransform_RunGo() {
+	em := JsTransform{
+		EnvironmentVariables: []string{"GSB_FOO", "GSB_BAR"},
+		MigrationJs:          `function format(input){return "[" + input + "]"}`,
+		TransformFuncName:    "format",
+	}
+
+	env := map[string]string{
+		"GSB_FOO": "to,encapsulate",
+	}
+
+	err := em.RunGo(env)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(env["GSB_FOO"])
+
+	// Output: [to,encapsulate]
+}
+
+func ExampleJsTransform_ToJs() {
+	em := JsTransform{
+		EnvironmentVariables: []string{"GSB_FOO", "GSB_BAR"},
+		MigrationJs:          `function format(input){return "[" + input + "]"}`,
+		TransformFuncName:    "format",
+	}
+
+	fmt.Println(em.ToJs())
+
+	// Output: {
+	// function format(input){return "[" + input + "]"}
+	//
+	// {
+	//   // GSB_FOO
+	//   var prop = '.properties.gsb_foo'
+	//   var context = {}; // no additional context defined
+	//   if (prop in properties['properties']) {
+	//     properties['properties'][prop].value = format(properties['properties'][prop].value, context);
+	//   }
+	// }
+	// {
+	//   // GSB_BAR
+	//   var prop = '.properties.gsb_bar'
+	//   var context = {}; // no additional context defined
+	//   if (prop in properties['properties']) {
+	//     properties['properties'][prop].value = format(properties['properties'][prop].value, context);
+	//   }
+	// }
+	// }
+}
+
+func TestJsTransform_RunGo(t *testing.T) {
+	cases := map[string]struct {
+		Migration   JsTransform
+		Env         map[string]string
+		ExpectedErr error
+		ExpectedEnv map[string]string
+	}{
+		"set value": {
+			Migration: JsTransform{
+				EnvironmentVariables: []string{"FOO"},
+				MigrationJs:          `function set(input){return "new-value"}`,
+				TransformFuncName:    "set",
+			},
+			Env:         map[string]string{"FOO": "old-value"},
+			ExpectedEnv: map[string]string{"FOO": "new-value"},
+		},
+		"ignores unknown": {
+			Migration: JsTransform{
+				EnvironmentVariables: []string{"FOO"},
+				MigrationJs:          `function set(input){return "new-value"}`,
+				TransformFuncName:    "set",
+			},
+			Env:         map[string]string{"BAR": "old-value"},
+			ExpectedEnv: map[string]string{"BAR": "old-value"},
+		},
+		"bad js": {
+			Migration: JsTransform{
+				EnvironmentVariables: []string{"FOO"},
+				MigrationJs:          `set function(input) return{return "new-value"}`,
+				TransformFuncName:    "set",
+			},
+			Env:         map[string]string{"FOO": "old-value"},
+			ExpectedErr: errors.New("processing FOO loading JS function: (anonymous): Line 1:5 Unexpected token function (and 3 more errors)"),
+			ExpectedEnv: map[string]string{"FOO": "old-value"},
+		},
+		"bad func": {
+			Migration: JsTransform{
+				EnvironmentVariables: []string{"FOO"},
+				MigrationJs:          `function set(input){return "new-value"}`,
+				TransformFuncName:    "invalidFuncName",
+			},
+			Env:         map[string]string{"FOO": "old-value"},
+			ExpectedErr: errors.New("processing FOO calling: invalidFuncName: ReferenceError: 'invalidFuncName' is not defined"),
+			ExpectedEnv: map[string]string{"FOO": "old-value"},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			err := tc.Migration.RunGo(tc.Env)
+			if !reflect.DeepEqual(err, tc.ExpectedErr) {
+				t.Errorf("Expected error: %v Got: %v", tc.ExpectedErr, err)
+			}
+
+			if !reflect.DeepEqual(tc.Env, tc.ExpectedEnv) {
+				t.Errorf("Expected: %v Got: %v", tc.ExpectedEnv, tc.Env)
+			}
+		})
+	}
+}

--- a/pkg/config/migration/migration.go
+++ b/pkg/config/migration/migration.go
@@ -30,24 +30,6 @@ type Migration struct {
 	GoFunc     func(env map[string]string) error
 }
 
-func deleteMigration(name string, env []string) Migration {
-	js := ``
-	for _, v := range env {
-		js += "delete properties.properties['.properties." + strings.ToLower(v) + "'];\n"
-	}
-
-	return Migration{
-		Name:       name,
-		TileScript: js,
-		GoFunc: func(envMap map[string]string) error {
-			for _, v := range env {
-				delete(envMap, v)
-			}
-			return nil
-		},
-	}
-}
-
 // NoOp is an empty migration.
 func NoOp() Migration {
 	return Migration{

--- a/pkg/config/migration/migration.go
+++ b/pkg/config/migration/migration.go
@@ -17,6 +17,7 @@ package migration
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -72,10 +73,258 @@ func DeleteWhitelistKeys() Migration {
 	return deleteMigration("Delete whitelist keys from 4.x", whitelistKeys)
 }
 
+// DeleteEnabledKeys removes the enable/disable flag keys.
+func DeleteEnabledKeys() Migration {
+	keys := []string{
+		"GSB_SERVICE_GOOGLE_BIGQUERY_ENABLED",
+		"GSB_SERVICE_GOOGLE_BIGTABLE_ENABLED",
+		"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_ENABLED",
+		"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_ENABLED",
+		"GSB_SERVICE_GOOGLE_ML_APIS_ENABLED",
+		"GSB_SERVICE_GOOGLE_PUBSUB_ENABLED",
+		"GSB_SERVICE_GOOGLE_SPANNER_ENABLED",
+		"GSB_SERVICE_GOOGLE_STORAGE_ENABLED",
+	}
+
+	return deleteMigration("Delete enabled keys from 4.x", keys)
+}
+
+// DeleteProvisionDefaultKeys removes the provision default keys.
+func DeleteProvisionDefaultKeys() Migration {
+	keys := []string{
+		"GSB_SERVICE_GOOGLE_BIGQUERY_PROVISION_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_BIGTABLE_PROVISION_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_PROVISION_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_PROVISION_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_ML_APIS_PROVISION_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_PUBSUB_PROVISION_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_SPANNER_PROVISION_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_STORAGE_PROVISION_DEFAULTS",
+	}
+
+	return deleteMigration("Delete provision defaults from 4.x", keys)
+}
+
+// DeleteBindDefaultKeys removes the bind default keys.
+func DeleteBindDefaultKeys() Migration {
+	keys := []string{
+		"GSB_SERVICE_GOOGLE_BIGQUERY_BIND_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_BIGTABLE_BIND_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_BIND_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_BIND_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_ML_APIS_BIND_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_PUBSUB_BIND_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_SPANNER_BIND_DEFAULTS",
+		"GSB_SERVICE_GOOGLE_STORAGE_BIND_DEFAULTS",
+	}
+
+	return deleteMigration("Delete bind defaults from 4.x", keys)
+}
+
+func customPlanKeys() []string {
+	return []string{
+		"BIGQUERY_CUSTOM_PLANS",
+		"BIGTABLE_CUSTOM_PLANS",
+		"CLOUDSQL_MYSQL_CUSTOM_PLANS",
+		"CLOUDSQL_POSTGRES_CUSTOM_PLANS",
+		"ML_APIS_CUSTOM_PLANS",
+		"PUBSUB_CUSTOM_PLANS",
+		"SPANNER_CUSTOM_PLANS",
+		"STORAGE_CUSTOM_PLANS",
+	}
+}
+
+// DeleteCustomPlanKeys removes the custom plan keys.
+func DeleteCustomPlanKeys() Migration {
+	return deleteMigration("Delete custom plans from 4.x", customPlanKeys())
+}
+
+func CollapseCustomPlans() Migration {
+	jst := JsTransform{
+		EnvironmentVariables: customPlanKeys(),
+		MigrationJs: `
+		function replaceCustomPlans(planList) {
+			// if this is already JSON rather than a tile custom format
+			// just return it
+			if (typeof(planList) === "string") {
+				return planList;
+			}
+
+		  var out = [];
+		  for (var i in planList) {
+		    var plan = planList[i];
+		    var converted = {}
+		    for (var k in plan) {
+		      converted[k] = plan[k].value
+		    }
+
+		    out.push(converted);
+		  }
+
+			return JSON.stringify(out);
+		}`,
+		TransformFuncName: "replaceCustomPlans",
+	}
+
+	return Migration{
+		Name:       "Collapse custom plans",
+		TileScript: jst.ToJs(),
+		GoFunc: func(env map[string]string) {
+			if err := jst.RunGo(env); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+}
+
+func FormatCustomPlans() Migration {
+	jst := JsTransform{
+		EnvironmentVariables: customPlanKeys(),
+		MigrationJs: `
+		function formatPlans(plansListJson) {
+			var planList = JSON.parse(plansListJson);
+
+			var out = [];
+			for (var i in planList) {
+				var plan = planList[i];
+				var converted = {};
+				var properties = {};
+				for (var k in plan) {
+					var value = plan[k];
+					if (k === 'service') { continue; } // skip service key, it's no longer needed
+
+					if(["guid", "description", "name", "display_name"].indexOf(k) >= 0) {
+						converted[k] = value
+					} else {
+						properties[k] = value;
+					}
+				}
+				converted.properties = properties;
+
+				out.push(converted);
+			}
+
+			return JSON.stringify(out);
+		}`,
+		TransformFuncName: "formatPlans",
+	}
+
+	return Migration{
+		Name:       "Format custom plans",
+		TileScript: jst.ToJs(),
+		GoFunc: func(env map[string]string) {
+			if err := jst.RunGo(env); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+}
+
+func MergeServices() Migration {
+	jst := JsTransform{
+		EnvironmentVariables: customPlanKeys(),
+		MigrationJs: `
+		function mergeServices(v, context) {
+			var out = {};
+			for (var key in context) {
+				var value = context[key];
+				if (value != null) {
+					out[key] = JSON.parse(context[key]);
+				}
+			}
+
+			return JSON.stringify(out, null, "  ");
+		}`,
+		TransformFuncName: "mergeServices",
+		Context: func(envVar string) map[string]string {
+			svcName := strings.TrimSuffix(envVar, "_CUSTOM_PLANS")
+
+			return map[string]string{
+				"custom_plans":       envVar,
+				"enabled":            fmt.Sprintf("GSB_SERVICE_GOOGLE_%s_ENABLED", svcName),
+				"bind_defaults":      fmt.Sprintf("GSB_SERVICE_GOOGLE_%s_BIND_DEFAULTS", svcName),
+				"provision_defaults": fmt.Sprintf("GSB_SERVICE_GOOGLE_%s_PROVISION_DEFAULTS", svcName),
+			}
+		},
+	}
+
+	return Migration{
+		Name:       "Merge Services",
+		TileScript: jst.ToJs(),
+		GoFunc: func(env map[string]string) {
+			if err := jst.RunGo(env); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+}
+
+func MergeToServiceConfig() Migration {
+	jst := JsTransform{
+		EnvironmentVariables: []string{"GSB_SERVICE_CONFIG"},
+		CreateIfNotExists:    true,
+		MigrationJs: `
+		function mergeServices(v, context) {
+			var out = {};
+			for (var key in context) {
+				var value = context[key];
+				if (value != null) {
+					out[key] = JSON.parse(context[key]);
+				}
+			}
+
+			return JSON.stringify(out, null, "  ");
+		}`,
+		TransformFuncName: "mergeServices",
+		Context: func(envVar string) map[string]string {
+			return map[string]string{
+				"f80c0a3e-bd4d-4809-a900-b4e33a6450f1": "BIGQUERY_CUSTOM_PLANS",
+				"b8e19880-ac58-42ef-b033-f7cd9c94d1fe": "BIGTABLE_CUSTOM_PLANS",
+				"4bc59b9a-8520-409f-85da-1c7552315863": "CLOUDSQL_MYSQL_CUSTOM_PLANS",
+				"cbad6d78-a73c-432d-b8ff-b219a17a803a": "CLOUDSQL_POSTGRES_CUSTOM_PLANS",
+				"3e897eb3-9062-4966-bd4f-85bda0f73b3d": "DATAFLOW_CUSTOM_PLANS",
+				"76d4abb2-fee7-4c8f-aee1-bcea2837f02b": "DATASTORE_CUSTOM_PLANS",
+				"e84b69db-3de9-4688-8f5c-26b9d5b1f129": "DIALOGFLOW_CUSTOM_PLANS",
+				"a2b7b873-1e34-4530-8a42-902ff7d66b43": "FIRESTORE_CUSTOM_PLANS",
+				"5ad2dce0-51f7-4ede-8b46-293d6df1e8d4": "ML_APIS_CUSTOM_PLANS",
+				"628629e3-79f5-4255-b981-d14c6c7856be": "PUBSUB_CUSTOM_PLANS",
+				"51b3e27e-d323-49ce-8c5f-1211e6409e82": "SPANNER_CUSTOM_PLANS",
+				"83837945-1547-41e0-b661-ea31d76eed11": "STACKDRIVER_DEBUGGER_CUSTOM_PLANS",
+				"2bc0d9ed-3f68-4056-b842-4a85cfbc727f": "STACKDRIVER_MONITORING_CUSTOM_PLANS",
+				"00b9ca4a-7cd6-406a-a5b7-2f43f41ade75": "STACKDRIVER_PROFILER_CUSTOM_PLANS",
+				"c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a": "STACKDRIVER_TRACE_CUSTOM_PLANS",
+				"b9e4332e-b42b-4680-bda5-ea1506797474": "STORAGE_CUSTOM_PLANS",
+			}
+		},
+	}
+
+	return Migration{
+		Name:       "Merge Service Config",
+		TileScript: jst.ToJs(),
+		GoFunc: func(env map[string]string) {
+			if _, ok := env["GSB_SERVICE_CONFIG"]; !ok {
+				env["GSB_SERVICE_CONFIG"] = ""
+			}
+
+			if err := jst.RunGo(env); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+}
+
 // migrations returns a list of all migrations to be performed in order.
 func migrations() []Migration {
 	return []Migration{
 		DeleteWhitelistKeys(),
+		CollapseCustomPlans(),
+		FormatCustomPlans(),
+		MergeServices(),
+		MergeToServiceConfig(),
+		DeleteProvisionDefaultKeys(),
+		DeleteBindDefaultKeys(),
+		DeleteCustomPlanKeys(),
+		DeleteEnabledKeys(),
 	}
 }
 

--- a/pkg/config/migration/migration.go
+++ b/pkg/config/migration/migration.go
@@ -17,7 +17,6 @@ package migration
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -28,7 +27,7 @@ import (
 type Migration struct {
 	Name       string
 	TileScript string
-	GoFunc     func(env map[string]string)
+	GoFunc     func(env map[string]string) error
 }
 
 func deleteMigration(name string, env []string) Migration {
@@ -40,10 +39,11 @@ func deleteMigration(name string, env []string) Migration {
 	return Migration{
 		Name:       name,
 		TileScript: js,
-		GoFunc: func(envMap map[string]string) {
+		GoFunc: func(envMap map[string]string) error {
 			for _, v := range env {
 				delete(envMap, v)
 			}
+			return nil
 		},
 	}
 }
@@ -53,262 +53,8 @@ func NoOp() Migration {
 	return Migration{
 		Name:       "Noop",
 		TileScript: ``,
-		GoFunc:     func(envMap map[string]string) {},
-	}
-}
-
-// DeleteWhitelistKeys removes the whitelist keys used prior to 4.0
-func DeleteWhitelistKeys() Migration {
-	whitelistKeys := []string{
-		"GSB_SERVICE_GOOGLE_BIGQUERY_WHITELIST",
-		"GSB_SERVICE_GOOGLE_BIGTABLE_WHITELIST",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_WHITELIST",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_WHITELIST",
-		"GSB_SERVICE_GOOGLE_ML_APIS_WHITELIST",
-		"GSB_SERVICE_GOOGLE_PUBSUB_WHITELIST",
-		"GSB_SERVICE_GOOGLE_SPANNER_WHITELIST",
-		"GSB_SERVICE_GOOGLE_STORAGE_WHITELIST",
-	}
-
-	return deleteMigration("Delete whitelist keys from 4.x", whitelistKeys)
-}
-
-// DeleteEnabledKeys removes the enable/disable flag keys.
-func DeleteEnabledKeys() Migration {
-	keys := []string{
-		"GSB_SERVICE_GOOGLE_BIGQUERY_ENABLED",
-		"GSB_SERVICE_GOOGLE_BIGTABLE_ENABLED",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_ENABLED",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_ENABLED",
-		"GSB_SERVICE_GOOGLE_ML_APIS_ENABLED",
-		"GSB_SERVICE_GOOGLE_PUBSUB_ENABLED",
-		"GSB_SERVICE_GOOGLE_SPANNER_ENABLED",
-		"GSB_SERVICE_GOOGLE_STORAGE_ENABLED",
-	}
-
-	return deleteMigration("Delete enabled keys from 4.x", keys)
-}
-
-// DeleteProvisionDefaultKeys removes the provision default keys.
-func DeleteProvisionDefaultKeys() Migration {
-	keys := []string{
-		"GSB_SERVICE_GOOGLE_BIGQUERY_PROVISION_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_BIGTABLE_PROVISION_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_PROVISION_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_PROVISION_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_ML_APIS_PROVISION_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_PUBSUB_PROVISION_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_SPANNER_PROVISION_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_STORAGE_PROVISION_DEFAULTS",
-	}
-
-	return deleteMigration("Delete provision defaults from 4.x", keys)
-}
-
-// DeleteBindDefaultKeys removes the bind default keys.
-func DeleteBindDefaultKeys() Migration {
-	keys := []string{
-		"GSB_SERVICE_GOOGLE_BIGQUERY_BIND_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_BIGTABLE_BIND_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_MYSQL_BIND_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_CLOUDSQL_POSTGRES_BIND_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_ML_APIS_BIND_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_PUBSUB_BIND_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_SPANNER_BIND_DEFAULTS",
-		"GSB_SERVICE_GOOGLE_STORAGE_BIND_DEFAULTS",
-	}
-
-	return deleteMigration("Delete bind defaults from 4.x", keys)
-}
-
-func customPlanKeys() []string {
-	return []string{
-		"BIGQUERY_CUSTOM_PLANS",
-		"BIGTABLE_CUSTOM_PLANS",
-		"CLOUDSQL_MYSQL_CUSTOM_PLANS",
-		"CLOUDSQL_POSTGRES_CUSTOM_PLANS",
-		"ML_APIS_CUSTOM_PLANS",
-		"PUBSUB_CUSTOM_PLANS",
-		"SPANNER_CUSTOM_PLANS",
-		"STORAGE_CUSTOM_PLANS",
-	}
-}
-
-// DeleteCustomPlanKeys removes the custom plan keys.
-func DeleteCustomPlanKeys() Migration {
-	return deleteMigration("Delete custom plans from 4.x", customPlanKeys())
-}
-
-func CollapseCustomPlans() Migration {
-	jst := JsTransform{
-		EnvironmentVariables: customPlanKeys(),
-		MigrationJs: `
-		function replaceCustomPlans(planList) {
-			// if this is already JSON rather than a tile custom format
-			// just return it
-			if (typeof(planList) === "string") {
-				return planList;
-			}
-
-		  var out = [];
-		  for (var i in planList) {
-		    var plan = planList[i];
-		    var converted = {}
-		    for (var k in plan) {
-		      converted[k] = plan[k].value
-		    }
-
-		    out.push(converted);
-		  }
-
-			return JSON.stringify(out);
-		}`,
-		TransformFuncName: "replaceCustomPlans",
-	}
-
-	return Migration{
-		Name:       "Collapse custom plans",
-		TileScript: jst.ToJs(),
-		GoFunc: func(env map[string]string) {
-			if err := jst.RunGo(env); err != nil {
-				log.Fatal(err)
-			}
-		},
-	}
-}
-
-func FormatCustomPlans() Migration {
-	jst := JsTransform{
-		EnvironmentVariables: customPlanKeys(),
-		MigrationJs: `
-		function formatPlans(plansListJson) {
-			var planList = JSON.parse(plansListJson);
-
-			var out = [];
-			for (var i in planList) {
-				var plan = planList[i];
-				var converted = {};
-				var properties = {};
-				for (var k in plan) {
-					var value = plan[k];
-					if (k === 'service') { continue; } // skip service key, it's no longer needed
-
-					if(["guid", "description", "name", "display_name"].indexOf(k) >= 0) {
-						converted[k] = value
-					} else {
-						properties[k] = value;
-					}
-				}
-				converted.properties = properties;
-
-				out.push(converted);
-			}
-
-			return JSON.stringify(out);
-		}`,
-		TransformFuncName: "formatPlans",
-	}
-
-	return Migration{
-		Name:       "Format custom plans",
-		TileScript: jst.ToJs(),
-		GoFunc: func(env map[string]string) {
-			if err := jst.RunGo(env); err != nil {
-				log.Fatal(err)
-			}
-		},
-	}
-}
-
-func MergeServices() Migration {
-	jst := JsTransform{
-		EnvironmentVariables: customPlanKeys(),
-		MigrationJs: `
-		function mergeServices(v, context) {
-			var out = {};
-			for (var key in context) {
-				var value = context[key];
-				if (value != null) {
-					out[key] = JSON.parse(context[key]);
-				}
-			}
-
-			return JSON.stringify(out, null, "  ");
-		}`,
-		TransformFuncName: "mergeServices",
-		Context: func(envVar string) map[string]string {
-			svcName := strings.TrimSuffix(envVar, "_CUSTOM_PLANS")
-
-			return map[string]string{
-				"custom_plans":       envVar,
-				"enabled":            fmt.Sprintf("GSB_SERVICE_GOOGLE_%s_ENABLED", svcName),
-				"bind_defaults":      fmt.Sprintf("GSB_SERVICE_GOOGLE_%s_BIND_DEFAULTS", svcName),
-				"provision_defaults": fmt.Sprintf("GSB_SERVICE_GOOGLE_%s_PROVISION_DEFAULTS", svcName),
-			}
-		},
-	}
-
-	return Migration{
-		Name:       "Merge Services",
-		TileScript: jst.ToJs(),
-		GoFunc: func(env map[string]string) {
-			if err := jst.RunGo(env); err != nil {
-				log.Fatal(err)
-			}
-		},
-	}
-}
-
-func MergeToServiceConfig() Migration {
-	jst := JsTransform{
-		EnvironmentVariables: []string{"GSB_SERVICE_CONFIG"},
-		CreateIfNotExists:    true,
-		MigrationJs: `
-		function mergeServices(v, context) {
-			var out = {};
-			for (var key in context) {
-				var value = context[key];
-				if (value != null) {
-					out[key] = JSON.parse(context[key]);
-				}
-			}
-
-			return JSON.stringify(out, null, "  ");
-		}`,
-		TransformFuncName: "mergeServices",
-		Context: func(envVar string) map[string]string {
-			return map[string]string{
-				"f80c0a3e-bd4d-4809-a900-b4e33a6450f1": "BIGQUERY_CUSTOM_PLANS",
-				"b8e19880-ac58-42ef-b033-f7cd9c94d1fe": "BIGTABLE_CUSTOM_PLANS",
-				"4bc59b9a-8520-409f-85da-1c7552315863": "CLOUDSQL_MYSQL_CUSTOM_PLANS",
-				"cbad6d78-a73c-432d-b8ff-b219a17a803a": "CLOUDSQL_POSTGRES_CUSTOM_PLANS",
-				"3e897eb3-9062-4966-bd4f-85bda0f73b3d": "DATAFLOW_CUSTOM_PLANS",
-				"76d4abb2-fee7-4c8f-aee1-bcea2837f02b": "DATASTORE_CUSTOM_PLANS",
-				"e84b69db-3de9-4688-8f5c-26b9d5b1f129": "DIALOGFLOW_CUSTOM_PLANS",
-				"a2b7b873-1e34-4530-8a42-902ff7d66b43": "FIRESTORE_CUSTOM_PLANS",
-				"5ad2dce0-51f7-4ede-8b46-293d6df1e8d4": "ML_APIS_CUSTOM_PLANS",
-				"628629e3-79f5-4255-b981-d14c6c7856be": "PUBSUB_CUSTOM_PLANS",
-				"51b3e27e-d323-49ce-8c5f-1211e6409e82": "SPANNER_CUSTOM_PLANS",
-				"83837945-1547-41e0-b661-ea31d76eed11": "STACKDRIVER_DEBUGGER_CUSTOM_PLANS",
-				"2bc0d9ed-3f68-4056-b842-4a85cfbc727f": "STACKDRIVER_MONITORING_CUSTOM_PLANS",
-				"00b9ca4a-7cd6-406a-a5b7-2f43f41ade75": "STACKDRIVER_PROFILER_CUSTOM_PLANS",
-				"c5ddfe15-24d9-47f8-8ffe-f6b7daa9cf4a": "STACKDRIVER_TRACE_CUSTOM_PLANS",
-				"b9e4332e-b42b-4680-bda5-ea1506797474": "STORAGE_CUSTOM_PLANS",
-			}
-		},
-	}
-
-	return Migration{
-		Name:       "Merge Service Config",
-		TileScript: jst.ToJs(),
-		GoFunc: func(env map[string]string) {
-			if _, ok := env["GSB_SERVICE_CONFIG"]; !ok {
-				env["GSB_SERVICE_CONFIG"] = ""
-			}
-
-			if err := jst.RunGo(env); err != nil {
-				log.Fatal(err)
-			}
+		GoFunc: func(envMap map[string]string) error {
+			return nil
 		},
 	}
 }
@@ -319,12 +65,7 @@ func migrations() []Migration {
 		DeleteWhitelistKeys(),
 		CollapseCustomPlans(),
 		FormatCustomPlans(),
-		MergeServices(),
 		MergeToServiceConfig(),
-		DeleteProvisionDefaultKeys(),
-		DeleteBindDefaultKeys(),
-		DeleteCustomPlanKeys(),
-		DeleteEnabledKeys(),
 	}
 }
 
@@ -343,23 +84,29 @@ func FullMigration() Migration {
 	return Migration{
 		Name:       "Full Migration",
 		TileScript: string(buf.Bytes()),
-		GoFunc: func(env map[string]string) {
+		GoFunc: func(env map[string]string) error {
 			for _, migration := range migrations {
-				migration.GoFunc(env)
+				if err := migration.GoFunc(env); err != nil {
+					return err
+				}
 			}
+
+			return nil
 		},
 	}
 }
 
 // MigrateEnv migrates the currently set environment variables and returns
 // the diff.
-func MigrateEnv() map[string]Diff {
+func MigrateEnv() (map[string]Diff, error) {
 	env := splitEnv()
 	orig := utils.CopyStringMap(env)
 
-	FullMigration().GoFunc(env)
+	if err := FullMigration().GoFunc(env); err != nil {
+		return nil, err
+	}
 
-	return DiffStringMap(orig, env)
+	return DiffStringMap(orig, env), nil
 }
 
 // splitEnv splits os.Environ style environment variables that

--- a/pkg/config/migration/migration_test.go
+++ b/pkg/config/migration/migration_test.go
@@ -109,6 +109,7 @@ type MigrationTest struct {
 }
 
 func (m *MigrationTest) Run(t *testing.T) {
+	t.Helper()
 	t.Log("Running JS migration function")
 	m.runJs(t)
 
@@ -117,6 +118,7 @@ func (m *MigrationTest) Run(t *testing.T) {
 }
 
 func (m *MigrationTest) runJs(t *testing.T) {
+	t.Helper()
 	out := GetMigrationResults(t, m.TileProperties, m.Migration.TileScript)
 
 	if !reflect.DeepEqual(out, m.ExpectedEnv) {
@@ -125,6 +127,7 @@ func (m *MigrationTest) runJs(t *testing.T) {
 }
 
 func (m *MigrationTest) runGo(t *testing.T) {
+	t.Helper()
 	// runGo runs a no-op JS migration to get the environment variables as the
 	// application would see them, then applies the go migration function to
 	// ensure it produces the same result for people migrating by hand as the
@@ -318,7 +321,7 @@ func TestFullMigration(t *testing.T) {
           "properties": {}
         }`,
 			Migration:   FullMigration(),
-			ExpectedEnv: map[string]string{},
+			ExpectedEnv: map[string]string{"GSB_SERVICE_CONFIG": "{}"},
 		},
 	}
 

--- a/pkg/config/migration/migration_test.go
+++ b/pkg/config/migration/migration_test.go
@@ -117,8 +117,8 @@ func (m *MigrationTest) Run(t *testing.T) {
 
 	t.Log("Running JS migration function")
 	out := GetMigrationResults(t, m.TileProperties, m.Migration.TileScript)
-	normalizeJson(t, out)
-	normalizeJson(t, m.ExpectedEnv)
+	normalizeJSON(t, out)
+	normalizeJSON(t, m.ExpectedEnv)
 
 	if !reflect.DeepEqual(out, m.ExpectedEnv) {
 		t.Logf("Diff %#v", DiffStringMap(out, m.ExpectedEnv))
@@ -135,15 +135,15 @@ func (m *MigrationTest) Run(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	normalizeJson(t, envFromTile)
-	normalizeJson(t, m.ExpectedEnv)
+	normalizeJSON(t, envFromTile)
+	normalizeJSON(t, m.ExpectedEnv)
 
 	if !reflect.DeepEqual(envFromTile, m.ExpectedEnv) {
 		t.Fatalf("Expected: %#v Got: %#v", m.ExpectedEnv, envFromTile)
 	}
 }
 
-func normalizeJson(t *testing.T, env map[string]string) {
+func normalizeJSON(t *testing.T, env map[string]string) {
 	for k, v := range env {
 		if !json.Valid([]byte(v)) {
 			continue


### PR DESCRIPTION
This includes code for the 4 to 5 tile and CLI migrations. As-of v5.0 all configuration for a service will be consolidated to a single environment variable `GSB_SERVICE_CONFIG`.

This variable is a map of service GUID -> service configurations. Each service configuration has a comment, a disabled flag, a list of custom plans, and provision and bind defaults. In total, this consolidates seven forms down to one.

The tile migration takes the following route:

* Whitelist keys are deleted because they're no longer used/supported.
* Custom plans get "collapsed" from something the tile uses internally into a flat JSON map of key->values like what happens when Opsman turns the tile into environment variables.
* Custom plans get formatted, meaning custom properties are put into a format that can be read into a struct without using custom logic in the broker.
* All services with any defined properties get merged into the new config.

What's included:

* A lot of JavaScript.
* A lot of tests.

What's not included:

* The new form field in the tile or documentation for it.