### PR TITLE
cherrypick #442 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
  - Ability for plans to selectively override user variables.
+ - Ability to get plan information from HIL execution environment on bind.
 
 ## [4.2.3] - 2019-06-12
 

--- a/docs/brokerpak-specification.md
+++ b/docs/brokerpak-specification.md
@@ -333,6 +333,7 @@ This is because they can resolve variables to the user's values first.
 * `request.instance_id` - _string_ The ID of the existing instance to bind to.
 * `request.service_id` - _string_ The GUID of the service this binding is for.
 * `request.plan_id` - _string_ The ID of plan the instance was created with.
+* `request.plan_properties` - _map[string]string_ A map of properties set in the service's plan.
 * `request.app_guid` - _string_ The ID of the application this binding is for.
 * `instance.name` - _string_ The name of the instance.
 * `instance.details` - _map[string]any_ Output variables of the instance as specified by ProvisionOutputVariables.

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -424,7 +424,15 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 		Id:   "00000000-0000-0000-0000-000000000000",
 		Name: "left-handed-smoke-sifter",
 		Plans: []ServicePlan{
-			{ServicePlan: brokerapi.ServicePlan{ID: "builtin-plan", Name: "Builtin!"}},
+			{
+				ServicePlan: brokerapi.ServicePlan{
+					ID:   "builtin-plan",
+					Name: "Builtin!",
+				},
+				ServiceProperties: map[string]string{
+					"service-property": "operator-set",
+				},
+			},
 		},
 		BindInputVariables: []BrokerVariable{
 			{
@@ -452,6 +460,11 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				Default:   `${instance.details["foo"]}`,
 				Overwrite: true,
 			},
+			{
+				Name:      "service-prop",
+				Default:   `${request.plan_properties["service-property"]}`,
+				Overwrite: true,
+			},
 		},
 	}
 
@@ -470,6 +483,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "us",
 				"name":         "name-us",
 				"instance-foo": "",
+				"service-prop": "operator-set",
 			},
 		},
 		"location gets truncated": {
@@ -479,6 +493,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "averylongl",
 				"name":         "name-averylonglocation",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"user location and name": {
@@ -488,6 +503,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "eu",
 				"name":         "foo",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"operator defaults override computed defaults": {
@@ -498,6 +514,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "eu",
 				"name":         "name-eu",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"user values override operator defaults": {
@@ -508,6 +525,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "nz",
 				"name":         "name-nz",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"operator defaults are not evaluated": {
@@ -518,6 +536,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "us",
 				"name":         "foo-${location}",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 		"instance info can get parsed": {
@@ -527,6 +546,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "us",
 				"name":         "name-us",
 				"instance-foo": "bar",
+				"service-prop": "operator-set",
 			},
 		},
 		"invalid-request": {
@@ -542,6 +562,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 				"location":     "eu",
 				"name":         "name-eu",
 				"instance-foo": "default",
+				"service-prop": "operator-set",
 			},
 		},
 	}

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -337,9 +337,10 @@ func (svc *ServiceDefinition) BindVariables(instance models.ServiceInstanceDetai
 		// Note: the value in instance is considered the official record so values
 		// are pulled from there rather than the request. In a future version of OSB
 		// the duplicate sending of fields is likely to be removed.
-		"request.plan_id":    instance.PlanId,
-		"request.service_id": instance.ServiceId,
-		"request.app_guid":   appGuid,
+		"request.plan_id":         instance.PlanId,
+		"request.service_id":      instance.ServiceId,
+		"request.app_guid":        appGuid,
+		"request.plan_properties": plan.GetServiceProperties(),
 
 		// specified by the existing instance
 		"instance.name":    instance.Name,


### PR DESCRIPTION
Already submitted as #442 , just cherrypicking to master

Adds the ability to get values from the plan at binding time. This is going to be used by certain plugins that have noop provisions but do have bindings that need to be configured by operators. The motivating example is IAM, operators should be able to create custom plans that users can use to bind service accounts with various roles but provisioning is undefined on them.

This has three parts:

1. Add plan info to be available under the `request.plan_properties` variable in HIL.
2. Change the Brokerpak loader's definition to work with these variables if they're declared under the BindSettings YAML section via a shim. Previously, no service had needed this so they weren't included as part of the variable resolution lifecycle.
3. Update the tests for these and write a new test for the ToService call which wasn't tested before outside of e2e tests.