### PR TITLE
Update CloudSQL API request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- PostgreSQL 11 (GA since 27.09.2019)
 - Support setting database flags (new configuration parameter: `database_flags`).
 - Support setting the storage auto resize limit (new configuration parameter: `auto_resize_limit`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Support setting database flags (new configuration parameter: `database_flags`).
+- Support setting the storage auto resize limit (new configuration parameter: `auto_resize_limit`).
 
 ## [4.3.0] - 2019-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Support setting database flags (new configuration parameter: `database_flags`).
+
 ## [4.3.0] - 2019-08-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support setting database flags (new configuration parameter: `database_flags`).
 - Support setting the storage auto resize limit (new configuration parameter: `auto_resize_limit`).
 
+### Changed
+- Deprecate `failover_replica` parameter for PostgreSQL (use `availability_type` instead).
+
+### Fixed
+- PostgreSQL can be configured high available again (new configuration parameter: `availability_type`).
+
 ## [4.3.0] - 2019-08-26
 
 ### Fixed

--- a/docs/classes/google-cloudsql-mysql.md
+++ b/docs/classes/google-cloudsql-mysql.md
@@ -12,45 +12,52 @@ Google CloudSQL for MySQL is a fully-managed MySQL database service.
 **Request Parameters**
 
 
- * `instance_name` _string_ - Name of the Cloud SQL instance. Default: `pcf-sb-${counter.next()}-${time.nano()}`.
-    * The string must have at most 84 characters.
-    * The string must match the regular expression `^[a-z][a-z0-9-]+$`.
- * `database_name` _string_ - Name of the database inside of the instance. Must be a valid identifier for your chosen database type. Default: `pcf-sb-${counter.next()}-${time.nano()}`.
  * `version` _string_ - The database engine type and version. Defaults to `MYSQL_5_6` for 1st gen MySQL instances or `MYSQL_5_7` for 2nd gen MySQL instances.
     * The value must be one of: [MYSQL_5_5 MYSQL_5_6 MYSQL_5_7].
- * `failover_replica_name` _string_ - (only for 2nd generation instances) If specified, creates a failover replica with the given name. Default: ``.
-    * The string must have at most 84 characters.
+ * `failover_replica_name` _string_ - (only for 2nd generation MySQL instances) If specified, creates a failover replica with the given name. (Requires binlog and backups to be enabled). Default: ``.
+    * The string must have at most 87 characters.
     * The string must match the regular expression `^(|[a-z][a-z0-9-]+)$`.
- * `failover_replica_suffix` _string_ - (only for 2nd generation instances) If specified, creates a failover replica with the instance name and this suffix. Overrides `failover_replica_name`. Default: ``.
+ * `failover_replica_suffix` _string_ - (only for 2nd generation MySQL instances) If specified, creates a failover replica with the instance name and this suffix. Overrides `failover_replica_name`. (Requires binlog and backups to be enabled). Default: ``.
     * The string must match the regular expression `^(|[a-z0-9-]+)$`.
+ * `instance_name` _string_ - Name of the CloudSQL instance. Default: `pcf-sb-${counter.next()}-${time.nano()}`.
+    * The string must have at most 87 characters.
+    * The string must match the regular expression `^[a-z][a-z0-9-]+$`.
+ * `database_name` _string_ - Name of the database inside of the instance. Must be a valid identifier for your chosen database type. Default: `pcf-sb-${counter.next()}-${time.nano()}`.
  * `activation_policy` _string_ - The activation policy specifies when the instance is activated; it is applicable only when the instance state is RUNNABLE. Default: `ALWAYS`.
     * The value must be one of: [ALWAYS NEVER ON_DEMAND].
  * `binlog` _string_ - Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.
     * The value must be one of: [false true].
- * `disk_size` _string_ - In GB (only for 2nd generation instances). Default: `10`.
-    * Examples: [10 500 10230].
-    * The string must have at most 5 characters.
-    * The string must match the regular expression `^[1-9][0-9]+$`.
  * `region` _string_ - The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases. Default: `us-central`.
     * Examples: [northamerica-northeast1 southamerica-east1 us-east1].
     * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
- * `zone` _string_ - (only for 2nd generation instances) Default: ``.
-    * The string must match the regular expression `^(|[A-Za-z][-a-z0-9A-Z]+)$`.
- * `disk_type` _string_ - (only for 2nd generation instances) Default: `PD_SSD`.
-    * The value must be one of: [PD_HDD PD_SSD].
- * `maintenance_window_day` _string_ - (only for 2nd generation instances) This specifies when a v2 CloudSQL instance should preferably be restarted for system maintenance purposes. Day of week (1-7), starting on Monday. Default: `1`.
-    * The value must be one of: [1 2 3 4 5 6 7].
- * `maintenance_window_hour` _string_ - (only for 2nd generation instances) The hour of the day when disruptive updates (updates that require an instance restart) to this CloudSQL instance can be made. Hour of day 0-23. Default: `0`.
-    * The string must match the regular expression `^([0-9]|1[0-9]|2[0-3])$`.
  * `backups_enabled` _string_ - Should daily backups be enabled for the service? Default: `true`.
     * The value must be one of: [false true].
  * `backup_start_time` _string_ - Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM. Default: `06:00`.
     * The string must match the regular expression `^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$`.
+ * `disk_size` _string_ - In GB (only for 2nd generation instances). Default: `10`.
+    * Examples: [10 500 10230].
+    * The string must have at most 5 characters.
+    * The string must match the regular expression `^[1-9][0-9]+$`.
+ * `disk_type` _string_ - (only for 2nd generation instances) Default: `PD_SSD`.
+    * The value must be one of: [PD_HDD PD_SSD].
+ * `database_flags` _string_ - The database flags passed to the instance at startup (comma separated list of flags, e.g. general_log=on,skip_show_database=off). Default: ``.
+    * Examples: [long_query_time=10 general_log=on,skip_show_database=off].
+    * The string must match the regular expression `^(|([a-z_]+=[a-zA-Z0-9\.\+\:-]+)(,[a-z_]+=[a-zA-Z0-9\.\+\:-]+)*)$`.
  * `authorized_networks` _string_ - A comma separated list without spaces. Default: ``.
+ * `zone` _string_ - (only for 2nd generation instances) Default: ``.
+    * The string must match the regular expression `^(|[A-Za-z][-a-z0-9A-Z]+)$`.
+ * `maintenance_window_day` _string_ - (only for 2nd generation instances) This specifies when a v2 CloudSQL instance should preferably be restarted for system maintenance purposes. Day of week (1-7), starting on Monday. Default: `1`.
+    * The value must be one of: [1 2 3 4 5 6 7].
+ * `maintenance_window_hour` _string_ - (only for 2nd generation instances) The hour of the day when disruptive updates (updates that require an instance restart) to this CloudSQL instance can be made. Hour of day 0-23. Default: `0`.
+    * The string must match the regular expression `^([0-9]|1[0-9]|2[0-3])$`.
  * `replication_type` _string_ - The type of replication this instance uses. This can be either ASYNCHRONOUS or SYNCHRONOUS. Default: `SYNCHRONOUS`.
     * The value must be one of: [ASYNCHRONOUS SYNCHRONOUS].
  * `auto_resize` _string_ - (only for 2nd generation instances) Configuration to increase storage size automatically. Default: `false`.
     * The value must be one of: [false true].
+ * `auto_resize_limit` _string_ - (only for 2nd generation instances) The maximum size to which storage capacity can be automatically increased. Default: `0`.
+    * Examples: [10 500 10230].
+    * The string must have at most 5 characters.
+    * The string must match the regular expression `^[0-9][0-9]*$`.
 
 
 ## Binding

--- a/docs/classes/google-cloudsql-postgres.md
+++ b/docs/classes/google-cloudsql-postgres.md
@@ -12,43 +12,49 @@ Google CloudSQL for PostgreSQL is a fully-managed PostgreSQL database service.
 **Request Parameters**
 
 
+ * `version` _string_ - The database engine type and version. Default: `POSTGRES_9_6`.
+    * The value must be one of: [POSTGRES_11 POSTGRES_9_6].
+ * `failover_replica_name` _string_ - DEPRECATED! Use availability_type for setting up high availability. Default: ``.
+    * The string must have at most 0 characters.
  * `instance_name` _string_ - Name of the CloudSQL instance. Default: `pcf-sb-${counter.next()}-${time.nano()}`.
-    * The string must have at most 75 characters.
+    * The string must have at most 87 characters.
     * The string must match the regular expression `^[a-z][a-z0-9-]+$`.
  * `database_name` _string_ - Name of the database inside of the instance. Must be a valid identifier for your chosen database type. Default: `pcf-sb-${counter.next()}-${time.nano()}`.
- * `version` _string_ - The database engine type and version. Default: `POSTGRES_9_6`.
-    * The value must be one of: [POSTGRES_9_6].
- * `failover_replica_name` _string_ - (only for 2nd generation instances) If specified, creates a failover replica with the given name. Default: ``.
-    * The string must have at most 75 characters.
-    * The string must match the regular expression `^(|[a-z][a-z0-9-]+)$`.
  * `activation_policy` _string_ - The activation policy specifies when the instance is activated; it is applicable only when the instance state is RUNNABLE. Default: `ALWAYS`.
     * The value must be one of: [ALWAYS NEVER].
- * `binlog` _string_ - Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.
-    * The value must be one of: [false true].
- * `disk_size` _string_ - In GB (only for 2nd generation instances). Default: `10`.
-    * Examples: [10 500 10230].
-    * The string must have at most 5 characters.
-    * The string must match the regular expression `^[1-9][0-9]+$`.
+ * `availability_type` _string_ - Availability type specifies whether the instance serves data from multiple zones. Default: `ZONAL`.
+    * The value must be one of: [REGIONAL ZONAL].
  * `region` _string_ - The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases. Default: `us-central`.
     * Examples: [northamerica-northeast1 southamerica-east1 us-east1].
     * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
- * `zone` _string_ - (only for 2nd generation instances) Default: ``.
-    * The string must match the regular expression `^(|[A-Za-z][-a-z0-9A-Z]+)$`.
- * `disk_type` _string_ - (only for 2nd generation instances) Default: `PD_SSD`.
-    * The value must be one of: [PD_HDD PD_SSD].
- * `maintenance_window_day` _string_ - (only for 2nd generation instances) This specifies when a v2 CloudSQL instance should preferably be restarted for system maintenance purposes. Day of week (1-7), starting on Monday. Default: `1`.
-    * The value must be one of: [1 2 3 4 5 6 7].
- * `maintenance_window_hour` _string_ - (only for 2nd generation instances) The hour of the day when disruptive updates (updates that require an instance restart) to this CloudSQL instance can be made. Hour of day 0-23. Default: `0`.
-    * The string must match the regular expression `^([0-9]|1[0-9]|2[0-3])$`.
  * `backups_enabled` _string_ - Should daily backups be enabled for the service? Default: `true`.
     * The value must be one of: [false true].
  * `backup_start_time` _string_ - Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM. Default: `06:00`.
     * The string must match the regular expression `^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$`.
+ * `disk_size` _string_ - In GB (only for 2nd generation instances). Default: `10`.
+    * Examples: [10 500 10230].
+    * The string must have at most 5 characters.
+    * The string must match the regular expression `^[1-9][0-9]+$`.
+ * `disk_type` _string_ - (only for 2nd generation instances) Default: `PD_SSD`.
+    * The value must be one of: [PD_HDD PD_SSD].
+ * `database_flags` _string_ - The database flags passed to the instance at startup (comma separated list of flags, e.g. general_log=on,skip_show_database=off). Default: ``.
+    * Examples: [long_query_time=10 general_log=on,skip_show_database=off].
+    * The string must match the regular expression `^(|([a-z_]+=[a-zA-Z0-9\.\+\:-]+)(,[a-z_]+=[a-zA-Z0-9\.\+\:-]+)*)$`.
  * `authorized_networks` _string_ - A comma separated list without spaces. Default: ``.
+ * `zone` _string_ - (only for 2nd generation instances) Default: ``.
+    * The string must match the regular expression `^(|[A-Za-z][-a-z0-9A-Z]+)$`.
+ * `maintenance_window_day` _string_ - (only for 2nd generation instances) This specifies when a v2 CloudSQL instance should preferably be restarted for system maintenance purposes. Day of week (1-7), starting on Monday. Default: `1`.
+    * The value must be one of: [1 2 3 4 5 6 7].
+ * `maintenance_window_hour` _string_ - (only for 2nd generation instances) The hour of the day when disruptive updates (updates that require an instance restart) to this CloudSQL instance can be made. Hour of day 0-23. Default: `0`.
+    * The string must match the regular expression `^([0-9]|1[0-9]|2[0-3])$`.
  * `replication_type` _string_ - The type of replication this instance uses. This can be either ASYNCHRONOUS or SYNCHRONOUS. Default: `SYNCHRONOUS`.
     * The value must be one of: [ASYNCHRONOUS SYNCHRONOUS].
  * `auto_resize` _string_ - (only for 2nd generation instances) Configuration to increase storage size automatically. Default: `false`.
     * The value must be one of: [false true].
+ * `auto_resize_limit` _string_ - (only for 2nd generation instances) The maximum size to which storage capacity can be automatically increased. Default: `0`.
+    * Examples: [10 500 10230].
+    * The string must have at most 5 characters.
+    * The string must match the regular expression `^[0-9][0-9]*$`.
 
 
 ## Binding

--- a/docs/classes/google-memorystore-redis.md
+++ b/docs/classes/google-memorystore-redis.md
@@ -17,6 +17,7 @@ Creates and manages Redis instances on the Google Cloud Platform.
     * The string must have at least 1 characters.
     * The string must match the regular expression `^[a-z]([-0-9a-z]*[a-z0-9]$)*`.
  * `authorized_network` _string_ - The name of the VPC network to attach the instance to. Default: `default`.
+    * Examples: [default projects/MYPROJECT/global/networks/MYNETWORK].
  * `region` _string_ - The region to create the instance in. Supported regions can be found here: https://cloud.google.com/memorystore/docs/redis/regions. Default: `us-east1`.
     * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
  * `memory_size_gb` _integer_ - Redis memory size in GiB. Default: `4`.

--- a/pkg/providers/builtin/cloudsql/broker.go
+++ b/pkg/providers/builtin/cloudsql/broker.go
@@ -155,6 +155,10 @@ func createFirstGenRequest(vars *varcontext.VarContext) *googlecloudsql.Database
 }
 
 func createInstanceRequest(vars *varcontext.VarContext) *googlecloudsql.DatabaseInstance {
+
+	// Split and parse DatabaseFlags
+	databaseFlags := parseDatabaseFlags(vars.GetString("database_flags"))
+
 	autoResize := vars.GetBool("auto_resize")
 
 	// set up instance resource
@@ -190,6 +194,31 @@ func createInstanceRequest(vars *varcontext.VarContext) *googlecloudsql.Database
 			Name: vars.GetString("failover_replica_name"),
 		},
 	}
