### PR TITLE
add ability for operators to override user variables in plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Documentation about installing Brokerpaks.
  - A new web-endpoint `/service-config` that hosts service configuration info.
  - Ability to get plan information from HIL execution environment on bind.
+ - Ability for plans to selectively override user variables.
 
 ### Changed
  - The format of the `/docs` endpoint is now nicely styled with Bootstrap 4.

--- a/docs/brokerpak-specification.md
+++ b/docs/brokerpak-specification.md
@@ -307,8 +307,9 @@ The broker makes additional variables available to be used during provision and 
 The variables fed into your Terraform services file are resolved in the following order:
 
 * Variables defined in your `computed_variables` JSON list.
-* (Only for Provision) Variables defined by the selected service plan in its `service_properties` map.
-* User defined variables (in `provision_input_variables` or `bind_input_variables`)
+* Variables defined by the selected service plan in its `service_properties` map.
+* Variables overridden by the plan (in `provision_overrides` or `bind_overrides`).
+* User defined variables (in `provision_input_variables` or `bind_input_variables`).
 * Operator default variables loaded from the environment.
 * Default variables (in `provision_input_variables` or `bind_input_variables`).
 

--- a/docs/service-config.md
+++ b/docs/service-config.md
@@ -28,7 +28,7 @@ Example:
 | Property | Type | Description |
 |----------|------|-------------|
 | <tt>guid</tt> \* | string | A GUID for this plan, must be unique. Changing this value after services are using it WILL BREAK your instances. |
-| <tt>name</tt> \* | string | A CLI friendly name for this plan. This can be changed without affecting existing instances, but may break scripts you build referencing it. |
+| <tt>name</tt> \* | string | A CLI friendly name for this plan. This can be changed without affecting existing instances, but may break scripts you've previously built referencing it. |
 | <tt>display_name</tt> \* | string | A human readable name for this plan, this can be changed. |
 | <tt>description</tt> \* | string | A human readable description for this plan, this can be changed. |
 | <tt>properties</tt> \* | string:string map | Properties used to configure the plan. Each service has its own set of properties used to customize it. |
@@ -119,6 +119,12 @@ Configuration needs to be done under the GUID: <tt>b8e19880-ac58-42ef-b033-f7cd9
 	        "description": "What makes this plan different?",
 	        "properties": {
 	          "//": "See the custom plan properties section below for configurable properties."
+	        },
+	        "provision_overrides": {
+	          "//": "You can override any user-settable provision variable here."
+	        },
+	        "bind_overrides": {
+	          "//": "You can override any user-settable bind variable here."
 	        }
 	      }
 	    ]
@@ -192,6 +198,12 @@ Configuration needs to be done under the GUID: <tt>4bc59b9a-8520-409f-85da-1c755
 	        "description": "What makes this plan different?",
 	        "properties": {
 	          "//": "See the custom plan properties section below for configurable properties."
+	        },
+	        "provision_overrides": {
+	          "//": "You can override any user-settable provision variable here."
+	        },
+	        "bind_overrides": {
+	          "//": "You can override any user-settable bind variable here."
 	        }
 	      }
 	    ]
@@ -282,6 +294,12 @@ Configuration needs to be done under the GUID: <tt>cbad6d78-a73c-432d-b8ff-b219a
 	        "description": "What makes this plan different?",
 	        "properties": {
 	          "//": "See the custom plan properties section below for configurable properties."
+	        },
+	        "provision_overrides": {
+	          "//": "You can override any user-settable provision variable here."
+	        },
+	        "bind_overrides": {
+	          "//": "You can override any user-settable bind variable here."
 	        }
 	      }
 	    ]
@@ -676,6 +694,12 @@ Configuration needs to be done under the GUID: <tt>51b3e27e-d323-49ce-8c5f-1211e
 	        "description": "What makes this plan different?",
 	        "properties": {
 	          "//": "See the custom plan properties section below for configurable properties."
+	        },
+	        "provision_overrides": {
+	          "//": "You can override any user-settable provision variable here."
+	        },
+	        "bind_overrides": {
+	          "//": "You can override any user-settable bind variable here."
 	        }
 	      }
 	    ]
