### PR TITLE
Fix cloudsql user deletion and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Built Brokerpaks now have a name of `{name}-{version}.brokerpak` as defined by the manifest rather than the name of the parent directory.
 - Services inside Brokerpaks now have a file name that includes their CLI friendly name to help differentiate them.
 - The `pak build` command now includes progress logs.
+- An unbind of a service now fails as early as possible to prevent partial deletions.
 
 ### Added
  - Ability for plans to selectively override user variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix bug that caused SQL users to never be deleted.
+
 ### Changed
 - Built Brokerpaks now have a name of `{name}-{version}.brokerpak` as defined by the manifest rather than the name of the parent directory.
 - Services inside Brokerpaks now have a file name that includes their CLI friendly name to help differentiate them.

--- a/pkg/providers/builtin/cloudsql/sql_account_manager.go
+++ b/pkg/providers/builtin/cloudsql/sql_account_manager.go
@@ -110,6 +110,7 @@ func (broker *CloudSQLBroker) deleteSqlUserAccount(ctx context.Context, binding 
 	for _, user := range userList.Items {
 		if user.Name == creds.Username {
 			hostToDelete = user.Host
+			foundUser = true
 			break
 		}
 	}


### PR DESCRIPTION
@basiszwo and I found two issues when trying to unbind a CloudSQL service instance.

1. When using the CloudSQL Postgres, it is possible that there are database objects depending on the bind-user. So an unbind would fail with the following error:
```
error occurred:
* Error deleting user: googleapi: Error 400: Invalid request: Failed to delete user <USERID>.
Detail: pq: role "<USERID>" cannot be dropped because some objects depend on it.
```
Since the Unbind function is implemented with an error-accumulator, it would still execute the other steps (like deleting the Service Account) and fail afterwards.
This might lead to a state where the binding still exists, but the Service Account is deleted.
In that case, our developers aren't able to connect to the CloudSQL instance on their own anymore.

Our fix causes the unbind process to fail as early as possible so that a partial deletion of the binding is unlikely (but still possible!).

2. The fix for #466 resulted in a bug which causes that no CloudSQL user would be deleted anymore. The variable `foundUser` never represented the actual state of the CloudSQL users.