### PR TITLE
Add enum for regions/zones

### DIFF
--- a/pkg/providers/builtin/bigtable/definition.go
+++ b/pkg/providers/builtin/bigtable/definition.go
@@ -16,9 +16,10 @@ package bigtable
 
 import (
 	"code.cloudfoundry.org/lager"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/base"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	. "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/common"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/pivotal-cf/brokerapi"
 	"golang.org/x/oauth2/jwt"
@@ -100,11 +101,66 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "zone",
 				Type:      broker.JsonTypeString,
 				Details:   "The zone to create the Cloud Bigtable cluster in. Zones that support Bigtable instances are noted on the Cloud Bigtable locations page: https://cloud.google.com/bigtable/docs/locations.",
-				Default:   "us-east1-b",
-				Constraints: validation.NewConstraintBuilder().
-					Pattern("^[A-Za-z][-a-z0-9A-Z]+$").
-					Examples("us-central1-a", "europe-west2-b", "asia-northeast1-a", "australia-southeast1-c").
-					Build(),
+				Default:   UsEast1B.Zone(),
+				Enum: map[interface{}]string{
+					UsCentral1A.Zone():             UsCentral1A.Zone(),
+					UsCentral1B.Zone():             UsCentral1B.Zone(),
+					UsCentral1C.Zone():             UsCentral1C.Zone(),
+					UsCentral1F.Zone():             UsCentral1F.Zone(),
+					UsWest2A.Zone():                UsWest2A.Zone(),
+					UsWest2B.Zone():                UsWest2B.Zone(),
+					UsWest2C.Zone():                UsWest2C.Zone(),
+					UsEast4A.Zone():                UsEast4A.Zone(),
+					UsEast4B.Zone():                UsEast4B.Zone(),
+					UsEast4C.Zone():                UsEast4C.Zone(),
+					UsWest1A.Zone():                UsWest1A.Zone(),
+					UsWest1B.Zone():                UsWest1B.Zone(),
+					UsWest1C.Zone():                UsWest1C.Zone(),
+					UsEast1B.Zone():                UsEast1B.Zone(),
+					UsEast1C.Zone():                UsEast1C.Zone(),
+					UsEast1D.Zone():                UsEast1D.Zone(),
+					NorthamericaNorthEast1A.Zone(): NorthamericaNorthEast1A.Zone(),
+					NorthamericaNorthEast1B.Zone(): NorthamericaNorthEast1B.Zone(),
+					NorthamericaNorthEast1C.Zone(): NorthamericaNorthEast1C.Zone(),
+					SouthAmericaEast1A.Zone():      SouthAmericaEast1A.Zone(),
+					SouthAmericaEast1B.Zone():      SouthAmericaEast1B.Zone(),
+					SouthAmericaEast1C.Zone():      SouthAmericaEast1C.Zone(),
+					EuropeWest1B.Zone():            EuropeWest1B.Zone(),
+					EuropeWest1D.Zone():            EuropeWest1D.Zone(),
+					EuropeNorth1A.Zone():           EuropeNorth1A.Zone(),
+					EuropeNorth1B.Zone():           EuropeNorth1B.Zone(),
+					EuropeNorth1C.Zone():           EuropeNorth1C.Zone(),
+					EuropeWest2A.Zone():            EuropeWest2A.Zone(),
+					EuropeWest2B.Zone():            EuropeWest2B.Zone(),
+					EuropeWest2C.Zone():            EuropeWest2C.Zone(),
+					EuropeWest4A.Zone():            EuropeWest4A.Zone(),
+					EuropeWest4B.Zone():            EuropeWest4B.Zone(),
+					EuropeWest4C.Zone():            EuropeWest4C.Zone(),
+					EuropeWest6A.Zone():            EuropeWest6A.Zone(),
+					EuropeWest6B.Zone():            EuropeWest6B.Zone(),
+					EuropeWest6C.Zone():            EuropeWest6C.Zone(),
+					AsiaSouth1A.Zone():             AsiaSouth1A.Zone(),
+					AsiaSouth1B.Zone():             AsiaSouth1B.Zone(),
+					AsiaSouth1C.Zone():             AsiaSouth1C.Zone(),
+					AsiaSouthEast1A.Zone():         AsiaSouthEast1A.Zone(),
+					AsiaSouthEast1B.Zone():         AsiaSouthEast1B.Zone(),
+					AsiaSouthEast1C.Zone():         AsiaSouthEast1C.Zone(),
+					AsiaEast1A.Zone():              AsiaEast1A.Zone(),
+					AsiaEast1B.Zone():              AsiaEast1B.Zone(),
+					AsiaEast1C.Zone():              AsiaEast1C.Zone(),
+					AsiaEast2A.Zone():              AsiaEast2A.Zone(),
+					AsiaEast2B.Zone():              AsiaEast2B.Zone(),
+					AsiaEast2C.Zone():              AsiaEast2C.Zone(),
+					AsiaNorthEast1A.Zone():         AsiaNorthEast1A.Zone(),
+					AsiaNorthEast1B.Zone():         AsiaNorthEast1B.Zone(),
+					AsiaNorthEast1C.Zone():         AsiaNorthEast1C.Zone(),
+					AsiaNorthEast2A.Zone():         AsiaNorthEast2A.Zone(),
+					AsiaNorthEast2B.Zone():         AsiaNorthEast2B.Zone(),
+					AsiaNorthEast2C.Zone():         AsiaNorthEast2C.Zone(),
+					AustraliaSouthEast1A.Zone():    AustraliaSouthEast1A.Zone(),
+					AustraliaSouthEast1B.Zone():    AustraliaSouthEast1B.Zone(),
+					AustraliaSouthEast1C.Zone():    AustraliaSouthEast1C.Zone(),
+				},
 			},
 		},
 		DefaultRoleWhitelist: roleWhitelist,

