### PR TITLE
Create /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o /bin/gcp-service-broker
 
+# Get latest CA certs
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
 # Create the final image
 FROM scratch
 
@@ -27,6 +31,8 @@ FROM scratch
 # This is a way to do it with only builtin Docker commands.
 WORKDIR /tmp
 WORKDIR /
+
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY --from=build /go/src/github.com/GoogleCloudPlatform/gcp-service-broker /src
 COPY --from=build /bin/gcp-service-broker /bin/gcp-service-broker

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,16 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Build the service broker
 FROM golang:1.11-alpine AS build
 
 WORKDIR /go/src/github.com/GoogleCloudPlatform/gcp-service-broker
@@ -19,7 +20,14 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o /bin/gcp-service-broker
 
+# Create the final image
 FROM scratch
+
+# We MUST create a /tmp directory for brokerpaks to be built with the image.
+# This is a way to do it with only builtin Docker commands.
+WORKDIR /tmp
+WORKDIR /
+
 COPY --from=build /go/src/github.com/GoogleCloudPlatform/gcp-service-broker /src
 COPY --from=build /bin/gcp-service-broker /bin/gcp-service-broker
 


### PR DESCRIPTION
Create the /tmp directory in the dockerfile. This _should_ let us use the released image as CI/CD. Releated to: #440 