### PR TITLE
delete replicas if they exist, fixes #466

### DIFF
--- a/pkg/providers/builtin/cloudsql/broker_test.go
+++ b/pkg/providers/builtin/cloudsql/broker_test.go
@@ -240,6 +240,36 @@ func TestCreateProvisionRequest(t *testing.T) {
 			Validate:    func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {},
 			ErrContains: "disk size",
 		},
+
+		"failover name specified": {
+			Service:    MysqlServiceDefinition(),
+			PlanId:     mysqlSecondGenPlan,
+			UserParams: `{"failover_replica_name":"my-replica"}`,
+			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
+				if di.FailoverReplica == nil {
+					t.Errorf("Expected FailoverReplica to not be nil")
+				}
+
+				if di.FailoverReplica.Name != "my-replica" {
+					t.Errorf("Expected FailoverReplica.Name to be 'my-replica' got %s.", di.FailoverReplica.Name)
+				}
+			},
+		},
+
+		"failover suffix overrides failover name": {
+			Service:    MysqlServiceDefinition(),
+			PlanId:     mysqlSecondGenPlan,
+			UserParams: `{"instance_name":"my-instance", "failover_replica_name":"my-replica", "failover_replica_suffix":"-failover"}`,
+			Validate: func(t *testing.T, di googlecloudsql.DatabaseInstance, ii InstanceInformation) {
+				if di.FailoverReplica == nil {
+					t.Errorf("Expected FailoverReplica to not be nil")
+				}
+
+				if di.FailoverReplica.Name != "my-instance-failover" {
+					t.Errorf("Expected FailoverReplica.Name to be 'my-replica-failover' got %s.", di.FailoverReplica.Name)
+				}
+			},
+		},
 	}
 
 	for tn, tc := range cases {

--- a/pkg/providers/builtin/cloudsql/sql_account_manager.go
+++ b/pkg/providers/builtin/cloudsql/sql_account_manager.go
@@ -106,11 +106,18 @@ func (broker *CloudSQLBroker) deleteSqlUserAccount(ctx context.Context, binding 
 	// which _is_ a valid host, so we expand to a single space string if the
 	// user we're trying to delete doesn't have some other host specified.
 	hostToDelete := ""
+	foundUser := false
 	for _, user := range userList.Items {
 		if user.Name == creds.Username {
 			hostToDelete = user.Host
 			break
 		}
+	}
+
+	// XXX: If the user was already deleted, don't fail here because it could
+	// block deprovisioning.
+	if !foundUser {
+		return nil
 	}
 
 	if hostToDelete == "" {


### PR DESCRIPTION
Fixes #466

This PR changes the way deletes are done from just deleting the master MySQL instance and any failover replicas it has. Replicas must be deleted before the master.

One fun side-effect is that even after the replica is done deleting the core instance may remain blocked for some period of time (returning HTTP status code 409s for attempts to delete it) so we have to repeatedly try until we get an operation id back.

A new example exercises the failed functionality and integration tests should show that it works now. A new field was added to the request `failover_replica_suffix`, if set it will set `failover_replica_name` to be the the instance name + the suffix. This allows us to use the randomly generated instance ids with failovers.