### PR TITLE
Introduce default expression field to schemas

### DIFF
--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -303,7 +303,7 @@ func (svc *ServiceDefinition) validatePlan(plan ServicePlan) error {
 func (svc *ServiceDefinition) provisionDefaults() []varcontext.DefaultVariable {
 	var out []varcontext.DefaultVariable
 	for _, provisionVar := range svc.ProvisionInputVariables {
-		out = append(out, varcontext.DefaultVariable{Name: provisionVar.FieldName, Default: provisionVar.Default, Overwrite: false, Type: string(provisionVar.Type)})
+		out = append(out, varcontext.DefaultVariable{Name: provisionVar.FieldName, Default: provisionVar.Default, Expression: provisionVar.Expression, Overwrite: false, Type: string(provisionVar.Type)})
 	}
 	return out
 }
@@ -311,7 +311,7 @@ func (svc *ServiceDefinition) provisionDefaults() []varcontext.DefaultVariable {
 func (svc *ServiceDefinition) bindDefaults() []varcontext.DefaultVariable {
 	var out []varcontext.DefaultVariable
 	for _, v := range svc.BindInputVariables {
-		out = append(out, varcontext.DefaultVariable{Name: v.FieldName, Default: v.Default, Overwrite: false, Type: string(v.Type)})
+		out = append(out, varcontext.DefaultVariable{Name: v.FieldName, Default: v.Default, Expression: v.Expression, Overwrite: false, Type: string(v.Type)})
 	}
 	return out
 }

--- a/pkg/broker/variables.go
+++ b/pkg/broker/variables.go
@@ -33,6 +33,8 @@ const (
 	JsonTypeNumeric JsonType = "number"
 	JsonTypeInteger JsonType = "integer"
 	JsonTypeBoolean JsonType = "boolean"
+
+	automaticallyGeneratedValueSentence = "If you do not specify this field, it generates automatically."
 )
 
 type JsonType string
@@ -48,6 +50,8 @@ type BrokerVariable struct {
 	Details string `yaml:"details"`
 	// The default value of the field.
 	Default interface{} `yaml:"default,omitempty"`
+	// The expression which will be evaluated if the default value is empty
+	Expression string `yaml:"expression,omitempty"`
 	// If there are a limited number of valid values for this field then
 	// Enum will hold them in value:friendly name pairs
 	Enum map[interface{}]string `yaml:"enum,omitempty"`
@@ -98,7 +102,11 @@ func (bv *BrokerVariable) ToSchema() map[string]interface{} {
 	}
 
 	if bv.Details != "" {
-		schema[validation.KeyDescription] = bv.Details
+		if bv.Expression != "" {
+			schema[validation.KeyDescription] = fmt.Sprintf("%s %s", bv.Details, automaticallyGeneratedValueSentence)
+		} else {
+			schema[validation.KeyDescription] = bv.Details
+		}
 	}
 
 	if bv.Type != "" {

--- a/pkg/broker/variables_test.go
+++ b/pkg/broker/variables_test.go
@@ -64,12 +64,13 @@ func TestBrokerVariable_ToSchema(t *testing.T) {
 				Constraints: map[string]interface{}{
 					"examples": []string{"SAMPLEA", "SAMPLEB"},
 				},
+				Expression: "${time.nano()}",
 			},
 			map[string]interface{}{
 				"title":       "Full Test Field Name",
 				"default":     "some-value",
 				"type":        JsonTypeString,
-				"description": "more information",
+				"description": "more information If you do not specify this field, it generates automatically.",
 				"enum":        []interface{}{"a", "b"},
 				"examples":    []string{"SAMPLEA", "SAMPLEB"},
 			},

--- a/pkg/providers/builtin/account_managers/service_account_manager.go
+++ b/pkg/providers/builtin/account_managers/service_account_manager.go
@@ -263,8 +263,8 @@ func ServiceAccountWhitelistWithDefault(whitelist []string, defaultValue string)
 func ServiceAccountBindComputedVariables() []varcontext.DefaultVariable {
 	return []varcontext.DefaultVariable{
 		// XXX names are truncated to 20 characters because of a bug in the IAM service
-		{Name: "service_account_name", Default: `${str.truncate(20, "pcf-binding-${request.binding_id}")}`, Overwrite: true},
-		{Name: "service_account_display_name", Default: "${service_account_name}", Overwrite: true},
+		{Name: "service_account_name", Expression: `${str.truncate(20, "pcf-binding-${request.binding_id}")}`, Overwrite: true},
+		{Name: "service_account_display_name", Expression: "${service_account_name}", Overwrite: true},
 	}
 }
 

--- a/pkg/providers/builtin/bigquery/definition.go
+++ b/pkg/providers/builtin/bigquery/definition.go
@@ -62,7 +62,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "name",
 				Type:      broker.JsonTypeString,
 				Details:   "The name of the BigQuery dataset.",
-				Default:   "pcf_sb_${counter.next()}_${time.nano()}",
+				Expression:   "pcf_sb_${counter.next()}_${time.nano()}",
 				Constraints: validation.NewConstraintBuilder().
 					Pattern("^[A-Za-z0-9_]+$").
 					MaxLength(1024).
@@ -80,7 +80,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			},
 		},
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
-			{Name: "labels", Default: "${json.marshal(request.default_labels)}", Overwrite: true},
+			{Name: "labels", Expression: "${json.marshal(request.default_labels)}", Overwrite: true},
 		},
 		DefaultRoleWhitelist:  roleWhitelist,
 		BindInputVariables:    accountmanagers.ServiceAccountWhitelistWithDefault(roleWhitelist, "bigquery.user"),

--- a/pkg/providers/builtin/bigtable/definition.go
+++ b/pkg/providers/builtin/bigtable/definition.go
@@ -68,7 +68,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "name",
 				Type:      broker.JsonTypeString,
 				Details:   "The name of the Cloud Bigtable instance.",
-				Default:   "pcf-sb-${counter.next()}-${time.nano()}",
+				Expression:   "pcf-sb-${counter.next()}-${time.nano()}",
 				Constraints: validation.NewConstraintBuilder().
 					MinLength(6).
 					MaxLength(33).
@@ -79,7 +79,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "cluster_id",
 				Type:      broker.JsonTypeString,
 				Details:   "The ID of the Cloud Bigtable cluster.",
-				Default:   "${str.truncate(20, name)}-cluster",
+				Expression:   "${str.truncate(20, name)}-cluster",
 				Constraints: validation.NewConstraintBuilder().
 					MinLength(6).
 					MaxLength(30).
@@ -90,7 +90,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "display_name",
 				Type:      broker.JsonTypeString,
 				Details:   "The human-readable display name of the Bigtable instance.",
-				Default:   "${name}",
+				Expression:   "${name}",
 				Constraints: validation.NewConstraintBuilder().
 					MinLength(4).
 					MaxLength(30).

--- a/pkg/providers/builtin/cloudsql/common-definition.go
+++ b/pkg/providers/builtin/cloudsql/common-definition.go
@@ -51,13 +51,13 @@ func commonBindVariables() []broker.BrokerVariable {
 			FieldName: "username",
 			Type:      broker.JsonTypeString,
 			Details:   "The SQL username for the account.",
-			Default:   `sb${str.truncate(14, time.nano())}`,
+			Expression:   `sb${str.truncate(14, time.nano())}`,
 		},
 		broker.BrokerVariable{
 			FieldName: "password",
 			Type:      broker.JsonTypeString,
 			Details:   "The SQL password for the account.",
-			Default:   "${rand.base64(32)}",
+			Expression:   "${rand.base64(32)}",
 		},
 	)
 }
