### PR TITLE
Remove dependency for a default network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
  - Added a workaround for an upstream CloudSQL issue that caused SQL user deletion to fail.
 
+### Changed
+ - Removed requirement to have a 'default' network when using google-redis.
+
 ## [4.2.2] - 2019-02-06
 
 ### Fixed
@@ -88,7 +91,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 - Running the service by executing the main executable. Use the `serve` sub-command instead.
 
-### Changed  
+### Changed
 - **Breaking** plan ids are now required and will not be generated if not supplied.
 - **Breaking** changed custom plan id field name from `guid` to `id`.
 - **Breaking** modified `"features"` plan configuration field name to `"service_properties"`.

--- a/google-brokers/google-redis.yml
+++ b/google-brokers/google-redis.yml
@@ -77,9 +77,8 @@ provision:
       pattern: ^[A-Za-z][-a-z0-9A-Z]+$
   - field_name: authorized_network
     type: string
-    details:  The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
-      This will look something like /projects/PROJECTID/global/networks/NETWORKNAME.
-    default: ''
+    details:  The name of the Google Compute Engine network to which the instance is connected. If left unspecified, the network named 'default' will be used.
+    default: default
   computed_inputs:
   - name: labels
     default: ${json.marshal(request.default_labels)}
@@ -94,8 +93,8 @@ provision:
     variable memory_size_gb { type = "string" }
     variable labels { type = "map" }
 
-    data "google_compute_network" "default-network" {
-      name = "default"
+    data "google_compute_network" "authorized-network" {
+      name = "${var.authorized_network}"
     }
 
     resource "google_redis_instance" "instance" {
@@ -104,7 +103,7 @@ provision:
       memory_size_gb     = "${var.memory_size_gb}"
       display_name       = "${var.display_name}"
       region             = "${var.region}"
-      authorized_network = "${coalesce(var.authorized_network, data.google_compute_network.default-network.self_link)}"
+      authorized_network = "${data.google_compute_network.authorized-network.self_link}"
       labels             = "${var.labels}"
 
       timeouts {


### PR DESCRIPTION
Because of the data resource 'default-network' it was needed to have a
default network even though one might not use it as "authorized_network".

When you're not having a 'default' network and you're trying to create a google-redis service with the following command, terraform fails with the appended error message.
```bash
$ cf create-service experimental-google-redis basic redis-01 -c '{"authorized_network":"<ANY_OTHER_THAN_DEFAULT>"}'
```

Error message:
```
data.google_compute_network.default-network: Refreshing state...
module.instance.data.google_compute_network.default-network: Refreshing state...
    
Error: Error applying plan:
    
1 error(s) occurred:
    
* module.instance.google_redis_instance.instance: Resource 'data.google_compute_network.default-network' not found for variable 'data.google_compute_network.default-network.self_link'
    
Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

Since we can define a default value for `${var.authorized_network}` and in addition it seems to be easier to name a network instead of using the "full-name" (/projects/<PROJECT_ID>/networks/global/<NETWORK_NAME>), we can just replace the hard-coded name of the network data source to remove this dependency.

This **does not** resolve the fact, that the service creation won't fail even though terraform fails (when terraform fails, the service status mostly stays at 'create in progress').

PS: In the CHANGELOG.md I added this change to the 4.2.3 release since I haven't found a release for it yet (even though the changelog format would suggest adding unreleased fixes in a `[unreleased]` part of the changelog).
Let me know when I should change this! :-)

 