--- a/pkg/providers/builtin/cloudsql/common-definition.go
+++ b/pkg/providers/builtin/cloudsql/common-definition.go
@@ -15,8 +15,8 @@
 package cloudsql
 
 import (
-	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 )
@@ -97,16 +97,6 @@ func commonProvisionVariables() []broker.BrokerVariable {
 				Pattern("^[1-9][0-9]+$").
 				MaxLength(5).
 				Examples("10", "500", "10230").
-				Build(),
-		},
-		{
-			FieldName: "region",
-			Type:      broker.JsonTypeString,
-			Details:   "The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases.",
-			Default:   "us-central",
-			Constraints: validation.NewConstraintBuilder().
-				Pattern("^[A-Za-z][-a-z0-9A-Z]+$").
-				Examples("northamerica-northeast1", "southamerica-east1", "us-east1").
 				Build(),
 		},
 		{
@@ -301,16 +291,6 @@ func commonBindOutputVariables() []broker.BrokerVariable {
 			Details:     "(deprecated) The id of the last operation on the database.",
 			Required:    false,
 			Constraints: validation.NewConstraintBuilder().Examples("mysql://user:pass@127.0.0.1/pcf-sb-2-1540412407295372465?ssl_mode=required").Build(),
-		},
-		{
-			FieldName: "region",
-			Type:      broker.JsonTypeString,
-			Details:   "The region the database is in.",
-			Required:  true,
-			Constraints: validation.NewConstraintBuilder().
-				Pattern("^[A-Za-z][-a-z0-9A-Z]+$").
-				Examples("northamerica-northeast1", "southamerica-east1", "us-east1").
-				Build(),
 		},
 	}...)
 }

--- a/pkg/providers/builtin/cloudsql/postgres-definition.go
+++ b/pkg/providers/builtin/cloudsql/postgres-definition.go
@@ -16,8 +16,9 @@ package cloudsql
 
 import (
 	"code.cloudfoundry.org/lager"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/base"
+	. "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/common"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
@@ -25,6 +26,29 @@ import (
 )
 
 const PostgresServiceId = "cbad6d78-a73c-432d-b8ff-b219a17a803a"
+
+var postgresRegions = map[interface{}]string{
+	NorthAmericaNorthEast1.Region(): NorthAmericaNorthEast1.Region(),
+	UsCentral1.Region():             UsCentral1.Region(),
+	UsEast1.Region():                UsEast1.Region(),
+	UsEast4.Region():                UsEast4.Region(),
+	UsWest1.Region():                UsWest1.Region(),
+	UsWest2.Region():                UsWest2.Region(),
+	SouthAmericaEast1.Region():      SouthAmericaEast1.Region(),
+	EuropeNorth1.Region():           EuropeNorth1.Region(),
+	EuropeWest1.Region():            EuropeWest1.Region(),
+	EuropeWest2.Region():            EuropeWest2.Region(),
+	EuropeWest3.Region():            EuropeWest3.Region(),
+	EuropeWest4.Region():            EuropeWest4.Region(),
+	EuropeWest6.Region():            EuropeWest6.Region(),
+	AsiaEast1.Region():              AsiaEast1.Region(),
+	AsiaEast2.Region():              AsiaEast2.Region(),
+	AsiaNorthEast1.Region():         AsiaNorthEast1.Region(),
+	AsiaNorthEast2.Region():         AsiaNorthEast2.Region(),
+	AsiaSouth1.Region():             AsiaSouth1.Region(),
+	AsiaSouthEast1.Region():         AsiaSouthEast1.Region(),
+	AustraliaSouthEast1.Region():    AustraliaSouthEast1.Region(),
+}
 
 // PostgresServiceDefinition creates a new ServiceDefinition object for the PostgreSQL service.
 func PostgresServiceDefinition() *broker.ServiceDefinition {
@@ -222,6 +246,13 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 					"NEVER":  "Never, instance does not turn on if a request arrives.",
 				},
 			},
