### PR TITLE
Migrate column request_detail to datatype text

### DIFF
--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -67,6 +67,10 @@ func RunMigrations(db *gorm.DB) error {
 		return autoMigrateTables(db, &models.TerraformDeploymentV1{})
 	}
 
+	migrations[5] = func() error { // v4.2.3
+		return autoMigrateTables(db, &models.ProvisionRequestDetailsV2{})
+	}
+
 	var lastMigrationNumber = -1
 
 	// if we've run any migrations before, we should have a migrations table, so find the last one we ran

--- a/db_service/models/historical_db.go
+++ b/db_service/models/historical_db.go
@@ -124,6 +124,24 @@ func (ProvisionRequestDetailsV1) TableName() string {
 	return "provision_request_details"
 }
 
+// ProvisionRequestDetailsV2 holds user-defined properties passed to a call
+// to provision a service.
+type ProvisionRequestDetailsV2 struct {
+	gorm.Model
+
+	ServiceInstanceId string
+
+	// is a json.Marshal of models.ProvisionDetails
+	RequestDetails string `gorm:"type:text"`
+}
+
+// TableName returns a consistent table name (`provision_request_details`) for
+// gorm so multiple structs from different versions of the database all operate
+// on the same table.
+func (ProvisionRequestDetailsV2) TableName() string {
+	return "provision_request_details"
+}
+
 // MigrationV1 represents the mgirations table. It holds a monotonically
 // increasing number that gets incremented with every database schema revision.
 type MigrationV1 struct {


### PR DESCRIPTION
closes #468 

Currently the column request_detail in the table ProvisionDetails
is of type string, actually it's varchar(255), which is not enough
space to store JSON based configuration data for creating services.

@josephlewis42 please let me know if I missed something. I am new to service broker development and more than happy to get your feedback and advisory in order to move this thing forward!