@@ -66,12 +66,12 @@ func commonBindComputedVariables() []varcontext.DefaultVariable {
 	serviceAccountComputed := accountmanagers.ServiceAccountBindComputedVariables()
 	sqlComputed := []varcontext.DefaultVariable{
 		// legacy behavior dictates that empty values get defaults
-		{Name: "password", Default: `${password == "" ? "` + passwordTemplate + `" : password}`, Overwrite: true},
-		{Name: "username", Default: `${username == "" ? "` + usernameTemplate + `" : username}`, Overwrite: true},
+		{Name: "password", Expression: `${password == "" ? "` + passwordTemplate + `" : password}`, Overwrite: true},
+		{Name: "username", Expression: `${username == "" ? "` + usernameTemplate + `" : username}`, Overwrite: true},
 
 		// necessary additions
-		{Name: "certname", Default: `${str.truncate(10, request.binding_id)}cert`, Overwrite: true},
-		{Name: "db_name", Default: `${instance.name}`, Overwrite: true},
+		{Name: "certname", Expression: `${str.truncate(10, request.binding_id)}cert`, Overwrite: true},
+		{Name: "db_name", Expression: `${instance.name}`, Overwrite: true},
 	}
 
 	return append(serviceAccountComputed, sqlComputed...)

--- a/pkg/providers/builtin/cloudsql/mysql-definition.go
+++ b/pkg/providers/builtin/cloudsql/mysql-definition.go
@@ -185,7 +185,7 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "instance_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the Cloud SQL instance.",
-				Default:   identifierTemplate,
+				Expression:   identifierTemplate,
 				Constraints: validation.NewConstraintBuilder().
 					Pattern("^[a-z][a-z0-9-]+$").
 					MaxLength(84).
@@ -195,7 +195,7 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "database_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the database inside of the instance. Must be a valid identifier for your chosen database type.",
-				Default:   identifierTemplate,
+				Expression:   identifierTemplate,
 			},
 			{
 				FieldName: "version",
@@ -239,19 +239,19 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 			},
 		}, commonProvisionVariables()...),
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
-			{Name: "labels", Default: `${json.marshal(request.default_labels)}`, Overwrite: true},
+			{Name: "labels", Expression: `${json.marshal(request.default_labels)}`, Overwrite: true},
 
 			// legacy behavior dictates that empty values get defaults
