### PR TITLE
Bump tile and app manifest to golang 1.16

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -21,4 +21,4 @@ applications:
   buildpack: go_buildpack
   env:
     GOPACKAGENAME: github.com/GoogleCloudPlatform/gcp-service-broker
-    GOVERSION: go1.14
+    GOVERSION: go1.16

--- a/tile.yml
+++ b/tile.yml
@@ -51,7 +51,7 @@ packages:
     path: /tmp/gcp-service-broker.zip
     env:
       GOPACKAGENAME: github.com/GoogleCloudPlatform/gcp-service-broker
-      GOVERSION: go1.14
+      GOVERSION: go1.16
       # You can override plans here.
   needs_cf_credentials: true
   enable_global_access_to_plans: true


### PR DESCRIPTION
The product cannot be pushed as a CF app, as is, because the manifests hardcode a preference for golang 1.16. I've manually edited the manifests and verified that the app pushes and runs successfully once go 1.16 has been selected.

Fixes #570 