+}
+
+func parseDatabaseFlags(flagsvar string) []*googlecloudsql.DatabaseFlags {
+	databaseFlags := []*googlecloudsql.DatabaseFlags{}
+
+	// Return empty DatabaseFlags when none is defined
+	if flagsvar == "" {
+		return databaseFlags
+	}
+
+	// Get each separate flag
+	flags := strings.Split(flagsvar, ",")
+
+	// Separate the flags into name and value
+	for _, f := range flags {
+		flag := strings.Split(f, "=")
+
+		databaseFlags = append(databaseFlags, &googlecloudsql.DatabaseFlags{
+			Name:            flag[0],
+			Value:           flag[1],
+			ForceSendFields: []string{"Value"},
+		})
+	}
+
+	return databaseFlags
 }
 
 // Bind creates a new username, password, and set of ssl certs for the given instance.

--- a/pkg/providers/builtin/cloudsql/broker.go
+++ b/pkg/providers/builtin/cloudsql/broker.go
@@ -185,6 +185,7 @@ func createInstanceRequest(vars *varcontext.VarContext) *googlecloudsql.Database
 			},
 			PricingPlan:            secondGenPricingPlan,
 			StorageAutoResize:      &autoResize,
+			StorageAutoResizeLimit: int64(vars.GetInt("auto_resize_limit")),
 			Tier:                   vars.GetString("tier"),
 			// UserLabels get defined in createProvisionRequest
 		},