@@ -931,6 +955,12 @@ Configuration needs to be done under the GUID: <tt>b9e4332e-b42b-4680-bda5-ea150
 	        "description": "What makes this plan different?",
 	        "properties": {
 	          "//": "See the custom plan properties section below for configurable properties."
+	        },
+	        "provision_overrides": {
+	          "//": "You can override any user-settable provision variable here."
+	        },
+	        "bind_overrides": {
+	          "//": "You can override any user-settable bind variable here."
 	        }
 	      }
 	    ]

--- a/docs/use.md
+++ b/docs/use.md
@@ -57,7 +57,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: BigQuery default plan. Plan ID: `10ff4e72-6e84-44eb-851f-bdb38a791914`.
+* **`default`**
+  * Plan ID: `10ff4e72-6e84-44eb-851f-bdb38a791914`.
+  * Description: BigQuery default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -165,8 +169,16 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **three-node-production-hdd**: BigTable HDD basic production plan: Approx: Reads: 1,500 QPS @ 200ms or Writes: 30,000 QPS @ 50ms or Scans: 540 MB/s, 24TB storage. Plan ID: `65a49268-2c73-481e-80f3-9fde5bd5a654`.
-  * **three-node-production-ssd**: BigTable SSD basic production plan: Approx: Reads: 30,000 QPS @ 6ms or Writes: 30,000 QPS @ 6ms or Scans: 660 MB/s, 7.5TB storage. Plan ID: `38aa0e65-624b-4998-9c06-f9194b56d252`.
+* **`three-node-production-hdd`**
+  * Plan ID: `65a49268-2c73-481e-80f3-9fde5bd5a654`.
+  * Description: BigTable HDD basic production plan: Approx: Reads: 1,500 QPS @ 200ms or Writes: 30,000 QPS @ 50ms or Scans: 540 MB/s, 24TB storage.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`three-node-production-ssd`**
+  * Plan ID: `38aa0e65-624b-4998-9c06-f9194b56d252`.
+  * Description: BigTable SSD basic production plan: Approx: Reads: 30,000 QPS @ 6ms or Writes: 30,000 QPS @ 6ms or Scans: 660 MB/s, 7.5TB storage.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -327,21 +339,81 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **mysql-db-f1-micro**: MySQL on a db-f1-micro (Shared CPUs, 0.6 GB/RAM, 3062 GB/disk, 250 Connections) Plan ID: `7d8f9ade-30c1-4c96-b622-ea0205cc5f0b`.
-  * **mysql-db-g1-small**: MySQL on a db-g1-small (Shared CPUs, 1.7 GB/RAM, 3062 GB/disk, 1,000 Connections) Plan ID: `b68bf4d8-1636-4121-af2f-087e46189929`.
-  * **mysql-db-n1-standard-1**: MySQL on a db-n1-standard-1 (1 CPUs, 3.75 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `bdfd8033-c2b9-46e9-9b37-1f3a5889eef4`.
-  * **mysql-db-n1-standard-2**: MySQL on a db-n1-standard-2 (2 CPUs, 7.5 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `2c99e938-4c1e-4da7-810a-94c9f5b71b57`.
-  * **mysql-db-n1-standard-4**: MySQL on a db-n1-standard-4 (4 CPUs, 15 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `d520a5f5-7485-4a83-849b-5439f911fe26`.
-  * **mysql-db-n1-standard-8**: MySQL on a db-n1-standard-8 (8 CPUs, 30 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `7ef42bb4-87e3-4ead-8118-4e88c98ed2e6`.
-  * **mysql-db-n1-standard-16**: MySQL on a db-n1-standard-16 (16 CPUs, 60 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `200bd90a-4323-46d8-8aa5-afd4601498d0`.
-  * **mysql-db-n1-standard-32**: MySQL on a db-n1-standard-32 (32 CPUs, 120 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `52305df2-1e64-4cdb-a4c9-bb5dddb33c3e`.
-  * **mysql-db-n1-standard-64**: MySQL on a db-n1-standard-64 (64 CPUs, 240 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `e45d7c44-4990-4dac-a14d-c5127e9ae0c5`.
-  * **mysql-db-n1-highmem-2**: MySQL on a db-n1-highmem-2 (2 CPUs, 13 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `07b8a04c-0efe-42d3-8b2c-2c23f7c79583`.
-  * **mysql-db-n1-highmem-4**: MySQL on a db-n1-highmem-4 (4 CPUs, 26 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `50fa4baa-e36f-41c3-bbe9-c986d9fbe3c8`.
-  * **mysql-db-n1-highmem-8**: MySQL on a db-n1-highmem-8 (8 CPUs, 52 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `6e8e5bc3-bf68-4e57-bda1-d9c9a67faee0`.
-  * **mysql-db-n1-highmem-16**: MySQL on a db-n1-highmem-16 (16 CPUs, 104 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `3c83ff6b-165e-47bf-9bba-f4801390d0ff`.
-  * **mysql-db-n1-highmem-32**: MySQL on a db-n1-highmem-32 (32 CPUs, 208 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `cbc6d376-8fd3-4a34-9ab5-324311f038f6`.
-  * **mysql-db-n1-highmem-64**: MySQL on a db-n1-highmem-64 (64 CPUs, 416 GB/RAM, 10230 GB/disk, 4,000 Connections) Plan ID: `b0742cc5-caba-4b8d-98e0-03380ae9522b`.
+* **`mysql-db-f1-micro`**
+  * Plan ID: `7d8f9ade-30c1-4c96-b622-ea0205cc5f0b`.
+  * Description: MySQL on a db-f1-micro (Shared CPUs, 0.6 GB/RAM, 3062 GB/disk, 250 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-g1-small`**
+  * Plan ID: `b68bf4d8-1636-4121-af2f-087e46189929`.
+  * Description: MySQL on a db-g1-small (Shared CPUs, 1.7 GB/RAM, 3062 GB/disk, 1,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-standard-1`**
+  * Plan ID: `bdfd8033-c2b9-46e9-9b37-1f3a5889eef4`.
+  * Description: MySQL on a db-n1-standard-1 (1 CPUs, 3.75 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-standard-2`**
+  * Plan ID: `2c99e938-4c1e-4da7-810a-94c9f5b71b57`.
+  * Description: MySQL on a db-n1-standard-2 (2 CPUs, 7.5 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-standard-4`**
+  * Plan ID: `d520a5f5-7485-4a83-849b-5439f911fe26`.
+  * Description: MySQL on a db-n1-standard-4 (4 CPUs, 15 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-standard-8`**
+  * Plan ID: `7ef42bb4-87e3-4ead-8118-4e88c98ed2e6`.
+  * Description: MySQL on a db-n1-standard-8 (8 CPUs, 30 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-standard-16`**
+  * Plan ID: `200bd90a-4323-46d8-8aa5-afd4601498d0`.
+  * Description: MySQL on a db-n1-standard-16 (16 CPUs, 60 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-standard-32`**
+  * Plan ID: `52305df2-1e64-4cdb-a4c9-bb5dddb33c3e`.
+  * Description: MySQL on a db-n1-standard-32 (32 CPUs, 120 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-standard-64`**
+  * Plan ID: `e45d7c44-4990-4dac-a14d-c5127e9ae0c5`.
+  * Description: MySQL on a db-n1-standard-64 (64 CPUs, 240 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-highmem-2`**
+  * Plan ID: `07b8a04c-0efe-42d3-8b2c-2c23f7c79583`.
+  * Description: MySQL on a db-n1-highmem-2 (2 CPUs, 13 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-highmem-4`**
+  * Plan ID: `50fa4baa-e36f-41c3-bbe9-c986d9fbe3c8`.
+  * Description: MySQL on a db-n1-highmem-4 (4 CPUs, 26 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-highmem-8`**
+  * Plan ID: `6e8e5bc3-bf68-4e57-bda1-d9c9a67faee0`.
+  * Description: MySQL on a db-n1-highmem-8 (8 CPUs, 52 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-highmem-16`**
+  * Plan ID: `3c83ff6b-165e-47bf-9bba-f4801390d0ff`.
+  * Description: MySQL on a db-n1-highmem-16 (16 CPUs, 104 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-highmem-32`**
+  * Plan ID: `cbc6d376-8fd3-4a34-9ab5-324311f038f6`.
+  * Description: MySQL on a db-n1-highmem-32 (32 CPUs, 208 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`mysql-db-n1-highmem-64`**
+  * Plan ID: `b0742cc5-caba-4b8d-98e0-03380ae9522b`.
+  * Description: MySQL on a db-n1-highmem-64 (64 CPUs, 416 GB/RAM, 10230 GB/disk, 4,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -504,21 +576,81 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **postgres-db-f1-micro**: PostgreSQL on a db-f1-micro (Shared CPUs, 0.6 GB/RAM, 3062 GB/disk, 250 Connections) Plan ID: `2513d4d9-684b-4c3c-add4-6404969006de`.
-  * **postgres-db-g1-small**: PostgreSQL on a db-g1-small (Shared CPUs, 1.7 GB/RAM, 3062 GB/disk, 1,000 Connections) Plan ID: `6c1174d8-243c-44d1-b7a8-e94a779f67f5`.
-  * **postgres-db-n1-standard-1**: PostgreSQL with 1 CPU, 3.75 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `c4e68ab5-34ca-4d02-857d-3e6b3ab079a7`.
-  * **postgres-db-n1-standard-2**: PostgreSQL with 2 CPUs, 7.5 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `3f578ecf-885c-4b60-b38b-60272f34e00f`.
-  * **postgres-db-n1-standard-4**: PostgreSQL with 4 CPUs, 15 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `b7fcab5d-d66d-4e82-af16-565e84cef7f9`.
-  * **postgres-db-n1-standard-8**: PostgreSQL with 8 CPUs, 30 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `4b2fa14a-caf1-42e0-bd8c-3342502008a8`.
-  * **postgres-db-n1-standard-16**: PostgreSQL with 16 CPUs, 60 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `ca2e770f-bfa5-4fb7-a249-8b943c3474ca`.
-  * **postgres-db-n1-standard-32**: PostgreSQL with 32 CPUs, 120 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `b44f8294-b003-4a50-80c2-706858073f44`.
-  * **postgres-db-n1-standard-64**: PostgreSQL with 64 CPUs, 240 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `d97326e0-5af2-4da5-b970-b4772d59cded`.
-  * **postgres-db-n1-highmem-2**: PostgreSQL with 2 CPUs, 13 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `c10f8691-02f5-44eb-989f-7217393012ca`.
-  * **postgres-db-n1-highmem-4**: PostgreSQL with 4 CPUs, 26 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `610cc78d-d26a-41a9-90b7-547a44517f03`.
-  * **postgres-db-n1-highmem-8**: PostgreSQL with 8 CPUs, 52 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `2a351e8d-958d-4c4f-ae46-c984fec18740`.
-  * **postgres-db-n1-highmem-16**: PostgreSQL with 16 CPUs, 104 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `51d3ca0c-9d21-447d-a395-3e0dc0659775`.
-  * **postgres-db-n1-highmem-32**: PostgreSQL with 32 CPUs, 208 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `2e72b386-f7ce-4f0d-a149-9f9a851337d4`.
-  * **postgres-db-n1-highmem-64**: PostgreSQL with 64 CPUs, 416 GB/RAM, 10230 GB/disk, supporting 4,000 connections. Plan ID: `82602649-e4ac-4a2f-b80d-dacd745aed6a`.
+* **`postgres-db-f1-micro`**
+  * Plan ID: `2513d4d9-684b-4c3c-add4-6404969006de`.
+  * Description: PostgreSQL on a db-f1-micro (Shared CPUs, 0.6 GB/RAM, 3062 GB/disk, 250 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-g1-small`**
+  * Plan ID: `6c1174d8-243c-44d1-b7a8-e94a779f67f5`.
+  * Description: PostgreSQL on a db-g1-small (Shared CPUs, 1.7 GB/RAM, 3062 GB/disk, 1,000 Connections)
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-standard-1`**
+  * Plan ID: `c4e68ab5-34ca-4d02-857d-3e6b3ab079a7`.
+  * Description: PostgreSQL with 1 CPU, 3.75 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-standard-2`**
+  * Plan ID: `3f578ecf-885c-4b60-b38b-60272f34e00f`.
+  * Description: PostgreSQL with 2 CPUs, 7.5 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-standard-4`**
+  * Plan ID: `b7fcab5d-d66d-4e82-af16-565e84cef7f9`.
+  * Description: PostgreSQL with 4 CPUs, 15 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-standard-8`**
+  * Plan ID: `4b2fa14a-caf1-42e0-bd8c-3342502008a8`.
+  * Description: PostgreSQL with 8 CPUs, 30 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-standard-16`**
+  * Plan ID: `ca2e770f-bfa5-4fb7-a249-8b943c3474ca`.
+  * Description: PostgreSQL with 16 CPUs, 60 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-standard-32`**
+  * Plan ID: `b44f8294-b003-4a50-80c2-706858073f44`.
+  * Description: PostgreSQL with 32 CPUs, 120 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-standard-64`**
+  * Plan ID: `d97326e0-5af2-4da5-b970-b4772d59cded`.
+  * Description: PostgreSQL with 64 CPUs, 240 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-highmem-2`**
+  * Plan ID: `c10f8691-02f5-44eb-989f-7217393012ca`.
+  * Description: PostgreSQL with 2 CPUs, 13 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-highmem-4`**
+  * Plan ID: `610cc78d-d26a-41a9-90b7-547a44517f03`.
+  * Description: PostgreSQL with 4 CPUs, 26 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-highmem-8`**
+  * Plan ID: `2a351e8d-958d-4c4f-ae46-c984fec18740`.
+  * Description: PostgreSQL with 8 CPUs, 52 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-highmem-16`**
+  * Plan ID: `51d3ca0c-9d21-447d-a395-3e0dc0659775`.
+  * Description: PostgreSQL with 16 CPUs, 104 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-highmem-32`**
+  * Plan ID: `2e72b386-f7ce-4f0d-a149-9f9a851337d4`.
+  * Description: PostgreSQL with 32 CPUs, 208 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`postgres-db-n1-highmem-64`**
+  * Plan ID: `82602649-e4ac-4a2f-b80d-dacd745aed6a`.
+  * Description: PostgreSQL with 64 CPUs, 416 GB/RAM, 10230 GB/disk, supporting 4,000 connections.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -642,7 +774,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: Dataflow default plan. Plan ID: `8e956dd6-8c0f-470c-9a11-065537d81872`.
+* **`default`**
+  * Plan ID: `8e956dd6-8c0f-470c-9a11-065537d81872`.
+  * Description: Dataflow default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -760,7 +896,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: Datastore default plan. Plan ID: `05f1fb6b-b5f0-48a2-9c2b-a5f236507a97`.
+* **`default`**
+  * Plan ID: `05f1fb6b-b5f0-48a2-9c2b-a5f236507a97`.
+  * Description: Datastore default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -872,7 +1012,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: Dialogflow default plan. Plan ID: `3ac4e1bd-b22d-4a99-864b-d3a3ac582348`.
+* **`default`**
+  * Plan ID: `3ac4e1bd-b22d-4a99-864b-d3a3ac582348`.
+  * Description: Dialogflow default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -958,7 +1102,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: Firestore default plan. Plan ID: `64403af0-4413-4ef3-a813-37f0306ef498`.
+* **`default`**
+  * Plan ID: `64403af0-4413-4ef3-a813-37f0306ef498`.
+  * Description: Firestore default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -1072,7 +1220,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: Machine Learning API default plan. Plan ID: `be7954e1-ecfb-4936-a0b6-db35e6424c7a`.
+* **`default`**
+  * Plan ID: `be7954e1-ecfb-4936-a0b6-db35e6424c7a`.
+  * Description: Machine Learning API default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -1180,7 +1332,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: PubSub Default plan. Plan ID: `622f4da3-8731-492a-af29-66a9146f8333`.
+* **`default`**
+  * Plan ID: `622f4da3-8731-492a-af29-66a9146f8333`.
+  * Description: PubSub Default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -1347,8 +1503,16 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **sandbox**: Useful for testing, not eligible for SLA. Plan ID: `44828436-cfbd-47ae-b4bc-48854564347b`.
-  * **minimal-production**: A minimal production level Spanner setup eligible for 99.99% SLA. Each node can provide up to 10,000 QPS of reads or 2,000 QPS of writes (writing single rows at 1KB data per row), and 2 TiB storage. Plan ID: `0752b1ad-a784-4dcc-96eb-64149089a1c9`.
+* **`sandbox`**
+  * Plan ID: `44828436-cfbd-47ae-b4bc-48854564347b`.
+  * Description: Useful for testing, not eligible for SLA.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`minimal-production`**
+  * Plan ID: `0752b1ad-a784-4dcc-96eb-64149089a1c9`.
+  * Description: A minimal production level Spanner setup eligible for 99.99% SLA. Each node can provide up to 10,000 QPS of reads or 2,000 QPS of writes (writing single rows at 1KB data per row), and 2 TiB storage.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -1467,7 +1631,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: Stackdriver Debugger default plan. Plan ID: `10866183-a775-49e8-96e3-4e7a901e4a79`.
+* **`default`**
+  * Plan ID: `10866183-a775-49e8-96e3-4e7a901e4a79`.
+  * Description: Stackdriver Debugger default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -1551,7 +1719,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: Stackdriver Monitoring default plan. Plan ID: `2e4b85c1-0ce6-46e4-91f5-eebeb373e3f5`.
+* **`default`**
+  * Plan ID: `2e4b85c1-0ce6-46e4-91f5-eebeb373e3f5`.
+  * Description: Stackdriver Monitoring default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -1635,7 +1807,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: Stackdriver Profiler default plan. Plan ID: `594627f6-35f5-462f-9074-10fb033fb18a`.
+* **`default`**
+  * Plan ID: `594627f6-35f5-462f-9074-10fb033fb18a`.
+  * Description: Stackdriver Profiler default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -1719,7 +1895,11 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **default**: Stackdriver Trace default plan. Plan ID: `ab6c2287-b4bc-4ff4-a36a-0575e7910164`.
+* **`default`**
+  * Plan ID: `ab6c2287-b4bc-4ff4-a36a-0575e7910164`.
+  * Description: Stackdriver Trace default plan.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
 
 
 ## Examples
@@ -1816,12 +1996,43 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 
-  * **standard**: Standard storage class. Auto-selects either regional or multi-regional based on the location. Plan ID: `e1d11f65-da66-46ad-977c-6d56513baf43`.
-  * **nearline**: Nearline storage class. Plan ID: `a42c1182-d1a0-4d40-82c1-28220518b360`.
-  * **reduced-availability**: Durable Reduced Availability storage class. Plan ID: `1a1f4fe6-1904-44d0-838c-4c87a9490a6b`.
-  * **coldline**: Google Cloud Storage Coldline is a very-low-cost, highly durable storage service for data archiving, online backup, and disaster recovery. Plan ID: `c8538397-8f15-45e3-a229-8bb349c3a98f`.
-  * **regional**: Data is stored in a narrow geographic region, redundant across availability zones with a 99.99% typical monthly availability. Plan ID: `5e6161d2-0202-48be-80c4-1006cce19b9d`.
-  * **multiregional**: Data is stored geo-redundantly with >99.99% typical monthly availability. Plan ID: `a5e8dfb5-e5ec-472a-8d36-33afcaff2fdb`.
+* **`standard`**
+  * Plan ID: `e1d11f65-da66-46ad-977c-6d56513baf43`.
+  * Description: Standard storage class. Auto-selects either regional or multi-regional based on the location.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`nearline`**
+  * Plan ID: `a42c1182-d1a0-4d40-82c1-28220518b360`.
+  * Description: Nearline storage class.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`reduced-availability`**
+  * Plan ID: `1a1f4fe6-1904-44d0-838c-4c87a9490a6b`.
+  * Description: Durable Reduced Availability storage class.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`coldline`**
+  * Plan ID: `c8538397-8f15-45e3-a229-8bb349c3a98f`.
+  * Description: Google Cloud Storage Coldline is a very-low-cost, highly durable storage service for data archiving, online backup, and disaster recovery.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`regional`**
+  * Plan ID: `5e6161d2-0202-48be-80c4-1006cce19b9d`.
+  * Description: Data is stored in a narrow geographic region, redundant across availability zones with a 99.99% typical monthly availability.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`multiregional`**
+  * Plan ID: `a5e8dfb5-e5ec-472a-8d36-33afcaff2fdb`.
+  * Description: Data is stored geo-redundantly with >99.99% typical monthly availability.
+  * This plan doesn't override user variables on provision.
+  * This plan doesn't override user variables on bind.
+* **`zzzlast`**
+  * Plan ID: `a5e8dfb5-e5ec-472a-8d36-33afcaff2fde`.
+  * Description: Data is stored geo-redundantly with >99.99% typical monthly availability.
+  * This plan overrides the following user variables on provision.
+    * `location` = `US`
+  * This plan overrides the following user variables on bind.
+    * `service_account_display_name` = `storage-client`
 
 
 ## Examples

--- a/pkg/broker/catalog.go
+++ b/pkg/broker/catalog.go
@@ -45,7 +45,9 @@ func (s Service) ToPlain() brokerapi.Service {
 type ServicePlan struct {
 	brokerapi.ServicePlan
 
-	ServiceProperties map[string]string `json:"service_properties"`
+	ServiceProperties  map[string]string      `json:"service_properties"`
+	ProvisionOverrides map[string]interface{} `json:"provision_overrides,omitempty"`
+	BindOverrides      map[string]interface{} `json:"bind_overrides,omitempty"`
 }
 
 // GetServiceProperties gets the plan settings variables as a string->interface map.

--- a/pkg/broker/service_config.go
+++ b/pkg/broker/service_config.go
@@ -40,11 +40,13 @@ type ServiceConfig struct {
 
 // CustomPlan holds operator defined variables for each service.
 type CustomPlan struct {
-	GUID        string            `json:"guid" validate:"required,uuid"`
-	Name        string            `json:"name" validate:"required"`
-	DisplayName string            `json:"display_name" validate:"required"`
-	Description string            `json:"description" validate:"required"`
-	Properties  map[string]string `json:"properties"`
+	GUID               string                 `json:"guid" validate:"required,uuid"`
+	Name               string                 `json:"name" validate:"required"`
+	DisplayName        string                 `json:"display_name" validate:"required"`
+	Description        string                 `json:"description" validate:"required"`
+	Properties         map[string]string      `json:"properties"`
+	ProvisionOverrides map[string]interface{} `json:"provision_overrides"`
+	BindOverrides      map[string]interface{} `json:"bind_overrides"`
 }
 
 // ToServicePlan converts the CustomPlan to a ServicePlan.
@@ -58,7 +60,9 @@ func (c *CustomPlan) ToServicePlan() ServicePlan {
 				DisplayName: c.DisplayName,
 			},
 		},
-		ServiceProperties: c.Properties,
+		ServiceProperties:  c.Properties,
+		ProvisionOverrides: c.ProvisionOverrides,
+		BindOverrides:      c.BindOverrides,
 	}
 }
 

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -193,9 +193,10 @@ func (svc *ServiceDefinition) bindDefaults() []varcontext.DefaultVariable {
 //
 // 1. Variables defined in your `computed_variables` JSON list.
 // 2. Variables defined by the selected service plan in its `service_properties` map.
-// 3. User defined variables (in `provision_input_variables` or `bind_input_variables`)
-// 4. Operator default variables loaded from the environment.
-// 5. Default variables (in `provision_input_variables` or `bind_input_variables`).
+// 3. Variables overridden in the plan's `provision_overrides` map.
+// 4. User defined variables (in `provision_input_variables` or `bind_input_variables`)
+// 5. Operator default variables loaded from the environment.
+// 6. Default variables (in `provision_input_variables` or `bind_input_variables`).
 //
 // Loading into the map occurs slightly differently.
 // Default variables and computed_variables get executed by interpolation.
@@ -217,6 +218,7 @@ func (svc *ServiceDefinition) ProvisionVariables(instanceId string, details brok
 		SetEvalConstants(constants).
 		MergeMap(svc.config.ProvisionDefaults).
 		MergeJsonObject(details.GetRawParameters()).
+		MergeMap(plan.ProvisionOverrides).
 		MergeDefaults(svc.provisionDefaults()).
 		MergeMap(plan.GetServiceProperties()).
 		MergeDefaults(svc.ProvisionComputedVariables)
@@ -229,6 +231,7 @@ func (svc *ServiceDefinition) ProvisionVariables(instanceId string, details brok
 // The variable resolution order is the following:
 //
 // 1. Variables defined in your `computed_variables` JSON list.
+// 2. Variables overridden in the plan's `bind_overrides` map.
 // 3. User defined variables (in `bind_input_variables`)
 // 4. Operator default variables loaded from the environment.
 // 5. Default variables (in `bind_input_variables`).
@@ -268,6 +271,7 @@ func (svc *ServiceDefinition) BindVariables(instance models.ServiceInstanceDetai
 		SetEvalConstants(constants).
 		MergeMap(svc.config.BindDefaults).
 		MergeJsonObject(details.GetRawParameters()).
+		MergeMap(plan.BindOverrides).
 		MergeDefaults(svc.bindDefaults()).
 		MergeDefaults(svc.BindComputedVariables)
 

--- a/pkg/generator/service-config-md.go
+++ b/pkg/generator/service-config-md.go
@@ -200,6 +200,12 @@ func createExampleCustomPlan(service *broker.ServiceDefinition) []broker.CustomP
 			Properties: map[string]string{
 				"//": "See the custom plan properties section below for configurable properties.",
 			},
+			ProvisionOverrides: map[string]interface{}{
+				"//": "You can override any user-settable provision variable here.",
+			},
+			BindOverrides: map[string]interface{}{
+				"//": "You can override any user-settable bind variable here.",
+			},
 		},
 	}
 }

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -118,8 +118,16 @@ The following plans are built-in to the GCP Service Broker and may be overriden
 or disabled by the broker administrator.
 
 {{ if eq (len .catalog.Plans) 0 }}_No plans available_{{ end }}
-{{ range $i, $plan := .catalog.Plans }}  * **{{ $plan.Name }}**: {{ $plan.Description }} Plan ID: {{code $plan.ID}}.
+{{ range $i, $plan := .catalog.Plans -}}
+* **{{code $plan.Name }}**
+  * Plan ID: {{code $plan.ID}}.
+  * Description: {{ $plan.Description }}
+  * This plan {{ if eq (len $plan.ProvisionOverrides) 0 -}} doesn't override {{- else -}} overrides the following {{- end}} user variables on provision.
+{{ range $k, $v := $plan.ProvisionOverrides}}    * {{ code $k }} = {{code $v}}
+{{ end }}  * This plan {{ if eq (len $plan.BindOverrides) 0 -}} doesn't override {{- else -}} overrides the following {{- end}} user variables on bind.
+{{ range $k, $v := $plan.BindOverrides}}    * {{ code $k }} = {{code $v}}
 {{ end }}
+{{- end }}
 
 ## Examples
 

--- a/pkg/providers/builtin/storage/definition.go
+++ b/pkg/providers/builtin/storage/definition.go
@@ -16,9 +16,9 @@ package storage
 
 import (
 	"code.cloudfoundry.org/lager"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/base"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"

--- a/pkg/providers/tf/definition.go
+++ b/pkg/providers/tf/definition.go
@@ -50,13 +50,15 @@ type TfServiceDefinitionV1 struct {
 // TfServiceDefinitionV1Plan represents a service plan in a human-friendly format
 // that can be converted into an OSB compatible plan.
 type TfServiceDefinitionV1Plan struct {
-	Name        string            `yaml:"name" validate:"required"`
-	Id          string            `yaml:"id" validate:"required,uuid"`
-	Description string            `yaml:"description" validate:"required"`
-	DisplayName string            `yaml:"display_name" validate:"required"`
-	Bullets     []string          `yaml:"bullets,omitempty"`
-	Free        bool              `yaml:"free,omitempty"`
-	Properties  map[string]string `yaml:"properties" validate:"required"`
+	Name               string                 `yaml:"name" validate:"required"`
+	Id                 string                 `yaml:"id" validate:"required,uuid"`
+	Description        string                 `yaml:"description" validate:"required"`
+	DisplayName        string                 `yaml:"display_name" validate:"required"`
+	Bullets            []string               `yaml:"bullets,omitempty"`
+	Free               bool                   `yaml:"free,omitempty"`
+	Properties         map[string]string      `yaml:"properties" validate:"required"`
+	ProvisionOverrides map[string]interface{} `yaml:"provision_overrides,omitempty"`
+	BindOverrides      map[string]interface{} `yaml:"bind_overrides,omitempty"`
 }
 
 // Converts this plan definition to a broker.ServicePlan.
@@ -73,8 +75,10 @@ func (plan *TfServiceDefinitionV1Plan) ToPlan() broker.ServicePlan {
 	}
 
 	return broker.ServicePlan{
-		ServicePlan:       masterPlan,
-		ServiceProperties: plan.Properties,
+		ServicePlan:        masterPlan,
+		ServiceProperties:  plan.Properties,
+		ProvisionOverrides: plan.ProvisionOverrides,
+		BindOverrides:      plan.BindOverrides,
 	}
 }
 


### PR DESCRIPTION
This allows operators to define plans that can override user provision and bind parameters.

This means more fine-grained control for operators that need complete control on their environment and more variables given to developers in all other environments.

This will also allow us as broker developers to build plans that target specific use-cases; for example in order to get an HA instance of Postgres you need a certain set of variables set in a specific way.