### PR TITLE
Tolerate an empty json hash for VCAP_SERVICES

### DIFF
--- a/db_service/vcap.go
+++ b/db_service/vcap.go
@@ -17,9 +17,10 @@ package db_service
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/viper"
 	"net/url"
 	"os"
+
+	"github.com/spf13/viper"
 )
 
 type VcapService struct {
@@ -35,9 +36,11 @@ type VcapService struct {
 func UseVcapServices() error {
 	vcapData, vcapExists := os.LookupEnv("VCAP_SERVICES")
 
-	if !vcapExists {
+	// CloudFoundry provides an empty VCAP_SERVICES hash by default
+	if !vcapExists || vcapData == "{}" {
 		return nil
 	}
+
 	vcapService, err := ParseVcapServices(vcapData)
 	if err != nil {
 		return fmt.Errorf("Error parsing VCAP_SERVICES: %s", err)


### PR DESCRIPTION
When trying to deploy the service broker as a Pivotal tile or cloud foundry application it is likely to fail (at least while using the old way to provide database credentials).

CloudFoundry by default provides a `VCAP_SERVICES={}` environment variable.

See `system_env_json` [here](https://apidocs.cloudfoundry.org/230/apps/get_app_summary.html):
> environment_json for system variables, **contains vcap_services by default**, a hash containing key/value pairs of the names and information of the services associated with your app.