### PR TITLE
Refactor RunExample to run self-contained examples

### DIFF
--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -54,7 +54,6 @@ func getAllCompleteServiceExamples(registry broker.BrokerRegistry) ([]CompleteSe
 
 	services := registry.GetAllServices()
 
-	// For all services available in the service broker
 	for _, service := range services {
 		for _, example := range service.Examples {
 			serviceCatalogEntry, err := service.CatalogEntry()

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -39,7 +39,7 @@ func RunExamplesForService(registry broker.BrokerRegistry, client *Client, servi
 		return err
 	}
 
-	for _, completeServiceExample := range getMatchingServiceExamples(allExamples, serviceName, exampleName) {
+	for _, completeServiceExample := range filterMatchingServiceExamples(allExamples, serviceName, exampleName) {
 		if err := RunExample(client, completeServiceExample); err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func getAllCompleteServiceExamples(registry broker.BrokerRegistry) ([]CompleteSe
 // Do not run example if:
 // 1. The service name is specified and does not match the current example's ServiceName
 // 2. The service name is specified and matches the current example's ServiceName, and the example name is specified and does not match the current example's ExampleName
-func getMatchingServiceExamples(allExamples []CompleteServiceExample, serviceName, exampleName string) []CompleteServiceExample {
+func filterMatchingServiceExamples(allExamples []CompleteServiceExample, serviceName, exampleName string) []CompleteServiceExample {
 	var matchingExamples []CompleteServiceExample
 
 	for _, completeServiceExample := range allExamples {

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pivotal-cf/brokerapi"
 )
 
-// RunExamplesForService runs all the exmaples for a given service name against
+// RunExamplesForService runs all the examples for a given service name against
 // the service broker pointed to by client. All examples in the registry get run
 // if serviceName is blank. If exampleName is non-blank then only the example
 // with the given name is run.
@@ -45,7 +45,19 @@ func RunExamplesForService(registry broker.BrokerRegistry, client *Client, servi
 				continue
 			}
 
-			if err := RunExample(client, example, service); err != nil {
+			serviceCatalogEntry, err := service.CatalogEntry()
+			if err != nil {
+				return err
+			}
+
+			var completeServiceExample = CompleteServiceExample{
+				Example:                    example,
+				ServiceId:                  serviceCatalogEntry.ID,
+				ServiceName:                service.Name,
+				ServiceBindOutputVariables: service.BindOutputVariables,
+			}
+
+			if err := RunExample(client, completeServiceExample); err != nil {
 				return err
 			}
 		}
@@ -55,10 +67,17 @@ func RunExamplesForService(registry broker.BrokerRegistry, client *Client, servi
 
 }
 
+type CompleteServiceExample struct {
+	Example                    broker.ServiceExample   `json: "service_example"`
+	ServiceName                string                  `json: "service_name"`
+	ServiceId                  string                  `json: "service_id"`
+	ServiceBindOutputVariables []broker.BrokerVariable `json: "broker_variables"`
+}
+
 // RunExample runs a single example against the given service on the broker
 // pointed to by client.
-func RunExample(client *Client, example broker.ServiceExample, service *broker.ServiceDefinition) error {
-	executor, err := newExampleExecutor(client, example, service)
+func RunExample(client *Client, serviceExample CompleteServiceExample) error {
+	executor, err := newExampleExecutor(client, serviceExample)
 	if err != nil {
 		return err
 	}
@@ -97,7 +116,7 @@ func RunExample(client *Client, example broker.ServiceExample, service *broker.S
 	}
 
 	credentialsEntry := binding.Credentials.(map[string]interface{})
-	if err := broker.ValidateVariables(credentialsEntry, service.BindOutputVariables); err != nil {
+	if err := broker.ValidateVariables(credentialsEntry, serviceExample.ServiceBindOutputVariables); err != nil {
 		log.Printf("Error: results don't match JSON Schema: %v", err)
 		return err
 	}
@@ -157,18 +176,13 @@ func pollUntilFinished(client *Client, instanceId string) error {
 	})
 }
 
-func newExampleExecutor(client *Client, example broker.ServiceExample, service *broker.ServiceDefinition) (*exampleExecutor, error) {
-	provisionParams, err := json.Marshal(example.ProvisionParams)
+func newExampleExecutor(client *Client, serviceExample CompleteServiceExample) (*exampleExecutor, error) {
+	provisionParams, err := json.Marshal(serviceExample.Example.ProvisionParams)
 	if err != nil {
 		return nil, err
 	}
 
-	bindParams, err := json.Marshal(example.BindParams)
-	if err != nil {
-		return nil, err
-	}
-
-	catalog, err := service.CatalogEntry()
+	bindParams, err := json.Marshal(serviceExample.Example.BindParams)
 	if err != nil {
 		return nil, err
 	}
@@ -176,9 +190,9 @@ func newExampleExecutor(client *Client, example broker.ServiceExample, service *
 	testid := rand.Uint32()
 
 	return &exampleExecutor{
-		Name:       fmt.Sprintf("%s/%s", service.Name, example.Name),
-		ServiceId:  catalog.ID,
-		PlanId:     example.PlanId,
+		Name:       fmt.Sprintf("%s/%s", serviceExample.ServiceName, serviceExample.Example.Name),
+		ServiceId:  serviceExample.ServiceId,
+		PlanId:     serviceExample.Example.PlanId,
 		InstanceId: fmt.Sprintf("ex%d", testid),
 		BindingId:  fmt.Sprintf("ex%d", testid),
 

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -39,7 +39,14 @@ func RunExamplesForService(registry broker.BrokerRegistry, client *Client, servi
 		return err
 	}
 
-	return runMatchingServiceExamples(client, allExamples, serviceName, exampleName)
+	for _, completeServiceExample := range getMatchingServiceExamples(allExamples, serviceName, exampleName) {
+		if err := RunExample(client, completeServiceExample); err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }
 
 type CompleteServiceExample struct {
@@ -82,19 +89,19 @@ func getAllCompleteServiceExamples(registry broker.BrokerRegistry) ([]CompleteSe
 // Do not run example if:
 // 1. The service name is specified and does not match the current example's ServiceName
 // 2. The service name is specified and matches the current example's ServiceName, and the example name is specified and does not match the current example's ExampleName
-func runMatchingServiceExamples(client *Client, allExamples []CompleteServiceExample, serviceName, exampleName string) error {
+func getMatchingServiceExamples(allExamples []CompleteServiceExample, serviceName, exampleName string) []CompleteServiceExample {
+	var matchingExamples []CompleteServiceExample
+
 	for _, completeServiceExample := range allExamples {
 
 		if (serviceName != "" && serviceName != completeServiceExample.ServiceName) || (serviceName != "" && exampleName != "" && exampleName != completeServiceExample.Example.Name) {
 			continue
 		}
 
-		if err := RunExample(client, completeServiceExample); err != nil {
-			return err
-		}
+		matchingExamples = append(matchingExamples, completeServiceExample)
 	}
 
-	return nil
+	return matchingExamples
 }
 
 // RunExample runs a single example against the given service on the broker

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -51,10 +51,10 @@ func RunExamplesForService(registry broker.BrokerRegistry, client *Client, servi
 			}
 
 			var completeServiceExample = CompleteServiceExample{
-				Example:                    example,
-				ServiceId:                  serviceCatalogEntry.ID,
-				ServiceName:                service.Name,
-				ServiceBindOutputVariables: service.BindOutputVariables,
+				Example:        example,
+				ServiceId:      serviceCatalogEntry.ID,
+				ServiceName:    service.Name,
+				ExpectedOutput: service.BindOutputVariables,
 			}
 
 			if err := RunExample(client, completeServiceExample); err != nil {
@@ -68,10 +68,10 @@ func RunExamplesForService(registry broker.BrokerRegistry, client *Client, servi
 }
 
 type CompleteServiceExample struct {
-	Example                    broker.ServiceExample   `json: "service_example"`
-	ServiceName                string                  `json: "service_name"`
-	ServiceId                  string                  `json: "service_id"`
-	ServiceBindOutputVariables []broker.BrokerVariable `json: "broker_variables"`
+	Example        broker.ServiceExample   `json: "service_example, inline"`
+	ServiceName    string                  `json: "service_name, inline"`
+	ServiceId      string                  `json: "service_id, inline"`
+	ExpectedOutput []broker.BrokerVariable `json: "broker_variables, inline"`
 }
 
 // RunExample runs a single example against the given service on the broker
@@ -116,7 +116,7 @@ func RunExample(client *Client, serviceExample CompleteServiceExample) error {
 	}
 
 	credentialsEntry := binding.Credentials.(map[string]interface{})
-	if err := broker.ValidateVariables(credentialsEntry, serviceExample.ServiceBindOutputVariables); err != nil {
+	if err := broker.ValidateVariables(credentialsEntry, serviceExample.ExpectedOutput); err != nil {
 		log.Printf("Error: results don't match JSON Schema: %v", err)
 		return err
 	}

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"math/rand"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
@@ -73,15 +74,20 @@ func getAllCompleteServiceExamples(registry broker.BrokerRegistry) ([]CompleteSe
 				ServiceId:      serviceCatalogEntry.ID,
 				ServiceName:    service.Name,
 				ExpectedOutput: service.BindOutputVariables,
-
 			}
 
 			allExamples = append(allExamples, completeServiceExample)
 		}
 	}
 
-	// Sort by name so there's a consistent order in the UI and tests.
-	sort.Slice(allExamples, func(i int, j int) bool { return allExamples[i].ServiceName < allExamples[j].ServiceName })
+	// Sort by ServiceName and ExampleName so there's a consistent order in the UI and tests.
+	sort.Slice(allExamples, func(i int, j int) bool {
+		if strings.Compare(allExamples[i].ServiceName, allExamples[j].ServiceName) != 0 {
+			return allExamples[i].ServiceName < allExamples[j].ServiceName
+		} else {
+			return allExamples[i].Example.Name < allExamples[j].Example.Name
+		}
+	})
 
 	return allExamples, nil
 }

--- a/pkg/client/example-runner_test.go
+++ b/pkg/client/example-runner_test.go
@@ -1,0 +1,1 @@
+package client

--- a/pkg/client/example-runner_test.go
+++ b/pkg/client/example-runner_test.go
@@ -1,1 +1,347 @@
 package client
+
+import (
+	"fmt"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
+	"reflect"
+	"testing"
+)
+
+func ExampleGetAllCompleteServiceExamples() {
+	allServiceExamples, err := GetAllCompleteServiceExamples(builtin.BuiltinBrokerRegistry())
+	fmt.Println(allServiceExamples != nil)
+	fmt.Println(err)
+	// Output:
+	// true
+	// <nil>
+}
+
+func TestGetExamplesForAService(t *testing.T) {
+	cases := map[string]struct {
+		ServiceDefinition *broker.ServiceDefinition
+		ExpectedResponse  []CompleteServiceExample
+		ExpectedError     error
+	}{
+		"service with no examples": {
+			ServiceDefinition: &broker.ServiceDefinition{
+				Id: "TestService",
+			},
+			ExpectedResponse: []CompleteServiceExample(nil),
+			ExpectedError:    nil,
+		},
+		"google-stackdriver-debugger": {
+			ServiceDefinition: &broker.ServiceDefinition{
+				Id:   "83837945-1547-41e0-b661-ea31d76eed11",
+				Name: "google-stackdriver-debugger",
+				BindOutputVariables: []broker.BrokerVariable{
+					{
+						Required:  true,
+						FieldName: "Email",
+						Type:      "string",
+						Details:   "Email address of the service account.",
+					},
+				},
+				Examples: []broker.ServiceExample{
+					{
+						Name:            "Basic Configuration",
+						Description:     "Creates an account with the permission `clouddebugger.agent`.",
+						PlanId:          "10866183-a775-49e8-96e3-4e7a901e4a79",
+						ProvisionParams: map[string]interface{}{},
+						BindParams:      map[string]interface{}{},
+					},
+				},
+			},
+			ExpectedResponse: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Basic Configuration",
+						Description:     "Creates an account with the permission `clouddebugger.agent`.",
+						PlanId:          "10866183-a775-49e8-96e3-4e7a901e4a79",
+						ProvisionParams: map[string]interface{}{},
+						BindParams:      map[string]interface{}{}},
+					ServiceName: "google-stackdriver-debugger",
+					ServiceId:   "83837945-1547-41e0-b661-ea31d76eed11",
+					ExpectedOutput: []broker.BrokerVariable{
+						{
+							Required:  true,
+							FieldName: "Email",
+							Type:      "string",
+							Details:   "Email address of the service account.",
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+		"google-dataflow": {
+			ServiceDefinition: &broker.ServiceDefinition{
+				Id:   "3e897eb3-9062-4966-bd4f-85bda0f73b3d",
+				Name: "google-dataflow",
+				BindOutputVariables: []broker.BrokerVariable{
+					{
+						Required:  true,
+						FieldName: "Email",
+						Type:      "string",
+						Details:   "Email address of the service account.",
+					},
+					{
+						Required:  true,
+						FieldName: "Name",
+						Type:      "string",
+						Details:   "The name of the service account.",
+					},
+				},
+				Examples: []broker.ServiceExample{
+					{
+						Name:            "Developer",
+						Description:     "Creates a Dataflow user and grants it permission to create, drain and cancel jobs.",
+						PlanId:          "8e956dd6-8c0f-470c-9a11-065537d81872",
+						ProvisionParams: map[string]interface{}{},
+						BindParams:      map[string]interface{}{},
+					},
+					{
+						Name:            "Viewer",
+						Description:     "Creates a Dataflow user and grants it permission to create, drain and cancel jobs.",
+						PlanId:          "8e956dd6-8c0f-470c-9a11-065537d81872",
+						ProvisionParams: map[string]interface{}{},
+						BindParams:      map[string]interface{}{"role": "dataflow.viewer"},
+					},
+				},
+			},
+			ExpectedResponse: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Developer",
+						Description:     "Creates a Dataflow user and grants it permission to create, drain and cancel jobs.",
+						PlanId:          "8e956dd6-8c0f-470c-9a11-065537d81872",
+						ProvisionParams: map[string]interface{}{},
+						BindParams:      map[string]interface{}{},
+					},
+					ServiceName: "google-dataflow",
+					ServiceId:   "3e897eb3-9062-4966-bd4f-85bda0f73b3d",
+					ExpectedOutput: []broker.BrokerVariable{
+						{
+							Required:  true,
+							FieldName: "Email",
+							Type:      "string",
+							Details:   "Email address of the service account.",
+						},
+						{
+							Required:  true,
+							FieldName: "Name",
+							Type:      "string",
+							Details:   "The name of the service account.",
+						},
+					},
+				},
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Viewer",
+						Description:     "Creates a Dataflow user and grants it permission to create, drain and cancel jobs.",
+						PlanId:          "8e956dd6-8c0f-470c-9a11-065537d81872",
+						ProvisionParams: map[string]interface{}{},
+						BindParams:      map[string]interface{}{"role": "dataflow.viewer"},
+					},
+					ServiceName: "google-dataflow",
+					ServiceId:   "3e897eb3-9062-4966-bd4f-85bda0f73b3d",
+					ExpectedOutput: []broker.BrokerVariable{
+						{
+							Required:  true,
+							FieldName: "Email",
+							Type:      "string",
+							Details:   "Email address of the service account.",
+						},
+						{
+							Required:  true,
+							FieldName: "Name",
+							Type:      "string",
+							Details:   "The name of the service account.",
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual, err := GetExamplesForAService(tc.ServiceDefinition)
+			expectError(t, tc.ExpectedError, err)
+			if !reflect.DeepEqual(tc.ExpectedResponse, actual) {
+				t.Errorf("Expected: %v got %v", tc.ExpectedResponse, actual)
+			}
+		})
+	}
+}
+
+func expectError(t *testing.T, expected, actual error) {
+	t.Helper()
+	expectedErr := expected != nil
+	gotErr := actual != nil
+
+	switch {
+	case expectedErr && gotErr:
+		if expected.Error() != actual.Error() {
+			t.Fatalf("Expected: %v, got: %v", expected, actual)
+		}
+	case expectedErr && !gotErr:
+		t.Fatalf("Expected: %v, got: %v", expected, actual)
+	case !expectedErr && gotErr:
+		t.Fatalf("Expected no error but got: %v", actual)
+	}
+}
+
+func TestFilterMatchingServiceExamples(t *testing.T) {
+	cases := map[string]struct {
+		ServiceExamples []CompleteServiceExample
+		ServiceName     string
+		ExampleName     string
+		Response        []CompleteServiceExample
+	}{
+		"No ServiceName or ExampleName specified.": {
+			ServiceExamples: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Foo",
+					},
+					ServiceName: "Service-Foo",
+				},
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Bar",
+					},
+					ServiceName: "Service-Bar",
+				},
+			},
+			ServiceName: "",
+			ExampleName: "",
+			Response: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Foo",
+					},
+					ServiceName: "Service-Foo",
+				},
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Bar",
+					},
+					ServiceName: "Service-Bar",
+				},
+			},
+		},
+		"ServiceName is specified, no ExampleName is specified. No matching CompleteServiceExample exists": {
+			ServiceExamples: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Foo",
+					},
+					ServiceName: "Service-Foo",
+				},
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Bar",
+					},
+					ServiceName: "Service-Bar",
+				},
+			},
+			ServiceName: "Service-Unicorn",
+			ExampleName: "",
+			Response: []CompleteServiceExample(nil),
+		},
+		"ServiceName is specified, no ExampleName is specified. Two matching CompleteServiceExample exist": {
+			ServiceExamples: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Foo",
+					},
+					ServiceName: "Service-Foo",
+				},
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Bar",
+					},
+					ServiceName: "Service-Bar",
+				},
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-FooBar",
+					},
+					ServiceName: "Service-Bar",
+				},
+			},
+			ServiceName: "Service-Bar",
+			ExampleName: "",
+			Response: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Bar",
+					},
+					ServiceName: "Service-Bar",
+				},
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-FooBar",
+					},
+					ServiceName: "Service-Bar",
+				},
+			},
+		},
+		"Both ServiceName and ExampleName are provided, but no matching CompleteServiceExample exists.": {
+			ServiceExamples: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Foo",
+					},
+					ServiceName: "Service-Foo",
+				},
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Bar",
+					},
+					ServiceName: "Service-Bar",
+				},
+			},
+			ServiceName: "Service-Bar",
+			ExampleName: "Example-Hello",
+			Response: []CompleteServiceExample(nil),
+		},
+		"Both ServiceName and ExampleName are provided, one matching CompleteServiceExample exists.": {
+			ServiceExamples: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Foo",
+					},
+					ServiceName: "Service-Foo",
+				},
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Bar",
+					},
+					ServiceName: "Service-Bar",
+				},
+			},
+			ServiceName: "Service-Bar",
+			ExampleName: "Example-Bar",
+			Response: []CompleteServiceExample{
+				{
+					ServiceExample: broker.ServiceExample{
+						Name:            "Example-Bar",
+					},
+					ServiceName: "Service-Bar",
+				},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual := FilterMatchingServiceExamples(tc.ServiceExamples, tc.ServiceName, tc.ExampleName)
+			if !reflect.DeepEqual(tc.Response, actual) {
+				t.Errorf("Expected: %v got %v", tc.Response, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit resolves #484 

Testing:
- Added example function for `GetAllCompleteServiceExamples` that serves as a sanity check to make sure the function runs error-free, and returns a non-nil array of `CompleteServiceExamples` given the builtin registry.
- Added unit tests to `GetExamplesForAService`, to make sure we could get valid `CompleteServiceExamples` given a `ServiceDefinition`
- Added unit tests for the logic in `FilterMatchingServiceExamples`