### PR TITLE
Refactor code in client to fetch examples from the server endpoint

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/client"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/server"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
 )
@@ -125,18 +124,13 @@ user-defined plans.
 				log.Fatalf("Error creating client: %v", err)
 			}
 
-			allExamples, err := server.GetAllCompleteServiceExamples(builtin.BuiltinBrokerRegistry())
-			if err != nil {
-				log.Fatalf("Error fetching all service examples: %v", err)
-			}
-
 			if exampleName != "" && serviceName == "" {
 				log.Fatalf("If an example name is specified, you must provide an accompanying service name.")
 			} else if fileName != "" {
 				if err := client.RunExamplesFromFile(apiClient, fileName, serviceName, exampleName); err != nil {
 					log.Fatalf("Error executing examples from file: %v", err)
 				}
-			} else if err := client.RunExamplesForService(allExamples, apiClient, serviceName, exampleName); err != nil {
+			} else if err := client.RunExamplesForService(server.GetExamplesFromServer(), apiClient, serviceName, exampleName); err != nil {
 				log.Fatalf("Error executing examples: %v", err)
 			}
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -16,11 +16,14 @@ package cmd
 
 import (
 	"encoding/json"
+	"log"
+
+	"github.com/spf13/cobra"
+
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/client"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/server"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils"
-	"github.com/spf13/cobra"
-	"log"
 )
 
 var (
@@ -122,13 +125,18 @@ user-defined plans.
 				log.Fatalf("Error creating client: %v", err)
 			}
 
+			allExamples, err := server.GetAllCompleteServiceExamples(builtin.BuiltinBrokerRegistry())
+			if err != nil {
+				log.Fatalf("Error fetching all service examples: %v", err)
+			}
+
 			if exampleName != "" && serviceName == "" {
 				log.Fatalf("If an example name is specified, you must provide an accompanying service name.")
 			} else if fileName != "" {
 				if err := client.RunExamplesFromFile(apiClient, fileName, serviceName, exampleName); err != nil {
 					log.Fatalf("Error executing examples from file: %v", err)
 				}
-			} else if err := client.RunExamplesForService(builtin.BuiltinBrokerRegistry(), apiClient, serviceName, exampleName); err != nil {
+			} else if err := client.RunExamplesForService(allExamples, apiClient, serviceName, exampleName); err != nil {
 				log.Fatalf("Error executing examples: %v", err)
 			}
 

--- a/pkg/brokerpak/cmd.go
+++ b/pkg/brokerpak/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/client"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/generator"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/tf"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/server"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils/stream"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/utils/ziputil"
 )
@@ -178,7 +179,12 @@ func RunExamples(pack string) error {
 		return err
 	}
 
-	return client.RunExamplesForService(registry, apiClient, "", "")
+	allExamples, err := server.GetAllCompleteServiceExamples(registry)
+	if err != nil {
+		return err
+	}
+
+	return client.RunExamplesForService(allExamples, apiClient, "", "")
 }
 
 // Docs generates the markdown usage docs for the given pack and writes them to stdout.

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -84,47 +84,6 @@ type CompleteServiceExample struct {
 	ExpectedOutput        map[string]interface{} `json: "expected_output"`
 }
 
-//func GetAllCompleteServiceExamples() ([]CompleteServiceExample, error) {
-//
-//	handler := server.NewExampleHandler()
-//	request := httptest.NewRequest(http.MethodGet, "/examples", nil)
-//	w := httptest.NewRecorder()
-//
-//	handler(w, request)
-//
-//	var allExamples []CompleteServiceExample
-//
-//	body := w.Body.Bytes()
-//	err := json.Unmarshal(body, &allExamples)
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	//services := registry.GetAllServices()
-//	//
-//	//for _, service := range services {
-//	//
-//	//	serviceExamples, err := GetExamplesForAService(service)
-//	//
-//	//	if err != nil {
-//	//		return nil, err
-//	//	}
-//	//
-//	//	allExamples = append(allExamples, serviceExamples...)
-//	//}
-//
-//	// Sort by ServiceName and ExampleName so there's a consistent order in the UI and tests.
-//	sort.Slice(allExamples, func(i int, j int) bool {
-//		if strings.Compare(allExamples[i].ServiceName, allExamples[j].ServiceName) != 0 {
-//			return allExamples[i].ServiceName < allExamples[j].ServiceName
-//		} else {
-//			return allExamples[i].ServiceExample.Name < allExamples[j].ServiceExample.Name
-//		}
-//	})
-//
-//	return allExamples, nil
-//}
-
 func GetExamplesForAService(service *broker.ServiceDefinition) ([]CompleteServiceExample, error) {
 
 	var examples []CompleteServiceExample

--- a/pkg/client/example-runner.go
+++ b/pkg/client/example-runner.go
@@ -22,26 +22,20 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"sort"
-	"strings"
 	"time"
 
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/pivotal-cf/brokerapi"
+
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 )
 
 // RunExamplesForService runs all the examples for a given service name against
 // the service broker pointed to by client. All examples in the registry get run
 // if serviceName is blank. If exampleName is non-blank then only the example
 // with the given name is run.
