### PR TITLE
Add migration to modify column type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Ability for plans to selectively override user variables.
  - Ability to get plan information from HIL execution environment on bind.
 
+### Fixed
+
+- "data too long" error for existing service broker installations when passing service provisioning configuration > 255 characters (#468)
+
 ## [4.2.3] - 2019-06-12
 
 ### Fixed

--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-const numMigrations = 6
+const numMigrations = 7
 
 // runs schema migrations on the provided service broker database to get it up to date
 func RunMigrations(db *gorm.DB) error {
@@ -69,6 +69,15 @@ func RunMigrations(db *gorm.DB) error {
 
 	migrations[5] = func() error { // v4.2.3
 		return autoMigrateTables(db, &models.ProvisionRequestDetailsV2{})
+	}
+
+	migrations[6] = func() error { // v4.2.4
+		if db.Dialect().GetName() == "sqlite3" {
+			// sqlite does not support changing column data types
+			return nil
+		} else {
+			return db.Model(&models.ProvisionRequestDetailsV2{}).ModifyColumn("request_details", "text").Error
+		}
 	}
 
 	var lastMigrationNumber = -1


### PR DESCRIPTION
In a previous commit (#bf2000b) the datatype for the column request_details
in the table provision_request_details was changed to text. Unfortunately
this only works for fresh service broker installations as gorm does not
modify the column type for existing columns.

As of this gorm's ModifyColumn has to be used explicitly.