### PR TITLE
added expanded label support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - A new web-endpoint `/service-config` that hosts service configuration info.
  - Ability to get plan information from HIL execution environment on bind.
  - Ability for plans to selectively override user variables.
+ - Expanded default labels to include org and space name for CF, namespace and clusterid for Kubernetes, and instance-name for all.
+ - A new default label `managed-by:gcp-service-broker` to help identify services which shouldn't be touched.
 
 ### Changed
  - The format of the `/docs` endpoint is now nicely styled with Bootstrap 4.
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Built Brokerpaks now have a name of `{name}-{version}.brokerpak` as defined by the manifest rather than the name of the parent directory.
  - Services inside Brokerpaks now have a file name that includes their CLI friendly name to help differentiate them.
  - The `pak build` command now includes progress logs.
+ - Instance label prefixes are now `cf-` rather than `pcf-`.
 
 ## [4.2.2] - 2019-02-06
 

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -4,9 +4,16 @@ The GCP Service Broker automatically labels supported resources with organizatio
 
 When these supported services are provisioned, they will have the following labels populated with information from the request:
 
- * `pcf-organization-guid`
- * `pcf-space-guid`
- * `pcf-instance-id`
+* `cf-organization-guid`
+* `cf-organization-name`
+* `cf-space-guid`
+* `cf-space-name`
+* `instance-id`
+* `instance-name`
+* `k8s-namespace`
+* `k8s-clusterid`
+
+All provisioned services supporting labels will have an additional label `manged-by` with a value of `gcp-service-broker`.
 
 GCP labels have a more restricted character set than the Service Broker so unsupported characters will be mapped to the underscore character (`_`).
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -81,18 +81,17 @@ func TestExtractDefaultLabels(t *testing.T) {
 			instanceId: "",
 			details:    brokerapi.ProvisionDetails{},
 			expected: map[string]string{
-				"pcf-organization-guid": "",
-				"pcf-space-guid":        "",
-				"pcf-instance-id":       "",
+				"managed-by": "gcp-service-broker",
 			},
 		},
 		"osb 2.13": {
 			instanceId: "my-instance",
 			details:    brokerapi.ProvisionDetails{OrganizationGUID: "org-guid", SpaceGUID: "space-guid"},
 			expected: map[string]string{
-				"pcf-organization-guid": "org-guid",
-				"pcf-space-guid":        "space-guid",
-				"pcf-instance-id":       "my-instance",
+				"cf-organization-guid": "org-guid",
+				"cf-space-guid":        "space-guid",
+				"instance-id":          "my-instance",
+				"managed-by":           "gcp-service-broker",
 			},
 		},
 		"osb future": {
@@ -103,18 +102,55 @@ func TestExtractDefaultLabels(t *testing.T) {
 				RawContext:       json.RawMessage(`{"organization_guid":"org-override", "space_guid":"space-override"}`),
 			},
 			expected: map[string]string{
-				"pcf-organization-guid": "org-override",
-				"pcf-space-guid":        "space-override",
-				"pcf-instance-id":       "my-instance",
+				"cf-organization-guid": "org-override",
+				"cf-space-guid":        "space-override",
+				"instance-id":          "my-instance",
+				"managed-by":           "gcp-service-broker",
 			},
 		},
 		"osb special characters": {
 			instanceId: "my~instance.",
 			details:    brokerapi.ProvisionDetails{},
 			expected: map[string]string{
-				"pcf-organization-guid": "",
-				"pcf-space-guid":        "",
-				"pcf-instance-id":       "my_instance_",
+				"instance-id": "my_instance_",
+				"managed-by":  "gcp-service-broker",
+			},
+		},
+		"kubernetes": {
+			instanceId: "my-instance",
+			details: brokerapi.ProvisionDetails{
+				RawContext: json.RawMessage(`{"namespace":"ns", "clusterid":"cluster-guid"}`),
+			},
+			expected: map[string]string{
+				"k8s-namespace": "ns",
+				"k8s-clusterid": "cluster-guid",
+				"instance-id":   "my-instance",
+				"managed-by":    "gcp-service-broker",
+			},
+		},
+		"cf": {
+			instanceId: "my-instance",
+			details: brokerapi.ProvisionDetails{
+				RawContext: json.RawMessage(`{"organization_name":"on", "space_name":"sn", "organization_guid":"og", "space_guid": "sg"}`),
+			},
+			expected: map[string]string{
+				"cf-organization-guid": "og",
+				"cf-space-guid":        "sg",
+				"cf-organization-name": "on",
+				"cf-space-name":        "sn",
+				"instance-id":          "my-instance",
+				"managed-by":           "gcp-service-broker",
+			},
+		},
+		"instance-info": {
+			instanceId: "my-instance",
+			details: brokerapi.ProvisionDetails{
+				RawContext: json.RawMessage(`{"instance_name":"mydb"}`),
+			},
+			expected: map[string]string{
+				"instance-name": "mydb",
+				"instance-id":   "my-instance",
+				"managed-by":    "gcp-service-broker",
 			},
 		},
 	}


### PR DESCRIPTION
Part of #446, expanding supported labels so policies can be written against them for operators to change Terraform environment variables on the fly.