### PR TITLE
Add support for Memorystore for Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ release/
 tile-history.yml
 ci/parameters.yml
 ci/vars.yml
+config.yml

--- a/pkg/providers/builtin/redis/broker.go
+++ b/pkg/providers/builtin/redis/broker.go
@@ -1,0 +1,131 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	googleredis "cloud.google.com/go/redis/apiv1beta1"
+	"fmt"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/db_service/models"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/base"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
+	"github.com/pivotal-cf/brokerapi"
+	"golang.org/x/net/context"
+	"google.golang.org/genproto/googleapis/cloud/redis/v1beta1"
+	"strconv"
+	"strings"
+)
+
+// RedisBroker is the service-broker back-end for creating and binding Redis services.
+type RedisBroker struct {
+	base.BrokerBase
+}
+
+// InstanceInformation holds the details needed to connect to a Redis instance after it has been provisioned
+type InstanceInformation struct {
+	RedisVersion string `json:"redis_version"`
+	Host         string `json:"host"`
+	Port         string `json:"port"`
+	MemorySizeGb int    `json:"memory_size_gb"`
+}
+
+// serviceTiers holds the valid value mapping for string service tiers to their REST call equivalent
+var serviceTiers = map[string]redis.Instance_Tier{
+	"basic":       redis.Instance_BASIC,
+	"standard_ha": redis.Instance_STANDARD_HA,
+}
+
+// Provision creates a new Redis instance from the settings in the user-provided details and service plan.
+func (b *RedisBroker) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
+
+	authorizedNetwork := provisionContext.GetString("authorized_network")
+	memorySizeGb := int32(provisionContext.GetInt("memory_size_gb"))
+	displayName := provisionContext.GetString("display_name")
+	instanceId := provisionContext.GetString("instance_id")
+	region := provisionContext.GetString("region")
+	serviceTier := serviceTiers[strings.ToLower(provisionContext.GetString("service_tier"))]
+	parent := fmt.Sprintf("projects/%s/locations/%s", b.ProjectId, region)
+	name := fmt.Sprintf("%s/instances/%s", parent, instanceId)
+
+	// Build Redis Instance
+	instance := &redis.Instance{
+		Name:              name,
+		DisplayName:       displayName,
+		Tier:              serviceTier,
+		MemorySizeGb:      memorySizeGb,
+		AuthorizedNetwork: authorizedNetwork,
+	}
+
+	ir := &redis.CreateInstanceRequest{
+		Parent:     parent,
+		InstanceId: instanceId,
+		Instance:   instance,
+	}
+
+	c, err := googleredis.NewCloudRedisClient(ctx)
+	if err != nil {
+		return models.ServiceInstanceDetails{}, err
+	}
+
+	op, err := c.CreateInstance(ctx, ir)
+	if err != nil {
+		return models.ServiceInstanceDetails{}, fmt.Errorf("Error creating new Redis instance: %s", err)
+	}
+
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return models.ServiceInstanceDetails{}, err
+	}
+
+	ii := InstanceInformation{
+		RedisVersion: resp.RedisVersion,
+		Host:         resp.Host,
+		Port:         strconv.Itoa(int(resp.Port)),
+		MemorySizeGb: int(resp.MemorySizeGb),
+	}
+
+	id := models.ServiceInstanceDetails{
+		Name: resp.Name,
+	}
+
+	if err := id.SetOtherDetails(ii); err != nil {
+		return models.ServiceInstanceDetails{}, fmt.Errorf("Error marshalling json: %s", err)
+	}
+
+	return id, nil
+}
+
+// Deprovision deletes the Redis instance with the given instance ID
+func (b *RedisBroker) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails) (*string, error) {
+	c, err := googleredis.NewCloudRedisClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &redis.DeleteInstanceRequest{
+		Name: instance.Name,
+	}
+
+	op, err := c.DeleteInstance(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("Error deleting Redis instance: %s", err)
+	}
+
+	err = op.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}