-			{Name: "instance_name", Default: `${instance_name == "" ? "` + identifierTemplate + `" : instance_name}`, Overwrite: true},
-			{Name: "database_name", Default: `${database_name == "" ? "` + identifierTemplate + `" : database_name}`, Overwrite: true},
+			{Name: "instance_name", Expression: `${instance_name == "" ? "` + identifierTemplate + `" : instance_name}`, Overwrite: true},
+			{Name: "database_name", Expression: `${database_name == "" ? "` + identifierTemplate + `" : database_name}`, Overwrite: true},
 
-			{Name: "is_first_gen", Default: `${regexp.matches("^(d|D)[0-9]+$", tier)}`, Overwrite: true},
-			{Name: "version", Default: `${is_first_gen ? "MYSQL_5_6" : "MYSQL_5_7"}`, Overwrite: false},
-			{Name: "binlog", Default: `${is_first_gen ? false : true}`, Overwrite: false},
-			{Name: "failover_replica_name", Default: `${failover_replica_suffix == "" ? failover_replica_name : "${instance_name}${failover_replica_suffix}"}`, Overwrite: true},
+			{Name: "is_first_gen", Expression: `${regexp.matches("^(d|D)[0-9]+$", tier)}`, Overwrite: true},
+			{Name: "version", Expression: `${is_first_gen ? "MYSQL_5_6" : "MYSQL_5_7"}`, Overwrite: false},
+			{Name: "binlog", Expression: `${is_first_gen ? false : true}`, Overwrite: false},
+			{Name: "failover_replica_name", Expression: `${failover_replica_suffix == "" ? failover_replica_name : "${instance_name}${failover_replica_suffix}"}`, Overwrite: true},
 
 			// validation
-			{Name: "_", Default: `${assert(disk_size <= max_disk_size, "disk size (${disk_size}) is greater than max allowed disk size for this plan (${max_disk_size})")}`, Overwrite: true},
+			{Name: "_", Expression: `${assert(disk_size <= max_disk_size, "disk size (${disk_size}) is greater than max allowed disk size for this plan (${max_disk_size})")}`, Overwrite: true},
 		},
 		DefaultRoleWhitelist:  roleWhitelist(),
 		BindInputVariables:    commonBindVariables(),

--- a/pkg/providers/builtin/cloudsql/postgres-definition.go
+++ b/pkg/providers/builtin/cloudsql/postgres-definition.go
@@ -181,7 +181,7 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "instance_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the CloudSQL instance.",
-				Default:   identifierTemplate,
+				Expression:   identifierTemplate,
 				Constraints: validation.NewConstraintBuilder().
 					Pattern("^[a-z][a-z0-9-]+$").
 					MaxLength(75).
@@ -191,7 +191,7 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "database_name",
 				Type:      broker.JsonTypeString,
 				Details:   "Name of the database inside of the instance. Must be a valid identifier for your chosen database type.",
-				Default:   identifierTemplate,
+				Expression:   identifierTemplate,
 			},
 			{
 				FieldName: "version",
@@ -224,18 +224,18 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 			},
 		}, commonProvisionVariables()...),
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
-			{Name: "labels", Default: `${json.marshal(request.default_labels)}`, Overwrite: true},
+			{Name: "labels", Expression: `${json.marshal(request.default_labels)}`, Overwrite: true},
 
 			// legacy behavior dictates that empty values get defaults
