### PR TITLE
Set provision_details column type to text

### DIFF
--- a/db_service/models/historical_db.go
+++ b/db_service/models/historical_db.go
@@ -114,7 +114,7 @@ type ProvisionRequestDetailsV1 struct {
 
 	ServiceInstanceId string
 	// is a json.Marshal of models.ProvisionDetails
-	RequestDetails string
+	RequestDetails string `gorm:"type:text"`
 }
 
 // TableName returns a consistent table name (`provision_request_details`) for


### PR DESCRIPTION
The RequestDetails must be bigger than default 255 varchar for classes with many provisioning parameters like PostgreSQL.

Fixes: https://github.com/GoogleCloudPlatform/gcp-service-broker/issues/500