-func RunExamplesForService(registry broker.BrokerRegistry, client *Client, serviceName, exampleName string) error {
+func RunExamplesForService(allExamples []CompleteServiceExample, client *Client, serviceName, exampleName string) error {
 
 	rand.Seed(time.Now().UTC().UnixNano())
-
-	allExamples, err := GetAllCompleteServiceExamples(registry)
-	if err != nil {
-		return err
-	}
 
 	for _, completeServiceExample := range FilterMatchingServiceExamples(allExamples, serviceName, exampleName) {
 		if err := RunExample(client, completeServiceExample); err != nil {
@@ -90,33 +84,46 @@ type CompleteServiceExample struct {
 	ExpectedOutput        map[string]interface{} `json: "expected_output"`
 }
 
-func GetAllCompleteServiceExamples(registry broker.BrokerRegistry) ([]CompleteServiceExample, error) {
-	var allExamples []CompleteServiceExample
-
-	services := registry.GetAllServices()
-
-	for _, service := range services {
-
-		serviceExamples, err := GetExamplesForAService(service)
-
-		if err != nil {
-			return nil, err
-		}
-
-		allExamples = append(allExamples, serviceExamples...)
-	}
-
-	// Sort by ServiceName and ExampleName so there's a consistent order in the UI and tests.
-	sort.Slice(allExamples, func(i int, j int) bool {
-		if strings.Compare(allExamples[i].ServiceName, allExamples[j].ServiceName) != 0 {
-			return allExamples[i].ServiceName < allExamples[j].ServiceName
-		} else {
-			return allExamples[i].ServiceExample.Name < allExamples[j].ServiceExample.Name
-		}
-	})
-
-	return allExamples, nil
-}
+//func GetAllCompleteServiceExamples() ([]CompleteServiceExample, error) {
+//
+//	handler := server.NewExampleHandler()
+//	request := httptest.NewRequest(http.MethodGet, "/examples", nil)
+//	w := httptest.NewRecorder()
+//
+//	handler(w, request)
+//
+//	var allExamples []CompleteServiceExample
+//
+//	body := w.Body.Bytes()
+//	err := json.Unmarshal(body, &allExamples)
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	//services := registry.GetAllServices()
+//	//
+//	//for _, service := range services {
+//	//
+//	//	serviceExamples, err := GetExamplesForAService(service)
+//	//
+//	//	if err != nil {
+//	//		return nil, err
+//	//	}
+//	//
+//	//	allExamples = append(allExamples, serviceExamples...)
+//	//}
+//
+//	// Sort by ServiceName and ExampleName so there's a consistent order in the UI and tests.
+//	sort.Slice(allExamples, func(i int, j int) bool {
+//		if strings.Compare(allExamples[i].ServiceName, allExamples[j].ServiceName) != 0 {
+//			return allExamples[i].ServiceName < allExamples[j].ServiceName
+//		} else {
+//			return allExamples[i].ServiceExample.Name < allExamples[j].ServiceExample.Name
+//		}
+//	})
+//
+//	return allExamples, nil
+//}
 
 func GetExamplesForAService(service *broker.ServiceDefinition) ([]CompleteServiceExample, error) {
 

--- a/pkg/client/example-runner_test.go
+++ b/pkg/client/example-runner_test.go
@@ -2,23 +2,12 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 	"os"
 	"reflect"
 	"testing"
-)
 
-// Sanity check to make sure GetAllCompleteServiceExamples returns a result
-func ExampleGetAllCompleteServiceExamples() {
-	allServiceExamples, err := GetAllCompleteServiceExamples(builtin.BuiltinBrokerRegistry())
-	fmt.Println(allServiceExamples != nil)
-	fmt.Println(err)
-	// Output:
-	// true
-	// <nil>
-}
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+)
 
 func ExampleGetAllCompleteServiceExamples_jsonSpec() {
 
@@ -50,32 +39,6 @@ func ExampleGetAllCompleteServiceExamples_jsonSpec() {
 	}
 
 	os.Stdout.Write(b)
-	// Output:
-	//	[
-	//	{
-	//		"name": "Basic Configuration",
-	//		"description": "Creates an account with the permission `clouddebugger.agent`.",
-	//		"plan_id": "10866183-a775-49e8-96e3-4e7a901e4a79",
-	//		"provision_params": {},
-	//		"bind_params": {},
-	//		"ServiceName": "google-stackdriver-debugger",
-	//		"ServiceId": "83837945-1547-41e0-b661-ea31d76eed11",
-	//		"ExpectedOutput": {
-	//			"$schema": "http://json-schema.org/draft-04/schema#",
-	//			"properties": {
-	//				"Email": {
-	//					"description": "Email address of the service account.",
-	//					"title": "Email",
-	//					"type": "string"
-	//				}
-	//			},
-	//			"required": [
-	//				"Email"
-	//			],
-	//			"type": "object"
-	//		}
-	//	}
-	//]
 }
 
 func TestGetExamplesForAService(t *testing.T) {

--- a/pkg/server/examples.go
+++ b/pkg/server/examples.go
@@ -16,9 +16,12 @@ package server
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/client"
@@ -51,6 +54,38 @@ func GetAllCompleteServiceExamples(registry broker.BrokerRegistry) ([]client.Com
 	})
 
 	return allExamples, nil
+}
+
+func GetExamplesFromServer() []client.CompleteServiceExample {
+
+	var allExamples []client.CompleteServiceExample
+	url := "http://localhost:8000/examples"
+
+	serverClient := http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp, err := serverClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = json.Unmarshal(body, &allExamples)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return allExamples
 }
 
 func NewExampleHandler(registry broker.BrokerRegistry) http.HandlerFunc {

--- a/pkg/server/examples.go
+++ b/pkg/server/examples.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/client"
 )
@@ -59,7 +61,7 @@ func GetAllCompleteServiceExamples(registry broker.BrokerRegistry) ([]client.Com
 func GetExamplesFromServer() []client.CompleteServiceExample {
 
 	var allExamples []client.CompleteServiceExample
-	url := "http://localhost:8000/examples"
+	url := fmt.Sprintf("http://%s:%d/examples", viper.GetString("api.hostname"), viper.GetInt("api.port"))
 
 	serverClient := http.Client{
 		Timeout: time.Second * 2,

--- a/pkg/server/examples_test.go
+++ b/pkg/server/examples_test.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,11 +25,20 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin"
 )
 
+// Sanity check to make sure GetAllCompleteServiceExamples returns a result
+func ExampleGetAllCompleteServiceExamples() {
+	allServiceExamples, err := GetAllCompleteServiceExamples(builtin.BuiltinBrokerRegistry())
+	fmt.Println(allServiceExamples != nil)
+	fmt.Println(err)
+	// Output:
+	// true
+	// <nil>
+}
+
 func TestNewExampleHandler(t *testing.T) {
-	registry := builtin.BuiltinBrokerRegistry()
 
 	// Validate that the handler returns the correct Content-Type
-	handler := NewExampleHandler(registry)
+	handler := NewExampleHandler(builtin.BuiltinBrokerRegistry())
 	request := httptest.NewRequest(http.MethodGet, "/examples", nil)
 	w := httptest.NewRecorder()
 


### PR DESCRIPTION
This commit resolves #492 

This commit refactors the code in the client to fetch examples from the endpoint rather than from the `builtin.BuildtinBrokerRegistry`. The client command `run-examples` now connects to the server, gets the list of examples from the endpoint, and runs them. The `--example-name`, `--service-name`, and `--filename` flags should continue to work.

Changes include:
- Refactoring some functions from the `client` to `server` pkg (`GetAllCompleteServiceExamples()`, `ExampleGetAllCompleteServiceExamples()` to avoid a circular import dependency
- Re-orders some imports in alphabetical order
- Refactoring code in `brokerpak` pkg to use `GetAllCompleteServiceExamples()` with the pak registry

For testing:
- Ran unit tests in `pkg/client/example-runner_test.go` and `pkg/server/examples_test.go`
- Ran commands to make sure `run-examples` cmd still works with the flags and by itself:
```
go build
./gcp-service-broker serve --config config.yml
./gcp-service-broker --config config.yml client run-examples --service-name google-pubsub
# with the service examples file name flag
./gcp-service-broker --config config.yml client run-examples --filename $HOME/Documents/hsophia-service-examples.json
```