-			{Name: "instance_name", Default: `${instance_name == "" ? "` + identifierTemplate + `" : instance_name}`, Overwrite: true},
-			{Name: "database_name", Default: `${database_name == "" ? "` + identifierTemplate + `" : database_name}`, Overwrite: true},
+			{Name: "instance_name", Expression: `${instance_name == "" ? "` + identifierTemplate + `" : instance_name}`, Overwrite: true},
+			{Name: "database_name", Expression: `${database_name == "" ? "` + identifierTemplate + `" : database_name}`, Overwrite: true},
 
 			// these variables are fixed for PostgreSQL
 			{Name: "is_first_gen", Default: `false`, Overwrite: true},
 			{Name: "binlog", Default: `false`, Overwrite: true},
 
 			// validation
-			{Name: "_", Default: `${assert(disk_size <= max_disk_size, "disk size (${disk_size}) is greater than max allowed disk size for this plan (${max_disk_size})")}`, Overwrite: true},
+			{Name: "_", Expression: `${assert(disk_size <= max_disk_size, "disk size (${disk_size}) is greater than max allowed disk size for this plan (${max_disk_size})")}`, Overwrite: true},
 		},
 
 		DefaultRoleWhitelist:  roleWhitelist(),

--- a/pkg/providers/builtin/pubsub/definition.go
+++ b/pkg/providers/builtin/pubsub/definition.go
@@ -58,10 +58,10 @@ func ServiceDefinition() *broker.ServiceDefinition {
 		},
 		ProvisionInputVariables: []broker.BrokerVariable{
 			{
-				FieldName: "topic_name",
-				Type:      broker.JsonTypeString,
-				Details:   `Name of the topic. Must not start with "goog".`,
-				Default:   "pcf_sb_${counter.next()}_${time.nano()}",
+				FieldName:  "topic_name",
+				Type:       broker.JsonTypeString,
+				Details:    `Name of the topic. Must not start with "goog".`,
+				Expression: "pcf_sb_${counter.next()}_${time.nano()}",
 				Constraints: validation.NewConstraintBuilder().
 					MinLength(3).
 					MaxLength(255).
@@ -109,7 +109,7 @@ again during that time (on a best-effort basis).
 			},
 		},
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
-			{Name: "labels", Default: "${json.marshal(request.default_labels)}", Overwrite: true},
+			{Name: "labels", Expression: "${json.marshal(request.default_labels)}", Overwrite: true},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:   accountmanagers.ServiceAccountWhitelistWithDefault(roleWhitelist, "pubsub.editor"),

