### PR TITLE
Fix storage name regex

### DIFF
--- a/pkg/providers/builtin/storage/definition.go
+++ b/pkg/providers/builtin/storage/definition.go
@@ -109,7 +109,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				Details:   "The name of the bucket. There is a single global namespace shared by all buckets so it MUST be unique.",
 				Default:   "pcf_sb_${counter.next()}_${time.nano()}",
 				Constraints: validation.NewConstraintBuilder(). // https://cloud.google.com/storage/docs/naming
-										Pattern("^[A-Za-z0-9_\\.]+$").
+										Pattern("^[a-z0-9_.-]+$").
 										MinLength(3).
 										MaxLength(222).
 										Build(),


### PR DESCRIPTION
**Description**
The regex for bucket name is different than this specified in docs. Using uppercase characters fails with
```
  Warning  ProvisionCallFailed               113s (x10 over 10m)  service-catalog-controller-manager  Error provisioning ServiceInstance of ServiceClass (K8S: "nagduan/b9e4332e-b42b-4680-bda5-ea1506797474" ExternalName: "google-storage") at ClusterServiceBroker "hb-google-cloud-platform-service-broker-default-e2076-gcp-servi": Status: 500; ErrorMessage: <nil>; Description: Error creating new bucket: googleapi: Error 400: Invalid bucket name: 'sapteched_2019_BNC_AMBA', invalid; ResponseError: <nil>
```

Docs:
> Bucket names must contain only lowercase letters, numbers, dashes (-), underscores (_), and dots (.). Names containing dots require verification.

source: https://cloud.google.com/storage/docs/naming

**Related issue**
- https://github.com/kyma-project/kyma/issues/5970