### PR TITLE
added ability to get plan info from bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - A new sub-command for generating service configuration documentation.
  - Documentation about installing Brokerpaks.
  - A new web-endpoint `/service-config` that hosts service configuration info.
+ - Ability to get plan information from HIL execution environment on bind.
 
 ### Changed
  - The format of the `/docs` endpoint is now nicely styled with Bootstrap 4.

--- a/brokerapi/brokers/gcp_service_broker.go
+++ b/brokerapi/brokers/gcp_service_broker.go
@@ -241,6 +241,12 @@ func (gcpBroker *GCPServiceBroker) Bind(ctx context.Context, instanceID, binding
 		return brokerapi.Binding{}, err
 	}
 
+	// verify the service exists and the plan exists
+	plan, err := serviceDefinition.GetPlanById(details.PlanID)
+	if err != nil {
+		return brokerapi.Binding{}, err
+	}
+
 	// Give the user a better error message if they give us a bad request
 	if !isValidOrEmptyJSON(details.GetRawParameters()) {
 		return brokerapi.Binding{}, ErrInvalidUserInput
@@ -248,7 +254,7 @@ func (gcpBroker *GCPServiceBroker) Bind(ctx context.Context, instanceID, binding
 
 	// validate parameters meet the service's schema and merge the plan's vars with
 	// the user's
-	vars, err := serviceDefinition.BindVariables(*instanceRecord, bindingID, details)
+	vars, err := serviceDefinition.BindVariables(*instanceRecord, bindingID, details, plan)
 	if err != nil {
 		return brokerapi.Binding{}, err
 	}

--- a/docs/brokerpak-specification.md
+++ b/docs/brokerpak-specification.md
@@ -333,6 +333,7 @@ This is because they can resolve variables to the user's values first.
 * `request.service_id` - _string_ The GUID of the service this binding is for.
 * `request.plan_id` - _string_ The ID of plan the instance was created with.
 * `request.app_guid` - _string_ The ID of the application this binding is for.
+* `request.plan_properties` - _map[string]string_ A map of properties set in the service's plan.
 * `instance.name` - _string_ The name of the instance.
 * `instance.details` - _map[string]any_ Output variables of the instance as specified by ProvisionOutputVariables.
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -353,7 +353,15 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 		Id:   "00000000-0000-0000-0000-000000000000",
 		Name: "left-handed-smoke-sifter",
 		Plans: []ServicePlan{
-			{ServicePlan: brokerapi.ServicePlan{ID: "builtin-plan", Name: "Builtin!"}},
+			{
+				ServicePlan: brokerapi.ServicePlan{
+					ID:   "builtin-plan",
+					Name: "Builtin!",
+				},
+				ServiceProperties: map[string]string{
+					"service-property": "operator-set",
+				},
+			},
 		},
 		BindInputVariables: []BrokerVariable{
 			{
@@ -381,6 +389,11 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				Default:   `${instance.details["foo"]}`,
 				Overwrite: true,
 			},
+			{
+				Name:      "service-prop",
+				Default:   `${request.plan_properties["service-property"]}`,
+				Overwrite: true,
+			},
 		},
 	}
 
@@ -398,6 +411,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "us",
 				"name":         "name-us",
 				"instance-foo": "",
+				"service-prop": "operator-set",
 			},
 		},
 		"location gets truncated": {
@@ -407,6 +421,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "averylongl",
 				"name":         "name-averylonglocation",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"user location and name": {
@@ -416,6 +431,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "eu",
 				"name":         "foo",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"operator defaults override computed defaults": {
@@ -426,6 +442,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "eu",
 				"name":         "name-eu",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"user values override operator defaults": {
@@ -436,6 +453,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "nz",
 				"name":         "name-nz",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"operator defaults are not evaluated": {
@@ -446,6 +464,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "us",
 				"name":         "foo-${location}",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"instance info can get parsed": {
@@ -455,6 +474,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "us",
 				"name":         "name-us",
 				"instance-foo": "bar",
+				"service-prop": "operator-set",
 			},
 		},
 		"invalid-request": {
@@ -473,7 +493,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 
 			details := brokerapi.BindDetails{RawParameters: json.RawMessage(tc.UserParams)}
 			instance := models.ServiceInstanceDetails{OtherDetails: tc.InstanceVars}
-			vars, err := service.BindVariables(instance, "binding-id-here", details)
+			vars, err := service.BindVariables(instance, "binding-id-here", details, &service.Plans[0])
 
 			expectError(t, tc.ExpectedError, err)
 

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -233,7 +233,7 @@ func (svc *ServiceDefinition) ProvisionVariables(instanceId string, details brok
 // 4. Operator default variables loaded from the environment.
 // 5. Default variables (in `bind_input_variables`).
 //
-func (svc *ServiceDefinition) BindVariables(instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails) (*varcontext.VarContext, error) {
+func (svc *ServiceDefinition) BindVariables(instance models.ServiceInstanceDetails, bindingID string, details brokerapi.BindDetails, plan *ServicePlan) (*varcontext.VarContext, error) {
 	otherDetails := make(map[string]interface{})
 	if err := instance.GetOtherDetails(&otherDetails); err != nil {
 		return nil, err
@@ -254,9 +254,10 @@ func (svc *ServiceDefinition) BindVariables(instance models.ServiceInstanceDetai
 		// Note: the value in instance is considered the official record so values
 		// are pulled from there rather than the request. In a future version of OSB
 		// the duplicate sending of fields is likely to be removed.
-		"request.plan_id":    instance.PlanId,
-		"request.service_id": instance.ServiceId,
-		"request.app_guid":   appGuid,
+		"request.plan_id":         instance.PlanId,
+		"request.service_id":      instance.ServiceId,
+		"request.app_guid":        appGuid,
+		"request.plan_properties": plan.GetServiceProperties(),
 
 		// specified by the existing instance
 		"instance.name":    instance.Name,

--- a/pkg/providers/tf/definition.go
+++ b/pkg/providers/tf/definition.go
@@ -177,6 +177,27 @@ func (tfb *TfServiceDefinitionV1) ToService(executor wrapper.TerraformExecutor) 
 		rawPlans = append(rawPlans, plan.ToPlan())
 	}
 
+	// Bindings get special computed properties because the broker didn't
+	// originally support injecting plan variables into a binding
+	// to fix that, we auto-inject the properties from the plan to make it look
+	// like they were to the TF template.
+	bindComputed := []varcontext.DefaultVariable{}
+	for _, pi := range tfb.BindSettings.PlanInputs {
+		bindComputed = append(bindComputed, varcontext.DefaultVariable{
+			Name:      pi.FieldName,
+			Default:   fmt.Sprintf("${request.plan_properties[%q]}", pi.FieldName),
+			Overwrite: true,
+			Type:      string(pi.Type),
+		})
+	}
+
+	bindComputed = append(bindComputed, tfb.BindSettings.Computed...)
+	bindComputed = append(bindComputed, varcontext.DefaultVariable{
+		Name:      "tf_id",
+		Default:   "tf:${request.instance_id}:${request.binding_id}",
+		Overwrite: true,
+	})
+
 	constDefn := *tfb
 	return &broker.ServiceDefinition{
 		Id:               tfb.Id,
@@ -197,15 +218,11 @@ func (tfb *TfServiceDefinitionV1) ToService(executor wrapper.TerraformExecutor) 
 			Default:   "tf:${request.instance_id}:",
 			Overwrite: true,
 		}),
-		BindInputVariables: tfb.BindSettings.UserInputs,
-		BindComputedVariables: append(tfb.BindSettings.Computed, varcontext.DefaultVariable{
-			Name:      "tf_id",
-			Default:   "tf:${request.instance_id}:${request.binding_id}",
-			Overwrite: true,
-		}),
-		BindOutputVariables: append(tfb.ProvisionSettings.Outputs, tfb.BindSettings.Outputs...),
-		PlanVariables:       append(tfb.ProvisionSettings.PlanInputs, tfb.BindSettings.PlanInputs...),
-		Examples:            tfb.Examples,
+		BindInputVariables:    tfb.BindSettings.UserInputs,
+		BindComputedVariables: bindComputed,
+		BindOutputVariables:   append(tfb.ProvisionSettings.Outputs, tfb.BindSettings.Outputs...),
+		PlanVariables:         append(tfb.ProvisionSettings.PlanInputs, tfb.BindSettings.PlanInputs...),
+		Examples:              tfb.Examples,
 		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
 			jobRunner := NewTfJobRunnerForProject(projectId)
 			jobRunner.Executor = executor
@@ -244,7 +261,8 @@ func NewExampleTfServiceDefinition() TfServiceDefinitionV1 {
 				Bullets:     []string{"information point 1", "information point 2", "some caveat here"},
 				Free:        false,
 				Properties: map[string]string{
-					"domain": "example.com",
+					"domain":                 "example.com",
+					"password_special_chars": `@/ \"?`,
 				},
 			},
 		},
@@ -281,17 +299,30 @@ func NewExampleTfServiceDefinition() TfServiceDefinitionV1 {
 			},
 		},
 		BindSettings: TfServiceDefinitionV1Action{
+			PlanInputs: []broker.BrokerVariable{
+				{
+					FieldName: "password_special_chars",
+					Type:      broker.JsonTypeString,
+					Details:   "Supply your own list of special characters to use for string generation.",
+					Required:  true,
+				},
+			},
 			Computed: []varcontext.DefaultVariable{
+				{Name: "domain", Default: `${request.plan_properties["domain"]}`, Overwrite: true},
 				{Name: "address", Default: `${instance.details["email"]}`, Overwrite: true},
 			},
 			Template: `
+			variable domain {type = "string"}
+			variable address {type = "string"}
+			variable password_special_chars {type = "string"}
+
 			resource "random_string" "password" {
 			  length = 16
 			  special = true
-			  override_special = "/@\" "
+			  override_special = "${var.password_special_chars}"
 			}
 
-			output uri {value = "smtp://${var.address}:${random_string.password.result}@smtp.mycompany.com"}
+			output uri {value = "smtp://${var.address}:${random_string.password.result}@smtp.${var.domain}"}
 			`,
 			Outputs: []broker.BrokerVariable{
 				{


### PR DESCRIPTION
Adds the ability to get values from the plan at binding time. This is going to be used by certain plugins that have noop provisions but do have bindings that need to be configured by operators. The motivating example is IAM, operators should be able to create custom plans that users can use to bind service accounts with various roles but provisioning is undefined on them.

This has three parts:

1. Add plan info to be available under the `request.plan_properties` variable in HIL.
2. Change the Brokerpak loader's definition to work with these variables if they're declared under the BindSettings YAML section via a shim. Previously, no service had needed this so they weren't included as part of the variable resolution lifecycle.
3. Update the tests for these and write a new test for the ToService call which wasn't tested before outside of e2e tests.