+			{
+				FieldName: "region",
+				Type:      broker.JsonTypeString,
+				Details:   "The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases.",
+				Default:   UsCentral1.Region(),
+				Enum:      postgresRegions,
+			},
 		}, commonProvisionVariables()...),
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
 			{Name: "labels", Default: `${json.marshal(request.default_labels)}`, Overwrite: true},
@@ -238,9 +269,18 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 			{Name: "_", Default: `${assert(disk_size <= max_disk_size, "disk size (${disk_size}) is greater than max allowed disk size for this plan (${max_disk_size})")}`, Overwrite: true},
 		},
 
-		DefaultRoleWhitelist:  roleWhitelist(),
-		BindInputVariables:    commonBindVariables(),
-		BindOutputVariables:   commonBindOutputVariables(),
+		DefaultRoleWhitelist: roleWhitelist(),
+		BindInputVariables:   commonBindVariables(),
+		BindOutputVariables: append([]broker.BrokerVariable{
+			{
+				FieldName: "region",
+				Type:      broker.JsonTypeString,
+				Details:   "The region the database is in.",
+				Required:  true,
+				Default:   UsCentral1.Region(),
+				Enum:      postgresRegions,
+			},
+		}, commonBindOutputVariables()...),
 		BindComputedVariables: commonBindComputedVariables(),
 		PlanVariables: []broker.BrokerVariable{
 			{

--- a/pkg/providers/builtin/common/region.go
+++ b/pkg/providers/builtin/common/region.go
@@ -1,0 +1,76 @@
+package common
+
+type Kind int
+
+const (
+	NorthAmericaNorthEast1 Kind = iota
+	UsCentral
+	UsCentral1
+	UsEast1
+	UsEast4
+	UsWest1
+	UsWest2
+	SouthAmericaEast1
+	EuropeNorth1
+	EuropeWest1
+	EuropeWest2
+	EuropeWest3
+	EuropeWest4
+	EuropeWest6
+	AsiaEast1
+	AsiaEast2
+	AsiaNorthEast1
+	AsiaNorthEast2
+	AsiaSouth1
+	AsiaSouthEast1
+	AustraliaSouthEast1
+)
+
+func (k Kind) Region() string {
+	switch k {
+	case NorthAmericaNorthEast1:
+		return "northamerica-northeast1"
+	case UsCentral:
+		return "us-central"
+	case UsCentral1:
+		return "us-central1"
+	case UsEast1:
+		return "us-east1"
+	case UsEast4:
+		return "us-east4"
+	case UsWest1:
+		return "us-west1"
+	case UsWest2:
+		return "us-west2"
+	case SouthAmericaEast1:
+		return "southamerica-east1"
+	case EuropeNorth1:
+		return "europe-north1"
+	case EuropeWest1:
+		return "europe-west1"
+	case EuropeWest2:
+		return "europe-west2"
+	case EuropeWest3:
+		return "europe-west3"
+	case EuropeWest4:
+		return "europe-west4"
+	case EuropeWest6:
+		return "europe-west6"
+	case AsiaEast1:
+		return "asia-east1"
+	case AsiaEast2:
+		return "asia-east2"
+	case AsiaNorthEast1:
+		return "asia-northeast1"
+	case AsiaNorthEast2:
+		return "asia-northeast2"
+	case AsiaSouth1:
+		return "asia-south1"
+	case AsiaSouthEast1:
+		return "asia-southeast1"
+	case AustraliaSouthEast1:
+		return "australia-southeast1"
+	default:
+		return ""
+	}
+}

--- a/pkg/providers/builtin/common/zone.go
+++ b/pkg/providers/builtin/common/zone.go
@@ -1,0 +1,182 @@
+package common
+
+const (
+	UsCentral1A Kind = iota
+	UsCentral1B
+	UsCentral1C
+	UsCentral1F
+	UsWest2A
+	UsWest2B
+	UsWest2C
+	UsEast4A
+	UsEast4B
+	UsEast4C
+	UsWest1A
+	UsWest1B
+	UsWest1C
+	UsEast1B
+	UsEast1C
+	UsEast1D
+	NorthamericaNorthEast1A
+	NorthamericaNorthEast1B
+	NorthamericaNorthEast1C
+	SouthAmericaEast1A
+	SouthAmericaEast1B
+	SouthAmericaEast1C
+	EuropeWest1B
+	EuropeWest1D
+	EuropeNorth1A
+	EuropeNorth1B
+	EuropeNorth1C
+	EuropeWest2A
+	EuropeWest2B
+	EuropeWest2C
+	EuropeWest4A
+	EuropeWest4B
+	EuropeWest4C
+	EuropeWest6A
+	EuropeWest6B
+	EuropeWest6C
+	AsiaSouth1A
+	AsiaSouth1B
+	AsiaSouth1C
+	AsiaSouthEast1A
+	AsiaSouthEast1B
+	AsiaSouthEast1C
+	AsiaEast1A
+	AsiaEast1B
+	AsiaEast1C
+	AsiaEast2A
+	AsiaEast2B
+	AsiaEast2C
+	AsiaNorthEast1A
+	AsiaNorthEast1B
+	AsiaNorthEast1C
+	AsiaNorthEast2A
+	AsiaNorthEast2B
+	AsiaNorthEast2C
+	AustraliaSouthEast1A
+	AustraliaSouthEast1B
+	AustraliaSouthEast1C
+)
+
+func (k Kind) Zone() string {
+	switch k {
+	case UsCentral1A:
+		return "us-central1-a"
+	case UsCentral1B:
+		return "us-central1-b"
+	case UsCentral1C:
+		return "us-central1-c"
+	case UsCentral1F:
+		return "us-central1-f"
+	case UsWest2A:
+		return "us-west2-a"
+	case UsWest2B:
+		return "us-west2-b"
+	case UsWest2C:
+		return "us-west2-c"
+	case UsEast4A:
+		return "us-east4-a"
+	case UsEast4B:
+		return "us-east4-b"
+	case UsEast4C:
+		return "us-east4-c"
+	case UsWest1A:
+		return "us-west1-a"
+	case UsWest1B:
+		return "us-west1-b"
+	case UsWest1C:
+		return "us-west1-c"
+	case UsEast1B:
+		return "us-east1-b"
+	case UsEast1C:
+		return "us-east1-c"
+	case UsEast1D:
+		return "us-east1-d"
+	case NorthamericaNorthEast1A:
+		return "northamerica-northeast1-a"
+	case NorthamericaNorthEast1B:
+		return "northamerica-northeast1-b"
+	case NorthamericaNorthEast1C:
+		return "northamerica-northeast1-c"
+	case SouthAmericaEast1A:
+		return "southamerica-east1-a"
+	case SouthAmericaEast1B:
+		return "southamerica-east1-b"
+	case SouthAmericaEast1C:
+		return "southamerica-east1-c"
+	case EuropeWest1B:
+		return "europe-west1-b"
+	case EuropeWest1D:
+		return "europe-west1-d"
+	case EuropeNorth1A:
+		return "europe-north1-a"
+	case EuropeNorth1B:
+		return "europe-north1-b"
+	case EuropeNorth1C:
+		return "europe-north1-c"
+	case EuropeWest2A:
+		return "europe-west2-a"
+	case EuropeWest2B:
+		return "europe-west2-b"
+	case EuropeWest2C:
+		return "europe-west2-c"
+	case EuropeWest4A:
+		return "europe-west4-a"
+	case EuropeWest4B:
+		return "europe-west4-b"
+	case EuropeWest4C:
+		return "europe-west4-c"
+	case EuropeWest6A:
+		return "europe-west6-a"
+	case EuropeWest6B:
+		return "europe-west6-b"
+	case EuropeWest6C:
+		return "europe-west6-c"
+	case AsiaSouth1A:
+		return "asia-south1-a"
+	case AsiaSouth1B:
+		return "asia-south1-b"
+	case AsiaSouth1C:
+		return "asia-south1-c"
+	case AsiaSouthEast1A:
+		return "asia-southeast1-a"
+	case AsiaSouthEast1B:
+		return "asia-southeast1-b"
+	case AsiaSouthEast1C:
+		return "asia-southeast1-c"
+	case AsiaEast1A:
+		return "asia-east1-a"
+	case AsiaEast1B:
+		return "asia-east1-b"
+	case AsiaEast1C:
+		return "asia-east1-c"
+	case AsiaEast2A:
+		return "asia-east2-a"
+	case AsiaEast2B:
+		return "asia-east2-b"
+	case AsiaEast2C:
+		return "asia-east2-c"
+	case AsiaNorthEast1A:
+		return "asia-northeast1-a"
+	case AsiaNorthEast1B:
+		return "asia-northeast1-b"
+	case AsiaNorthEast1C:
+		return "asia-northeast1-c"
+	case AsiaNorthEast2A:
+		return "asia-northeast2-a"
+	case AsiaNorthEast2B:
+		return "asia-northeast2-b"
+	case AsiaNorthEast2C:
+		return "asia-northeast2-c"
+	case AustraliaSouthEast1A:
+		return "australia-southeast1-a"
+	case AustraliaSouthEast1B:
+		return "australia-southeast1-b"
+	case AustraliaSouthEast1C:
+		return "australia-southeast1-c"
+	default:
+		return ""
+	}
+}

--- a/pkg/providers/builtin/redis/definition.go
+++ b/pkg/providers/builtin/redis/definition.go
@@ -19,6 +19,7 @@ import (
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
 	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/base"
+	. "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/common"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/pivotal-cf/brokerapi"
 	"golang.org/x/oauth2/jwt"
@@ -94,11 +95,27 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "region",
 				Type:      broker.JsonTypeString,
 				Details:   "The region in which to provision the Redis instance. See: https://cloud.google.com/memorystore/docs/redis/regions for supported regions.",
-				Default:   "us-east1",
-				Constraints: validation.NewConstraintBuilder().
-					Pattern("^[a-z]+[-][a-z0-9]+$").
-					Examples("us-central1", "europe-west2", "asia-northeast1", "australia-southeast1").
-					Build(),
+				Default:   UsEast1.Region(),
+				Enum: map[interface{}]string{
+					AsiaEast1.Region():              AsiaEast1.Region(),
+					AsiaEast2.Region():              AsiaEast2.Region(),
+					AsiaNorthEast1.Region():         AsiaNorthEast1.Region(),
+					AsiaSouth1.Region():             AsiaSouth1.Region(),
+					AsiaSouthEast1.Region():         AsiaSouthEast1.Region(),
+					AustraliaSouthEast1.Region():    AustraliaSouthEast1.Region(),
+					EuropeNorth1.Region():           EuropeNorth1.Region(),
+					EuropeWest1.Region():            EuropeWest1.Region(),
+					EuropeWest2.Region():            EuropeWest2.Region(),
+					EuropeWest3.Region():            EuropeWest3.Region(),
+					EuropeWest4.Region():            EuropeWest4.Region(),
+					NorthAmericaNorthEast1.Region(): NorthAmericaNorthEast1.Region(),
+					SouthAmericaEast1.Region():      SouthAmericaEast1.Region(),
+					UsCentral1.Region():             UsCentral1.Region(),
+					UsEast1.Region():                UsEast1.Region(),
+					UsEast4.Region():                UsEast4.Region(),
+					UsWest1.Region():                UsWest1.Region(),
+					UsWest2.Region():                UsWest2.Region(),
+				},
 			},
 			{
 				FieldName: "display_name",


### PR DESCRIPTION
In our application we use GCP broker. Our UI helps end-user using simple providing for services. In PR, I propose to use fields of type enum for regions and zone to enhance the general user-experience, manual completion of these fields may cause various types of errors (both on UI and via CLI).

Below is a screen of what the GCP broker looks like together with our application and fields of the type `enum`:

<img width="1906" alt="Screen Shot 2019-08-27 at 15 06 06" src="https://user-images.githubusercontent.com/10399074/63773984-99310e00-c8dc-11e9-83bb-6711123aa381.png">
