### PR TITLE
Brokerpak Quality of Life Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - The format of the `/docs` endpoint is now nicely styled with Bootstrap 4.
  - Cleaned up the customization documentation.
  - Merged the environment variables `GSB_SERVICE_*_ENABLED`, `GSB_SERVICE_*_WHITELIST`, `GSB_SERVICE_*_PROVISION_DEFAULTS`, `GSB_SERVICE_*_BIND_DEFAULTS` and `*_CUSTOM_PLANS` into `GSB_SERVICE_CONFIG`.
+ - Built Brokerpaks now have a name of `{name}-{version}.brokerpak` as defined by the manifest rather than the name of the parent directory.
+ - Services inside Brokerpaks now have a file name that includes their CLI friendly name to help differentiate them.
+ - The `pak build` command now includes progress logs.
 
 ## [4.2.2] - 2019-02-06
 

--- a/pkg/brokerpak/cmd.go
+++ b/pkg/brokerpak/cmd.go
@@ -49,17 +49,13 @@ func Init(directory string) error {
 // manifest.yml file. If the pack was successful, the returned string will be
 // the path to the created brokerpak.
 func Pack(directory string) (string, error) {
-	abs, err := filepath.Abs(directory)
-	if err != nil {
-		return "", err
-	}
 	manifestPath := filepath.Join(directory, manifestName)
 	manifest := &Manifest{}
 	if err := stream.Copy(stream.FromFile(manifestPath), stream.ToYaml(manifest)); err != nil {
 		return "", err
 	}
 
-	packname := filepath.Base(abs) + ".brokerpak"
+	packname := fmt.Sprintf("%s-%s.brokerpak", manifest.Name, manifest.Version)
 	return packname, manifest.Pack(directory, packname)
 }
 


### PR DESCRIPTION
Fixes #430, #431

Pleasantly surprising, the existing test cases didn't need to be updated because they actually respected return values rather than hard-coding.

 - Built Brokerpaks now have a name of `{name}-{version}.brokerpak` as defined by the manifest rather than the name of the parent directory.
 - Services inside Brokerpaks now have a file name that includes their CLI friendly name to help differentiate them.
 - The `pak build` command now includes progress logs.