--- a/pkg/providers/builtin/redis/definition.go
+++ b/pkg/providers/builtin/redis/definition.go
@@ -80,10 +80,10 @@ func ServiceDefinition() *broker.ServiceDefinition {
 					Build(),
 			},
 			{
-				FieldName: "instance_id",
-				Type:      broker.JsonTypeString,
-				Details:   "The name of the Redis instance.",
-				Default:   "gsb-${counter.next()}-${time.nano()}",
+				FieldName:  "instance_id",
+				Type:       broker.JsonTypeString,
+				Details:    "The name of the Redis instance.",
+				Expression: "gsb-${counter.next()}-${time.nano()}",
 				Constraints: validation.NewConstraintBuilder().
 					MinLength(1).
 					MaxLength(40).
@@ -101,10 +101,10 @@ func ServiceDefinition() *broker.ServiceDefinition {
 					Build(),
 			},
 			{
-				FieldName: "display_name",
-				Type:      broker.JsonTypeString,
-				Details:   "The human-readable display name of the Redis instance.",
-				Default:   "${instance_id}",
+				FieldName:  "display_name",
+				Type:       broker.JsonTypeString,
+				Details:    "The human-readable display name of the Redis instance.",
+				Expression: "${instance_id}",
 				Constraints: validation.NewConstraintBuilder().
 					MinLength(4).
 					MaxLength(30).

--- a/pkg/providers/builtin/registry.go
+++ b/pkg/providers/builtin/registry.go
@@ -37,7 +37,7 @@ import (
 // BuiltinBrokerRegistry creates a new registry with all the built-in brokers
 // added to it.
 func BuiltinBrokerRegistry() broker.BrokerRegistry {
-	out := broker.BrokerRegistry{}
+   	out := broker.BrokerRegistry{}
 	RegisterBuiltinBrokers(out)
 	return out
 }

--- a/pkg/providers/builtin/spanner/definition.go
+++ b/pkg/providers/builtin/spanner/definition.go
@@ -67,10 +67,11 @@ func ServiceDefinition() *broker.ServiceDefinition {
 		},
 		ProvisionInputVariables: []broker.BrokerVariable{
 			{
-				FieldName: "name",
-				Type:      broker.JsonTypeString,
-				Details:   "A unique identifier for the instance, which cannot be changed after the instance is created.",
-				Default:   "pcf-sb-${counter.next()}-${time.nano()}",
+				FieldName:  "name",
+				Type:       broker.JsonTypeString,
+				Details:    "A unique identifier for the instance, which cannot be changed after the instance is created.",
+				Default:    nil,
+				Expression: "pcf-sb-${counter.next()}-${time.nano()}",
 				Constraints: validation.NewConstraintBuilder().
 					MinLength(6).
 					MaxLength(30).
@@ -81,7 +82,8 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				FieldName: "display_name",
 				Type:      broker.JsonTypeString,
 				Details:   "The name of this instance configuration as it appears in UIs.",
-				Default:   "${name}",
+				Default:   nil,
+				Expression: "${name}",
 				Constraints: validation.NewConstraintBuilder().
 					MinLength(4).
 					MaxLength(30).
@@ -102,7 +104,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			},
 		},
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
-			{Name: "labels", Default: "${json.marshal(request.default_labels)}", Overwrite: true},
+			{Name: "labels", Expression: "${json.marshal(request.default_labels)}", Overwrite: true},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:   accountmanagers.ServiceAccountWhitelistWithDefault(roleWhitelist, "spanner.databaseUser"),

--- a/pkg/providers/builtin/storage/definition.go
+++ b/pkg/providers/builtin/storage/definition.go
@@ -104,15 +104,15 @@ func ServiceDefinition() *broker.ServiceDefinition {
 		},
 		ProvisionInputVariables: []broker.BrokerVariable{
 			{
-				FieldName: "name",
-				Type:      broker.JsonTypeString,
-				Details:   "The name of the bucket. There is a single global namespace shared by all buckets so it MUST be unique.",
-				Default:   "pcf_sb_${counter.next()}_${time.nano()}",
+				FieldName:  "name",
+				Type:       broker.JsonTypeString,
+				Details:    "The name of the bucket. There is a single global namespace shared by all buckets so it MUST be unique.",
+				Expression: "pcf_sb_${counter.next()}_${time.nano()}",
 				Constraints: validation.NewConstraintBuilder(). // https://cloud.google.com/storage/docs/naming
-										Pattern("^[A-Za-z0-9_\\.]+$").
-										MinLength(3).
-										MaxLength(222).
-										Build(),
+					Pattern("^[A-Za-z0-9_\\.]+$").
+					MinLength(3).
+					MaxLength(222).
+					Build(),
 			},
 			{
 				FieldName: "location",
@@ -133,7 +133,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 			},
 		},
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
-			{Name: "labels", Default: "${json.marshal(request.default_labels)}", Overwrite: true},
+			{Name: "labels", Expression: "${json.marshal(request.default_labels)}", Overwrite: true},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:   accountmanagers.ServiceAccountWhitelistWithDefault(roleWhitelist, "storage.objectAdmin"),
@@ -144,10 +144,10 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				Details:   "Name of the bucket this binding is for.",
 				Required:  true,
 				Constraints: validation.NewConstraintBuilder(). // https://cloud.google.com/storage/docs/naming
-										Pattern("^[A-Za-z0-9_\\.]+$").
-										MinLength(3).
-										MaxLength(222).
-										Build(),
+					Pattern("^[A-Za-z0-9_\\.]+$").
+					MinLength(3).
+					MaxLength(222).
+					Build(),
 			},
 		),
 		PlanVariables: []broker.BrokerVariable{

--- a/pkg/varcontext/builder_test.go
+++ b/pkg/varcontext/builder_test.go
@@ -205,7 +205,7 @@ func TestDefaultVariable_Validate(t *testing.T) {
 	cases := map[string]validation.ValidatableTest{
 		"empty": validation.ValidatableTest{
 			Object: &DefaultVariable{},
-			Expect: errors.New("missing field(s): default, name"),
+			Expect: errors.New("expected exactly one, got neither: default, expression\nmissing field(s): name"),
 		},
 		"bad type": validation.ValidatableTest{
 			Object: &DefaultVariable{


### PR DESCRIPTION
This PR moves the default HIL expression to new field `Expression` and makes empty default values for such fields. It solves a problem with expressions in default values which does not match required pattern.