--- a/pkg/providers/builtin/redis/definition.go
+++ b/pkg/providers/builtin/redis/definition.go
@@ -1,0 +1,169 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	"code.cloudfoundry.org/lager"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/account_managers"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/base"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
+	"github.com/pivotal-cf/brokerapi"
+	"golang.org/x/oauth2/jwt"
+)
+
+func ServiceDefinition() *broker.ServiceDefinition {
+	roleWhitelist := []string{
+		"redis.editor",
+		"redis.viewer",
+	}
+
+	return &broker.ServiceDefinition{
+		Id:               "3ea92b54-838c-4fe1-b75d-9bda513380aa",
+		Name:             "google-memorystore-redis",
+		Description:      "Creates and manages Redis instances on the Google Cloud Platform.",
+		DisplayName:      "Google Cloud Memorystore for Redis API",
+		ImageUrl:         "https://cloud.google.com/_static/images/cloud/products/logos/svg/cache.svg",
+		DocumentationUrl: "https://cloud.google.com/memorystore/docs/redis",
+		SupportUrl:       "https://cloud.google.com/memorystore/docs/redis/support",
+		Tags:             []string{"gcp", "memorystore", "redis"},
+		Bindable:         true,
+		PlanUpdateable:   false,
+		Plans: []broker.ServicePlan{
+			{
+				ServicePlan: brokerapi.ServicePlan{
+					ID:          "dd1923b6-ac26-4697-83d6-b3a0c05c2c94",
+					Name:        "basic",
+					Description: "Provides a standalone Redis instance. Use this tier for applications that require a simple Redis cache.",
+					Free:        brokerapi.FreeValue(false),
+				},
+				ServiceProperties: map[string]string{"service_tier": "basic"},
+			},
+			{
+				ServicePlan: brokerapi.ServicePlan{
+					ID:          "41771881-b456-4940-9081-34b6424744c6",
+					Name:        "standard_ha",
+					Description: "Provides a highly available Redis instance that includes automatically enabled cross-zone replication and automatic failover. Use this tier for applications that require high availability for a Redis instance.",
+					Free:        brokerapi.FreeValue(false),
+				},
+				ServiceProperties: map[string]string{"service_tier": "standard_ha"},
+			},
+		},
+		ProvisionInputVariables: []broker.BrokerVariable{
+			{
+				FieldName: "authorized_network",
+				Type:      broker.JsonTypeString,
+				Details:   "Optional. The full name of the Google Compute Engine network to which the instance is connected.",
+				Default:   "",
+			},
+			{
+				FieldName: "memory_size_gb",
+				Type:      broker.JsonTypeString,
+				Details:   "The Redis instance's provisioned capacity in GB. See: https://cloud.google.com/memorystore/pricing for more information.",
+				Default:   "4",
+				Constraints: validation.NewConstraintBuilder().
+					MinLength(1).
+					MaxLength(10).
+					Pattern("[1-9][0-9]*").
+					Build(),
+			},
+			{
+				FieldName: "instance_id",
+				Type:      broker.JsonTypeString,
+				Details:   "The name of the Redis instance.",
+				Default:   "gsb-${counter.next()}-${time.nano()}",
+				Constraints: validation.NewConstraintBuilder().
+					MinLength(1).
+					MaxLength(40).
+					Pattern("^[a-z]([-0-9a-z]*[a-z0-9]$)*").
+					Build(),
+			},
+			{
+				FieldName: "region",
+				Type:      broker.JsonTypeString,
+				Details:   "The region in which to provision the Redis instance. See: https://cloud.google.com/memorystore/docs/redis/regions for supported regions.",
+				Default:   "us-east1",
+				Constraints: validation.NewConstraintBuilder().
+					Pattern("^[a-z]+[-][a-z0-9]+$").
+					Examples("us-central1", "europe-west2", "asia-northeast1", "australia-southeast1").
+					Build(),
+			},
+			{
+				FieldName: "display_name",
+				Type:      broker.JsonTypeString,
+				Details:   "The human-readable display name of the Redis instance.",
+				Default:   "${instance_id}",
+				Constraints: validation.NewConstraintBuilder().
+					MinLength(4).
+					MaxLength(30).
+					Build(),
+			},
+		},
+		DefaultRoleWhitelist: roleWhitelist,
+		BindInputVariables:   accountmanagers.ServiceAccountWhitelistWithDefault(roleWhitelist, "redis.viewer"),
+		BindOutputVariables: append(accountmanagers.ServiceAccountBindOutputVariables(),
+			broker.BrokerVariable{
+				FieldName: "redis_version",
+				Type:      broker.JsonTypeString,
+				Details:   "The version of Redis software.",
+				Required:  true,
+			},
+			broker.BrokerVariable{
+				FieldName: "host",
+				Type:      broker.JsonTypeString,
+				Details:   "Hostname or IP address of the exposed Redis endpoint used by clients to connect to the service.",
+				Required:  true,
+			},
+			broker.BrokerVariable{
+				FieldName: "port",
+				Type:      broker.JsonTypeString,
+				Details:   "The port number of the exposed Redis endpoint.",
+				Required:  true,
+			},
+			broker.BrokerVariable{
+				FieldName: "memory_size_gb",
+				Type:      broker.JsonTypeInteger,
+				Details:   "Redis memory size in GiB.",
+				Required:  true,
+			},
+		),
+		BindComputedVariables: accountmanagers.ServiceAccountBindComputedVariables(),
+		PlanVariables: []broker.BrokerVariable{
+			{
+				FieldName: "service_tier",
+				Type:      broker.JsonTypeString,
+				Details:   "Either BASIC or STANDARD_HA. See: https://cloud.google.com/memorystore/pricing for more information.",
+				Default:   "basic",
+				Required:  true,
+			},
+		},
+		Examples: []broker.ServiceExample{
+			{
+				Name:            "Basic Redis Configuration",
+				Description:     "Create a Redis instance with basic service tier.",
+				PlanId:          "dd1923b6-ac26-4697-83d6-b3a0c05c2c94",
+				ProvisionParams: map[string]interface{}{},
+				BindParams: map[string]interface{}{
+					"role": "redis.viewer",
+				},
+			},
+		},
+		ProviderBuilder: func(projectId string, auth *jwt.Config, logger lager.Logger) broker.ServiceProvider {
+			bb := base.NewBrokerBase(projectId, auth, logger)
+			return &RedisBroker{BrokerBase: bb}
+		},
+		IsBuiltin: true,
+	}
+}