--- a/pkg/providers/builtin/cloudsql/broker.go
+++ b/pkg/providers/builtin/cloudsql/broker.go
@@ -140,14 +140,14 @@ func createFirstGenRequest(vars *varcontext.VarContext) *googlecloudsql.Database
 	// set up instance resource
 	return &googlecloudsql.DatabaseInstance{
 		Settings: &googlecloudsql.Settings{
+			ActivationPolicy: vars.GetString("activation_policy"),
 			IpConfiguration: &googlecloudsql.IpConfiguration{
 				RequireSsl:  true,
 				Ipv4Enabled: true,
 			},
-			Tier:             vars.GetString("tier"),
-			PricingPlan:      vars.GetString("pricing_plan"),
-			ActivationPolicy: vars.GetString("activation_policy"),
-			ReplicationType:  vars.GetString("replication_type"),
+			Tier:            vars.GetString("tier"),
+			PricingPlan:     vars.GetString("pricing_plan"),
+			ReplicationType: vars.GetString("replication_type"),
 		},
 		DatabaseVersion: vars.GetString("version"),
 		Region:          vars.GetString("region"),
@@ -158,28 +158,31 @@ func createInstanceRequest(vars *varcontext.VarContext) *googlecloudsql.Database
 	autoResize := vars.GetBool("auto_resize")
 
 	// set up instance resource
+	// https://github.com/googleapis/google-api-go-client/blob/master/sqladmin/v1beta4/sqladmin-gen.go#L647
 	return &googlecloudsql.DatabaseInstance{
 		Settings: &googlecloudsql.Settings{
+			ActivationPolicy: vars.GetString("activation_policy"),
+			// BackupConfiguration gets defined in createProvisionRequest
+			DataDiskSizeGb: int64(vars.GetInt("disk_size")),
+			DataDiskType:   vars.GetString("disk_type"),
+			DatabaseFlags:  databaseFlags,
 			IpConfiguration: &googlecloudsql.IpConfiguration{
 				RequireSsl:  true,
 				Ipv4Enabled: true,
 			},
-			Tier:           vars.GetString("tier"),
-			DataDiskSizeGb: int64(vars.GetInt("disk_size")),
 			LocationPreference: &googlecloudsql.LocationPreference{
 				Zone: vars.GetString("zone"),
 			},
-			DataDiskType: vars.GetString("disk_type"),
 			MaintenanceWindow: &googlecloudsql.MaintenanceWindow{
 				Day:             int64(vars.GetInt("maintenance_window_day")),
 				Hour:            int64(vars.GetInt("maintenance_window_hour")),
 				UpdateTrack:     "stable",
 				ForceSendFields: []string{"Day", "Hour"},
 			},
-			PricingPlan:       secondGenPricingPlan,
-			ActivationPolicy:  vars.GetString("activation_policy"),
-			ReplicationType:   vars.GetString("replication_type"),
-			StorageAutoResize: &autoResize,
+			PricingPlan:            secondGenPricingPlan,
+			StorageAutoResize:      &autoResize,
+			Tier:                   vars.GetString("tier"),
+			// UserLabels get defined in createProvisionRequest
 		},
 		DatabaseVersion: vars.GetString("version"),
 		Region:          vars.GetString("region"),

--- a/pkg/providers/builtin/cloudsql/broker.go
+++ b/pkg/providers/builtin/cloudsql/broker.go
@@ -166,6 +166,7 @@ func createInstanceRequest(vars *varcontext.VarContext) *googlecloudsql.Database
 	return &googlecloudsql.DatabaseInstance{
 		Settings: &googlecloudsql.Settings{
 			ActivationPolicy: vars.GetString("activation_policy"),
+			AvailabilityType: vars.GetString("availability_type"),
 			// BackupConfiguration gets defined in createProvisionRequest
 			DataDiskSizeGb: int64(vars.GetInt("disk_size")),
 			DataDiskType:   vars.GetString("disk_type"),

--- a/pkg/providers/builtin/cloudsql/common-definition.go
+++ b/pkg/providers/builtin/cloudsql/common-definition.go
@@ -198,6 +198,17 @@ func commonProvisionVariables() []broker.BrokerVariable {
 				"false": "do not increase storage size automatically",
 			},
 		},
+		{
+			FieldName: "auto_resize_limit",
+			Type:      broker.JsonTypeString,
+			Details:   "(only for 2nd generation instances) The maximum size to which storage capacity can be automatically increased.",
+			Default:   "0",
+			Constraints: validation.NewConstraintBuilder().
+				Pattern("^[0-9][0-9]*$").
+				MaxLength(5).
+				Examples("10", "500", "10230").
+				Build(),
+		},
 	}
 }
 

--- a/pkg/providers/builtin/cloudsql/common-definition.go
+++ b/pkg/providers/builtin/cloudsql/common-definition.go
@@ -130,12 +130,13 @@ func commonProvisionVariables() []broker.BrokerVariable {
 			},
 		},
 		{
+			FieldName: "database_flags",
 			Type:      broker.JsonTypeString,
-			Details:   "The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases.",
-			Default:   "us-central",
+			Details:   "The database flags passed to the instance at startup (comma separated list of flags, e.g. general_log=on,skip_show_database=off).",
+			Default:   "",
 			Constraints: validation.NewConstraintBuilder().
-				Pattern("^[A-Za-z][-a-z0-9A-Z]+$").
-				Examples("northamerica-northeast1", "southamerica-east1", "us-east1").
+				Pattern(`^(|([a-z_]+=[a-zA-Z0-9\.\+\:-]+)(,[a-z_]+=[a-zA-Z0-9\.\+\:-]+)*)$`).
+				Examples("long_query_time=10", "general_log=on,skip_show_database=off").
 				Build(),
 		},
 		{

--- a/pkg/providers/builtin/cloudsql/common-definition.go
+++ b/pkg/providers/builtin/cloudsql/common-definition.go
@@ -15,8 +15,8 @@
 package cloudsql
 
 import (
-	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	accountmanagers "github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/account_managers"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 )
@@ -80,13 +80,33 @@ func commonBindComputedVariables() []varcontext.DefaultVariable {
 func commonProvisionVariables() []broker.BrokerVariable {
 	return []broker.BrokerVariable{
 		{
-			FieldName: "binlog",
+			FieldName: "region",
 			Type:      broker.JsonTypeString,
-			Details:   "Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.",
+			Details:   "The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases.",
+			Default:   "us-central",
+			Constraints: validation.NewConstraintBuilder().
+				Pattern("^[A-Za-z][-a-z0-9A-Z]+$").
+				Examples("northamerica-northeast1", "southamerica-east1", "us-east1").
+				Build(),
+		},
+		{
+			FieldName: "backups_enabled",
+			Type:      broker.JsonTypeString,
+			Details:   "Should daily backups be enabled for the service?",
+			Default:   "true",
 			Enum: map[interface{}]string{
-				"true":  "use binary log",
-				"false": "do not use binary log",
+				"true":  "enable daily backups",
+				"false": "do not enable daily backups",
 			},
+		},
+		{
+			FieldName: "backup_start_time",
+			Type:      broker.JsonTypeString,
+			Details:   "Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM.",
+			Default:   "06:00",
+			Constraints: validation.NewConstraintBuilder().
+				Pattern("^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$").
+				Build(),
 		},
 		{
 			FieldName: "disk_size",
@@ -100,7 +120,16 @@ func commonProvisionVariables() []broker.BrokerVariable {
 				Build(),
 		},
 		{
-			FieldName: "region",
+			FieldName: "disk_type",
+			Type:      broker.JsonTypeString,
+			Details:   "(only for 2nd generation instances)",
+			Default:   "PD_SSD",
+			Enum: map[interface{}]string{
+				"PD_SSD": "flash storage drive",
+				"PD_HDD": "magnetic hard drive",
+			},
+		},
+		{
 			Type:      broker.JsonTypeString,
 			Details:   "The geographical region. See the instance locations list https://cloud.google.com/sql/docs/mysql/instance-locations for which regions support which databases.",
 			Default:   "us-central",
@@ -110,6 +139,12 @@ func commonProvisionVariables() []broker.BrokerVariable {
 				Build(),
 		},
 		{
+			FieldName: "authorized_networks",
+			Type:      broker.JsonTypeString,
+			Details:   "A comma separated list without spaces.",
+			Default:   "",
+		},
+		{
 			FieldName: "zone",
 			Type:      broker.JsonTypeString,
 			Details:   "(only for 2nd generation instances)",
@@ -117,16 +152,6 @@ func commonProvisionVariables() []broker.BrokerVariable {
 			Constraints: validation.NewConstraintBuilder().
 				Pattern("^(|[A-Za-z][-a-z0-9A-Z]+)$").
 				Build(),
-		},
-		{
-			FieldName: "disk_type",
-			Type:      broker.JsonTypeString,
-			Details:   "(only for 2nd generation instances)",
-			Default:   "PD_SSD",
-			Enum: map[interface{}]string{
-				"PD_SSD": "flash storage drive",
-				"PD_HDD": "magnetic hard drive",
-			},
 		},
 		{
 			FieldName: "maintenance_window_day",
@@ -151,31 +176,6 @@ func commonProvisionVariables() []broker.BrokerVariable {
 			Constraints: validation.NewConstraintBuilder().
 				Pattern("^([0-9]|1[0-9]|2[0-3])$").
 				Build(),
-		},
-		{
-			FieldName: "backups_enabled",
-			Type:      broker.JsonTypeString,
-			Details:   "Should daily backups be enabled for the service?",
-			Default:   "true",
-			Enum: map[interface{}]string{
-				"true":  "enable daily backups",
-				"false": "do not enable daily backups",
-			},
-		},
-		{
-			FieldName: "backup_start_time",
-			Type:      broker.JsonTypeString,
-			Details:   "Start time for the daily backup configuration in UTC timezone in the 24 hour format - HH:MM.",
-			Default:   "06:00",
-			Constraints: validation.NewConstraintBuilder().
-				Pattern("^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$").
-				Build(),
-		},
-		{
-			FieldName: "authorized_networks",
-			Type:      broker.JsonTypeString,
-			Details:   "A comma separated list without spaces.",
-			Default:   "",
 		},
 		{
 			FieldName: "replication_type",

--- a/pkg/providers/builtin/cloudsql/mysql-definition.go
+++ b/pkg/providers/builtin/cloudsql/mysql-definition.go
@@ -259,6 +259,9 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 			{Name: "binlog", Default: `${is_first_gen ? false : true}`, Overwrite: false},
 			{Name: "failover_replica_name", Default: `${failover_replica_suffix == "" ? failover_replica_name : "${instance_name}${failover_replica_suffix}"}`, Overwrite: true},
 
+			// availability_type is only available for Postgres instances
+			{Name: "availability_type", Default: ``, Overwrite: true},
+
 			// validation
 			{Name: "_", Default: `${assert(disk_size <= max_disk_size, "disk size (${disk_size}) is greater than max allowed disk size for this plan (${max_disk_size})")}`, Overwrite: true},
 		},

--- a/pkg/providers/builtin/cloudsql/mysql-definition.go
+++ b/pkg/providers/builtin/cloudsql/mysql-definition.go
@@ -29,7 +29,7 @@ const (
 	CloudsqlMySQLName = "google-cloudsql-mysql"
 )
 
-// MysqlServiceDefinition creates a new ServiceDefinition object for the Bigtable service.
+// MysqlServiceDefinition creates a new ServiceDefinition object for the MySQL service.
 func MysqlServiceDefinition() *broker.ServiceDefinition {
 	return &broker.ServiceDefinition{
 		Id:               "4bc59b9a-8520-409f-85da-1c7552315863",
@@ -182,22 +182,6 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 
 		ProvisionInputVariables: append([]broker.BrokerVariable{
 			{
-				FieldName: "instance_name",
-				Type:      broker.JsonTypeString,
-				Details:   "Name of the Cloud SQL instance.",
-				Default:   identifierTemplate,
-				Constraints: validation.NewConstraintBuilder().
-					Pattern("^[a-z][a-z0-9-]+$").
-					MaxLength(84).
-					Build(),
-			},
-			{
-				FieldName: "database_name",
-				Type:      broker.JsonTypeString,
-				Details:   "Name of the database inside of the instance. Must be a valid identifier for your chosen database type.",
-				Default:   identifierTemplate,
-			},
-			{
 				FieldName: "version",
 				Type:      broker.JsonTypeString,
 				Details:   "The database engine type and version. Defaults to `MYSQL_5_6` for 1st gen MySQL instances or `MYSQL_5_7` for 2nd gen MySQL instances.",
@@ -227,6 +211,22 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 					Build(),
 			},
 			{
+				FieldName: "instance_name",
+				Type:      broker.JsonTypeString,
+				Details:   "Name of the CloudSQL instance.",
+				Default:   identifierTemplate,
+				Constraints: validation.NewConstraintBuilder().
+					Pattern("^[a-z][a-z0-9-]+$").
+					MaxLength(87).
+					Build(),
+			},
+			{
+				FieldName: "database_name",
+				Type:      broker.JsonTypeString,
+				Details:   "Name of the database inside of the instance. Must be a valid identifier for your chosen database type.",
+				Default:   identifierTemplate,
+			},
+			{
 				FieldName: "activation_policy",
 				Type:      broker.JsonTypeString,
 				Details:   "The activation policy specifies when the instance is activated; it is applicable only when the instance state is RUNNABLE.",
@@ -235,6 +235,15 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 					"ALWAYS":    "Always, instance is always on.",
 					"NEVER":     "Never, instance does not turn on if a request arrives.",
 					"ON_DEMAND": "On Demand, instance responds to incoming requests and turns off when not in use.",
+				},
+			},
+			{
+				FieldName: "binlog",
+				Type:      broker.JsonTypeString,
+				Details:   "Whether binary log is enabled. If backup configuration is disabled, binary log must be disabled as well. Defaults: `false` for 1st gen, `true` for 2nd gen, set to `true` to use.",
+				Enum: map[interface{}]string{
+					"true":  "use binary log",
+					"false": "do not use binary log",
 				},
 			},
 		}, commonProvisionVariables()...),

--- a/pkg/providers/builtin/cloudsql/mysql-definition.go
+++ b/pkg/providers/builtin/cloudsql/mysql-definition.go
@@ -186,7 +186,7 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 				Type:      broker.JsonTypeString,
 				Details:   "The database engine type and version. Defaults to `MYSQL_5_6` for 1st gen MySQL instances or `MYSQL_5_7` for 2nd gen MySQL instances.",
 				Enum: map[interface{}]string{
-					"MYSQL_5_5": "MySQL 5.5.X",
+					"MYSQL_5_5": "MySQL 5.5.X (Will be deprecated from 4 March 2020)",
 					"MYSQL_5_6": "MySQL 5.6.X",
 					"MYSQL_5_7": "MySQL 5.7.X",
 				},
@@ -194,17 +194,17 @@ func MysqlServiceDefinition() *broker.ServiceDefinition {
 			{
 				FieldName: "failover_replica_name",
 				Type:      broker.JsonTypeString,
-				Details:   "(only for 2nd generation instances) If specified, creates a failover replica with the given name.",
+				Details:   "(only for 2nd generation MySQL instances) If specified, creates a failover replica with the given name. (Requires binlog and backups to be enabled).",
 				Default:   "",
 				Constraints: validation.NewConstraintBuilder().
 					Pattern("^(|[a-z][a-z0-9-]+)$").
-					MaxLength(84).
+					MaxLength(87).
 					Build(),
 			},
 			{
 				FieldName: "failover_replica_suffix",
 				Type:      broker.JsonTypeString,
-				Details:   "(only for 2nd generation instances) If specified, creates a failover replica with the instance name and this suffix. Overrides `failover_replica_name`.",
+				Details:   "(only for 2nd generation MySQL instances) If specified, creates a failover replica with the instance name and this suffix. Overrides `failover_replica_name`. (Requires binlog and backups to be enabled).",
 				Default:   "",
 				Constraints: validation.NewConstraintBuilder().
 					Pattern("^(|[a-z0-9-]+)$").

--- a/pkg/providers/builtin/cloudsql/postgres-definition.go
+++ b/pkg/providers/builtin/cloudsql/postgres-definition.go
@@ -16,8 +16,8 @@ package cloudsql
 
 import (
 	"code.cloudfoundry.org/lager"
-	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/broker"
+	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/providers/builtin/base"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/validation"
 	"github.com/GoogleCloudPlatform/gcp-service-broker/pkg/varcontext"
 	"github.com/pivotal-cf/brokerapi"
@@ -178,25 +178,9 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 		},
 		ProvisionInputVariables: append([]broker.BrokerVariable{
 			{
-				FieldName: "instance_name",
-				Type:      broker.JsonTypeString,
-				Details:   "Name of the CloudSQL instance.",
-				Default:   identifierTemplate,
-				Constraints: validation.NewConstraintBuilder().
-					Pattern("^[a-z][a-z0-9-]+$").
-					MaxLength(75).
-					Build(),
-			},
-			{
-				FieldName: "database_name",
-				Type:      broker.JsonTypeString,
-				Details:   "Name of the database inside of the instance. Must be a valid identifier for your chosen database type.",
-				Default:   identifierTemplate,
-			},
-			{
 				FieldName: "version",
 				Type:      broker.JsonTypeString,
-				Details:   "The database engine type and version.",
+				Details:   "The database engine type and version. Defaults to `POSTGRES_9_6`.",
 				Default:   "POSTGRES_9_6",
 				Enum: map[interface{}]string{
 					"POSTGRES_9_6": "PostgreSQL 9.6.X",
@@ -211,6 +195,22 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 					Pattern("^(|[a-z][a-z0-9-]+)$").
 					MaxLength(75).
 					Build(),
+			},
+			{
+				FieldName: "instance_name",
+				Type:      broker.JsonTypeString,
+				Details:   "Name of the CloudSQL instance.",
+				Default:   identifierTemplate,
+				Constraints: validation.NewConstraintBuilder().
+					Pattern("^[a-z][a-z0-9-]+$").
+					MaxLength(75).
+					Build(),
+			},
+			{
+				FieldName: "database_name",
+				Type:      broker.JsonTypeString,
+				Details:   "Name of the database inside of the instance. Must be a valid identifier for your chosen database type.",
+				Default:   identifierTemplate,
 			},
 			{
 				FieldName: "activation_policy",

--- a/pkg/providers/builtin/cloudsql/postgres-definition.go
+++ b/pkg/providers/builtin/cloudsql/postgres-definition.go
@@ -180,10 +180,11 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 			{
 				FieldName: "version",
 				Type:      broker.JsonTypeString,
-				Details:   "The database engine type and version. Defaults to `POSTGRES_9_6`.",
+				Details:   "The database engine type and version.",
 				Default:   "POSTGRES_9_6",
 				Enum: map[interface{}]string{
 					"POSTGRES_9_6": "PostgreSQL 9.6.X",
+					"POSTGRES_11":  "PostgreSQL 11",
 				},
 			},
 			{

--- a/pkg/providers/builtin/cloudsql/postgres-definition.go
+++ b/pkg/providers/builtin/cloudsql/postgres-definition.go
@@ -192,8 +192,7 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 				Details:   "(only for 2nd generation instances) If specified, creates a failover replica with the given name.",
 				Default:   "",
 				Constraints: validation.NewConstraintBuilder().
-					Pattern("^(|[a-z][a-z0-9-]+)$").
-					MaxLength(75).
+					MaxLength(0). // Postgres does not use failover replicas - it uses availability_type
 					Build(),
 			},
 			{
@@ -203,7 +202,7 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 				Default:   identifierTemplate,
 				Constraints: validation.NewConstraintBuilder().
 					Pattern("^[a-z][a-z0-9-]+$").
-					MaxLength(75).
+					MaxLength(87).
 					Build(),
 			},
 			{

--- a/pkg/providers/builtin/cloudsql/postgres-definition.go
+++ b/pkg/providers/builtin/cloudsql/postgres-definition.go
@@ -189,7 +189,7 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 			{
 				FieldName: "failover_replica_name",
 				Type:      broker.JsonTypeString,
-				Details:   "(only for 2nd generation instances) If specified, creates a failover replica with the given name.",
+				Details:   "DEPRECATED! Use availability_type for setting up high availability.",
 				Default:   "",
 				Constraints: validation.NewConstraintBuilder().
 					MaxLength(0). // Postgres does not use failover replicas - it uses availability_type
@@ -219,6 +219,16 @@ func PostgresServiceDefinition() *broker.ServiceDefinition {
 				Enum: map[interface{}]string{
 					"ALWAYS": "Always, instance is always on.",
 					"NEVER":  "Never, instance does not turn on if a request arrives.",
+				},
+			},
+			{
+				FieldName: "availability_type",
+				Type:      broker.JsonTypeString,
+				Details:   "Availability type specifies whether the instance serves data from multiple zones.",
+				Default:   "ZONAL",
+				Enum: map[interface{}]string{
+					"ZONAL":    "The instance serves data from only one zone. Outages in that zone affect data accessibility",
+					"REGIONAL": "The instance can serve data from more than one zone in a region (it is highly available).",
 				},
 			},
 		}, commonProvisionVariables()...),


### PR DESCRIPTION
This PR updates the DatabaseInstance request to comply with the current state of the sqladmin API.
It also adds some features like setting the storage auto resize limit and database flags.

The changes were made using the `DatabaseInstance`-struct from the [sqladmin v1beta4 API](https://github.com/googleapis/google-api-go-client/blob/master/sqladmin/v1beta4/sqladmin-gen.go#L647).

Excerpt from the CHANGELOG.md:
### Added
- PostgreSQL 11 (GA since 27.09.2019)
- Support setting database flags (new configuration parameter: `database_flags`).
- Support setting the storage auto resize limit (new configuration parameter: `auto_resize_limit`).

### Changed
- Deprecate `failover_replica` parameter for PostgreSQL (use `availability_type` instead).

### Fixed
- PostgreSQL can be configured high available again (new configuration parameter: `availability_type`).
