### PR TITLE
Cleanup IAM policy when deleting a service account

### DIFF
--- a/pkg/providers/builtin/account_managers/iam.go
+++ b/pkg/providers/builtin/account_managers/iam.go
@@ -51,3 +51,17 @@ func rolesToMembersMap(bindings []*cloudresourcemanager.Binding) map[string]util
 
 	return bm
 }
+
+// Remove a member from all role bindings to clean up the iam policy before deleting a service account.
+func removeMemberFromBindings(bindings []*cloudresourcemanager.Binding, memberToRemove string) []*cloudresourcemanager.Binding {
+	for _, binding := range bindings {
+		for i, member := range binding.Members {
+			if member == memberToRemove {
+				binding.Members = append(binding.Members[:i], binding.Members[i+1:]...)
+				break
+			}
+		}
+	}
+
+	return bindings
+}


### PR DESCRIPTION
This PR fixes #474.

The IAM policy won't automatically be cleaned up when deleting a service
account. It is necessary to manually remove the service account from all
its role memberships. Otherwise, all created role bindings will remain
existent in the policy, leading to many orphaned bindings.

*Since I'm relatively new to programming in golang:*
I had problems finding an easy solution on how to avoid the code duplication in the methods `revokeRolesFromAccount` and `grantRoleToAccount`.
I would appreciate any hint on how I could/should (or should not?) resolve this! 🙂