--- a/pkg/providers/builtin/registry.go
+++ b/pkg/providers/builtin/registry.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/firestore"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/ml"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/pubsub"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/redis"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/spanner"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/stackdriver"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/storage"
@@ -54,6 +55,7 @@ func RegisterBuiltinBrokers(registry broker.BrokerRegistry) {
 	registry.Register(dialogflow.ServiceDefinition())
 	registry.Register(firestore.ServiceDefinition())
 	registry.Register(pubsub.ServiceDefinition())
+	registry.Register(redis.ServiceDefinition())
 	registry.Register(spanner.ServiceDefinition())
 	registry.Register(stackdriver.StackdriverDebuggerServiceDefinition())
 	registry.Register(stackdriver.StackdriverMonitoringServiceDefinition())


### PR DESCRIPTION
Add Redis as a built-in service with two service plans corresponding to the two service tiers:
- basic
- standard high availability

Users can also specify the Redis instance's
- authorized network
- capacity tier
- display name
- instance id
- location id

Service Broker outputs instance variables to client can connect to the Redis instance: 
- name
- host
- port
- redis version
- memorysize in GiB

Console output after creating an instance example with "Basic Tier" examples:
```
2019/06/21 12:08:18 Running Example: google-memorystore-redis/Basic Redis Configuration
2019/06/21 12:08:18 gcp-service-broker client provision --instanceid "ex1103823129" --planid "dd1923b6-ac26-4697-83d6-b3a0c05c2c94" --serviceid "3ea92b54-838c-4fe1-b75d-9bda513380aa" --params "{}"
2019/06/21 12:08:18 gcp-service-broker client bind --instanceid "ex1103823129" --planid "dd1923b6-ac26-4697-83d6-b3a0c05c2c94" --serviceid "3ea92b54-838c-4fe1-b75d-9bda513380aa" --bindingid "ex1103823129" --params "{\"role\":\"redis.viewer\"}"
2019/06/21 12:08:18 gcp-service-broker client unbind --instanceid "ex1103823129" --planid "dd1923b6-ac26-4697-83d6-b3a0c05c2c94" --serviceid "3ea92b54-838c-4fe1-b75d-9bda513380aa" --bindingid "ex1103823129"
2019/06/21 12:08:18 gcp-service-broker client deprovision --instanceid "ex1103823129" --planid "dd1923b6-ac26-4697-83d6-b3a0c05c2c94" --serviceid "3ea92b54-838c-4fe1-b75d-9bda513380aa"
2019/06/21 12:08:18 Provisioning google-memorystore-redis/Basic Redis Configuration
2019/06/21 12:12:30 PUT http://user:pass@localhost:8000/v2/service_instances/ex1103823129?accepts_incomplete=true -> 201, "{}\n"
2019/06/21 12:12:30 Binding google-memorystore-redis/Basic Redis Configuration
2019/06/21 12:12:33 PUT http://user:pass@localhost:8000/v2/service_instances/ex1103823129/service_bindings/ex1103823129 -> 201, "{\"credentials\":{\"Email\":\"gsb-binding-ex110382@jlewisiii-gsb.iam.gserviceaccount.com\",\"Name\":\"gsb-binding-ex110382\",\"PrivateKeyData\":\"ewogICJ0eXBlIjogInNlcnZpY2VfYWNjb3VudCIsCiAgInByb2plY3RfaWQiOiAiamxld2lzaWlpLWdzYiIsCiAgInByaXZhdGVfa2V5X2lkIjogIjFmNmZmYzZlODczMmYyMWE0N2UzN2EyMzNjMGEyMWNmNGEyYjdhNTMiLAogICJwcml2YXRlX2tleSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2QUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktZd2dnU2lBZ0VBQW9JQkFRRExPUkE3Y0NWVHFjT1FcbjkwV2pzSUZka1YveTFzK3N2Z3B1RWRSYThMbC9JYkdrUmJnNjB6eWpNZkM0TlBOOWRmVFRhcllSTkxxSElJMENcbk4xekJFemVMY3gyZGd1ZHlpcjJRa3Zlb1BpRWFCeExnQVFIdzArNkF5MEgveEpEWnFJODBMZ3JHZXlKdEdkeXlcbnNWbjZ2dE00VUJDdkhSVm1VZmx1ZmZVaDJTWEZTTThEMUdkcTY2bnR6SlU5U3Z5NTNBZ2F1emZBS1ZuZXlvR3hcbmhLdndxUU9HbUR5cVVIRWl4YzlKc0RTcFIraU1KSFd0Z2cyRkZSZ1l2MzV4cnh2cVlObTg1aXM3ajZIbTNoc3pcblVmTFBIVFgwUWNKZkRGREhuUlh6SkxkUno1ei9PVlBVSVRXaU9qalloY1RrSnVzVlBpQVdPRGJwSjR0S0cwNFJcbkRIQ2QycGg1QWdNQkFBRUNnZ0VBQUppKzRJbk1Wa0gybDNKSkU2UUtSb2NpMHJ0STVLU0hNbnBlRnY2WXhpa3lcbnYyZk9xaFRpTUp3amdvcng3R2IxckhtUSszSnpSTC9MOTRYSVFZU0lBbmU0bzhuVldrdW9KdjN1STdjN3BpV3FcbkFNWGRVVmdjbmJ5d1h0V2ZLT3NhMjkxSEUxSkdaWVJ3cTl2NDhXaWJoVkZqaHliQ1NyNElDZDF0VHVlTXVleE5cbmlpMiswMTZtdEFIdy9uTVVWWWtmUERSY2xROFVCOU43NHpyT3J1dUJDSHJoQ0dlSUZBRi9YUHY5MnhDZ0R3SG5cbmsweUFSZU9VeDNrbGZ4NEo0dmR4NEkzSEprbkZZMU9UYzkrQzV3V0l0L3hyR0VjYTlXQlBqTjlMdUhsdzk4MmxcbnE3T080YUppK3JxVDBMU2Nkb2pwcHNLK2tnblBPTC9vNGl1M0JGMVVQUUtCZ1FEN0FVUlM0SFoyRU9qR1RadkFcbmJrRGlQMlVsclBTQjRsYlpSb1A3ck1EZlVveHFXWVk2b1ZTNFhiV3ZpQkV4L1kyTmZzNFRJYkdRUkdJM1BKZ1NcblMxMWp1OVVxbU1KTlo1TzF2TUh4VFZjUHB3bUpzTUtrcFNWdm5FZjYxT0lVbVJndzRLc1RWT0tDaklFTnhlMDRcbnRXNHIzVWNvZzFZRXRDOU9iOWdKNEM0MzlRS0JnUURQUkYrRFhua1kwaW8xaHBldnExaDhyV3I1NW14RlVpS29cbjZPbjNCK1g4aUd5MGpzcXQrV255UDI5NnZsZXk4WWp3SGIrKzR0eTF4TGc3YjgzMy9GNTR4eGkyN2hQeEkyMUlcbkpuTjZiRDBnWmhnU2dKQ0pkTzN2ZmZ1THJaczdrcWcySElMKzVtNUtDMnFMOGhYK2RYeU5xSUZOTjc3R2VySFdcbkRwMGxWUnIvOVFLQmdINUpJK1FDdFBjd0NMMkUzSUVUdDZkZE4vbWRyQ01SQ3Bza3BGRGltT09ETjh4bUlHZXRcbk5kL1FuaEdqaHVzODQ1UTJJVjUwekU2R2FWZmJMN084b1U4RmVQbUdnL1BIMGdSVTVNc1FHMlp2cHhmVWpBbWtcbllWSm5NYnZja2FiRlkrdHJqZ2NhNVIvRHEwYVB0NHVabE1XUy9qTSs2TzlTN0o0dEhXZlNsODVsQW9HQVQ2VEhcblN2U2ZkZEUwVlBNT0VIdTMrZGl0ZGE5OFJUcmxoS0JUWHhCUzZMSUhpMjRmSmJEa2JDakNEcGxibTdCQ1hYb2dcbjl4bTNrOFV1d2ZBWlprUThqUTU4U2JhOFJQbkhBV1Y5RkRySlZrekV6VDlIeXZuNmYvK2FERGMrb2lxZHBvVllcbk5OaVk0cXoyV1NaQ0cxQkw5eWNiNEc4ZVNLaFc4NWtUKzRkelk0MENnWUFIcDFXU0hWcTUyYzVhK0kvMVJ0ay9cbnpsRG91Z3BHbVh5QmhVS0ZVTVNMWEkwNkhBZllHVEdQZzVzTktDN0pINTJxbXdEMFpMa2x3dFdyWkJGOGRlbkRcbjY5bkgxNzBiZ1R0V3pHejcrcDFVMGhXY1BhVUZBQURoM01KdU4yTUVNcjdwMUlPOXllQjRrUDdYM1BsMXU1RzVcbjZjS1U5UFhTK01vdEFDa1A4a25kdUE9PVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuIiwKICAiY2xpZW50X2VtYWlsIjogImdzYi1iaW5kaW5nLWV4MTEwMzgyQGpsZXdpc2lpaS1nc2IuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLAogICJjbGllbnRfaWQiOiAiMTA1MTQwOTYyMjgzMzM4MTAwMDQ0IiwKICAiYXV0aF91cmkiOiAiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tL28vb2F1dGgyL2F1dGgiLAogICJ0b2tlbl91cmkiOiAiaHR0cHM6Ly9vYXV0aDIuZ29vZ2xlYXBpcy5jb20vdG9rZW4iLAogICJhdXRoX3Byb3ZpZGVyX3g1MDlfY2VydF91cmwiOiAiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vb2F1dGgyL3YxL2NlcnRzIiwKICAiY2xpZW50X3g1MDlfY2VydF91cmwiOiAiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vcm9ib3QvdjEvbWV0YWRhdGEveDUwOS9nc2ItYmluZGluZy1leDExMDM4MiU0MGpsZXdpc2lpaS1nc2IuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iCn0K\",\"ProjectId\":\"jlewisiii-gsb\",\"UniqueId\":\"105140962283338100044\",\"host\":\"10.0.0.3\",\"memory_size_gb\":4,\"port\":\"6379\",\"redis_version\":\"REDIS_4_0\"}}\n"
2019/06/21 12:12:33 Unbinding google-memorystore-redis/Basic Redis Configuration
2019/06/21 12:12:34 DELETE http://user:pass@localhost:8000/v2/service_instances/ex1103823129/service_bindings/ex1103823129?service_id=3ea92b54-838c-4fe1-b75d-9bda513380aa&plan_id=dd1923b6-ac26-4697-83d6-b3a0c05c2c94 -> 200, "{}\n"
2019/06/21 12:12:34 Deprovisioning google-memorystore-redis/Basic Redis Configuration
2019/06/21 12:14:54 DELETE http://user:pass@localhost:8000/v2/service_instances/ex1103823129?accepts_incomplete=true&service_id=3ea92b54-838c-4fe1-b75d-9bda513380aa&plan_id=dd1923b6-ac26-4697-83d6-b3a0c05c2c94 -> 200, "{}\n"
2019/06/21 12:14:54 Cleaning up the environment
2019/06/21 12:14:54 Unbinding google-memorystore-redis/Basic Redis Configuration
2019/06/21 12:14:54 DELETE http://user:pass@localhost:8000/v2/service_instances/ex1103823129/service_bindings/ex1103823129?service_id=3ea92b54-838c-4fe1-b75d-9bda513380aa&plan_id=dd1923b6-ac26-4697-83d6-b3a0c05c2c94 -> 410, "{}\n"
2019/06/21 12:14:54 Deprovisioning google-memorystore-redis/Basic Redis Configuration
2019/06/21 12:14:54 DELETE http://user:pass@localhost:8000/v2/service_instances/ex1103823129?accepts_incomplete=true&service_id=3ea92b54-838c-4fe1-b75d-9bda513380aa&plan_id=dd1923b6-ac26-4697-83d6-b3a0c05c2c94 -> 410, "{}\n"
2019/06/21 12:14:54 Success

```