### PR TITLE
 Add verify generated stage for travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ install: skip
 services:
   - docker
 
-script:
-  - go test -v ./... -tags=service_broker
-  - docker build -t gcp-service-broker .
+jobs:
+  include:
+    - stage: test
+      name: unit tests
+      script: ./hack/test.sh
+    - stage: test
+      name: verify generated sources
+      script: ./hack/verify-generated.sh
+    - stage: build
+      name: build docker image
+      script: docker build -t gcp-service-broker .

--- a/docs/classes/google-memorystore-redis.md
+++ b/docs/classes/google-memorystore-redis.md
@@ -17,6 +17,7 @@ Creates and manages Redis instances on the Google Cloud Platform.
     * The string must have at least 1 characters.
     * The string must match the regular expression `^[a-z]([-0-9a-z]*[a-z0-9]$)*`.
  * `authorized_network` _string_ - The name of the VPC network to attach the instance to. Default: `default`.
+    * Examples: [default projects/MYPROJECT/global/networks/MYNETWORK].
  * `region` _string_ - The region to create the instance in. Supported regions can be found here: https://cloud.google.com/memorystore/docs/redis/regions. Default: `us-east1`.
     * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.
  * `memory_size_gb` _integer_ - Redis memory size in GiB. Default: `4`.

--- a/docs/classes/google-storage.md
+++ b/docs/classes/google-storage.md
@@ -15,7 +15,7 @@ Unified object storage for developers and enterprises. Cloud Storage allows worl
  * `name` _string_ - The name of the bucket. There is a single global namespace shared by all buckets so it MUST be unique. Default: `pcf_sb_${counter.next()}_${time.nano()}`.
     * The string must have at most 222 characters.
     * The string must have at least 3 characters.
-    * The string must match the regular expression `^[A-Za-z0-9_\.]+$`.
+    * The string must match the regular expression `^[a-z0-9_.-]+$`.
  * `location` _string_ - The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. See: https://cloud.google.com/storage/docs/bucket-locations Default: `US`.
     * Examples: [US EU southamerica-east1].
     * The string must match the regular expression `^[A-Za-z][-a-z0-9A-Z]+$`.

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This is a helper script for validating if GCP Service Broker generators were executed and results were committed
+#
+set -o nounset
+set -o errexit
+set -o pipefail
+
+readonly CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Prints first argument as header. Additionally prints current date.
+shout() {
+    echo -e "
+#################################################################################################
+# $(date)
+# $1
+#################################################################################################
+"
+}
+
+shout "- Running GCP Service Broker generators..."
+${CURRENT_DIR}/build.sh
+
+shout "- Checking for modified files..."
+
+# The porcelain format is used because it guarantees not to change in a backwards-incompatible
+# way between Git versions or based on user configuration.
+# source: https://git-scm.com/docs/git-status#_porcelain_format_version_1
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Detected modified files:"
+    git status --porcelain
+
+    echo "
+    Run:
+        ./hack/build.sh
+    in the root of the repository and commit changes.
+    "
+    exit 1
+else
+    echo "No issues detected. Have a nice day :-)"
+fi
+


### PR DESCRIPTION
**Description**

Currently is easy to forget about executing gcp-broker generators. 
Current problems on the master are caused by those PRs:
- https://github.com/GoogleCloudPlatform/gcp-service-broker/pull/544 - this is also my fault 🤦‍♂ 
- https://github.com/GoogleCloudPlatform/gcp-service-broker/pull/535

The source was changed but docs are not updated. As a result, the master docs are inconsistent with the master binary and docker image.

Changes proposed in this pull request:
- Add  helper script for validating if GCP Service Broker generators were executed and results were committed
- Execute verify-generated.sh script on CI
- Introduce named stages for Travis. 
   - **stage:** Test
     - unit tests
     - verify generated sources
   - **stage:** build
      - docker image build
- Update generated documentation

Travis CI when everything is fine: https://travis-ci.com/mszostok/gcp-service-broker/builds/133523796

Travis CI when someone forgot to commit generated sources: https://travis-ci.com/mszostok/gcp-service-broker/builds/133523118

**Screenshots:**

1. Failure:
    ![failed_1](https://user-images.githubusercontent.com/17568639/67561201-ade32400-f71c-11e9-9ec5-cf6861129ec6.png)

    ![failed_2](https://user-images.githubusercontent.com/17568639/67561199-ade32400-f71c-11e9-86cb-5795c217eb3b.png)

2. Success:
    ![success](https://user-images.githubusercontent.com/17568639/67561689-98bac500-f71d-11e9-8b5c-157e6d274db0.png)
