### PR TITLE
Update requirements.yaml to point to correct helm repo

### DIFF
--- a/deployments/helm/gcp-service-broker/requirements.yaml
+++ b/deployments/helm/gcp-service-broker/requirements.yaml
@@ -16,4 +16,4 @@ dependencies:
 - name: mysql
   version: "1.6.3"
   condition: mysql.embedded
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable


### PR DESCRIPTION
The repository value pointed to the old location for stable charts. I updated it to: https://charts.helm.sh/stable