### PR TITLE
 Add new /examples endpoint that returns array of CompleteServiceExamples

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -108,6 +108,7 @@ func serve() {
 	brokerAPI := brokerapi.New(serviceBroker, logger, credentials)
 	http.Handle("/", brokerAPI)
 	http.Handle("/docs", server.NewDocsHandler(cfg.Registry))
+	http.Handle("/examples", server.NewExampleHandler(cfg.Registry))
 	http.ListenAndServe(":"+port, nil)
 }
 
@@ -128,5 +129,6 @@ func serveDocs() {
 
 	http.Handle("/", server.NewDocsHandler(registry))
 	http.Handle("/docs", server.NewDocsHandler(registry))
+	http.Handle("/examples", server.NewExampleHandler(registry))
 	http.ListenAndServe(":"+port, nil)
 }

--- a/pkg/server/examples.go
+++ b/pkg/server/examples.go
@@ -1,0 +1,46 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/client"
+)
+
+func NewExampleHandler(registry broker.BrokerRegistry) http.HandlerFunc {
+	allExamples, err := client.GetAllCompleteServiceExamples(registry)
+	if err != nil {
+		return func(w http.ResponseWriter, rep *http.Request) {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+
+	json, err := json.Marshal(allExamples)
+
+	if err != nil {
+		return func(w http.ResponseWriter, rep *http.Request) {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(json)
+	}
+}

--- a/pkg/server/examples.go
+++ b/pkg/server/examples.go
@@ -30,7 +30,7 @@ func NewExampleHandler(registry broker.BrokerRegistry) http.HandlerFunc {
 		}
 	}
 
-	json, err := json.Marshal(allExamples)
+	exampleJSON, err := json.Marshal(allExamples)
 
 	if err != nil {
 		return func(w http.ResponseWriter, rep *http.Request) {
@@ -41,6 +41,6 @@ func NewExampleHandler(registry broker.BrokerRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(json)
+		w.Write(exampleJSON)
 	}
 }

--- a/pkg/server/examples_test.go
+++ b/pkg/server/examples_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 the Service Broker Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/client"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
+)
+
+func TestNewExampleHandler(t *testing.T) {
+	registry := builtin.BuiltinBrokerRegistry()
+
+	// Validate that the handler returns the correct Content-Type
+	handler := NewExampleHandler(registry)
+	request := httptest.NewRequest(http.MethodGet, "/examples", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, request)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected response code: %d got: %d", http.StatusOK, w.Code)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("Expected application/json content type got: %q", contentType)
+	}
+
+	body := w.Body.Bytes()
+	var allExamples []client.CompleteServiceExample
+
+	err := json.Unmarshal(body, &allExamples)
+	if err != nil {
+		t.Errorf("Error unmarshalling json data: %q", err)
+	}
+
+}

--- a/pkg/server/examples_test.go
+++ b/pkg/server/examples_test.go
@@ -43,6 +43,7 @@ func TestNewExampleHandler(t *testing.T) {
 		t.Errorf("Expected application/json content type got: %q", contentType)
 	}
 
+	// Validate that the results can be unmarshalled to a CompleteServiceExamples type
 	body := w.Body.Bytes()
 	var allExamples []client.CompleteServiceExample
 


### PR DESCRIPTION
This commit partly resolves #492 