### PR TITLE
fixed formatting of some fields in the generated docs

### DIFF
--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -173,8 +173,8 @@ Uses plan: {{ code $example.PlanId }}.
 
 }
 
-func mdCode(text string) string {
-	return fmt.Sprintf("`%s`", text)
+func mdCode(text interface{}) string {
+	return fmt.Sprintf("`%v`", text)
 }
 
 func varNotes(variable broker.BrokerVariable) string {

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -173,8 +173,8 @@ Uses plan: {{ code $example.PlanId }}.
 
 }
 
-func mdCode(text interface{}) string {
-	return fmt.Sprintf("`%v`", text)
+func mdCode(value interface{}) string {
+	return fmt.Sprintf("`%v`", value)
 }
 
 func varNotes(variable broker.BrokerVariable) string {


### PR DESCRIPTION
The formatter expected all values to be strings but that's not actually the case for some of the values we want to format so this is now a generic value to enable formatting values like `true` and `42`.