### PR TITLE
added flag to run only a single example for brokerpaks

### DIFF
--- a/cmd/pak.go
+++ b/cmd/pak.go
@@ -136,18 +136,21 @@ dependencies, services it provides, and the contents.
 		},
 	})
 
-	pakCmd.AddCommand(&cobra.Command{
+	var serviceName string
+	runExamplesCmd := &cobra.Command{
 		Use:   "run-examples [pack.brokerpak]",
 		Short: "run the examples from a brokerpak",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := brokerpak.RunExamples(args[0]); err != nil {
+			if err := brokerpak.RunExamples(args[0], serviceName); err != nil {
 				log.Fatalf("Error executing examples: %v", err)
 			}
 
 			log.Println("Success")
 		},
-	})
+	}
+	runExamplesCmd.Flags().StringVarP(&serviceName, "service-name", "", "", "name of the service to run tests for or blank for all")
+	pakCmd.AddCommand(runExamplesCmd)
 
 	pakCmd.AddCommand(&cobra.Command{
 		Use:     "docs [pack.brokerpak]",

--- a/pkg/brokerpak/cmd.go
+++ b/pkg/brokerpak/cmd.go
@@ -167,7 +167,9 @@ func RegisterAll(registry *broker.ServiceRegistry) error {
 }
 
 // RunExamples executes the examples from a brokerpak.
-func RunExamples(pack string) error {
+// If serviceName is not blank then only examples for the service with the
+// given name are run.
+func RunExamples(pack, serviceName string) error {
 	registry, err := registryFromLocalBrokerpak(pack)
 	if err != nil {
 		return err
@@ -178,7 +180,7 @@ func RunExamples(pack string) error {
 		return err
 	}
 
-	return client.RunExamplesForService(registry, apiClient, "")
+	return client.RunExamplesForService(registry, apiClient, serviceName)
 }
 
 // Docs generates the markdown usage docs for the given pack and writes them to stdout.


### PR DESCRIPTION
This is useful for faster turnaround when developing brokerpaks.