### PR TITLE
cmd: rename 'buildpacks'

### DIFF
--- a/pkg/generator/pcf-artifacts.go
+++ b/pkg/generator/pcf-artifacts.go
@@ -54,8 +54,7 @@ const (
 applications:
 - name: {{.appName}}
   memory: 1G
-  buildpacks:
-  - {{.buildpack}}
+  buildpack: {{.buildpack}}
   env:
     GOPACKAGENAME: {{.goPackageName}}
     GOVERSION: {{.goVersion}}`


### PR DESCRIPTION
This change renames 'buildpacks' to 'buildpack' and changes its type
from array to single value to work with Pivotal's updated tile.yml
schema.